### PR TITLE
feat: detect, reuse, and persist key-protected local AI upstreams

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -183,7 +183,14 @@ func loadConfig() config {
 func saveConfig(c config) error {
 	_ = os.MkdirAll(filepath.Dir(configPath()), 0700)
 	b, _ := json.MarshalIndent(c, "", "  ")
-	return os.WriteFile(configPath(), b, 0600)
+	if err := os.WriteFile(configPath(), b, 0600); err != nil {
+		return err
+	}
+	// WriteFile does NOT re-apply the mode to a file that already exists, so a config
+	// created by an older build (before it held secrets like upstream_key) could linger
+	// world-readable. Force 0600 now that it can contain a bearer credential at rest.
+	_ = os.Chmod(configPath(), 0600)
+	return nil
 }
 
 // loadOrCreateStation returns this install's friendly, NON-SENSITIVE broadcast

--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -302,6 +302,18 @@ func tuiHooks(cfg config) tui.Hooks {
 			c.Prices[model] = SharePrice{PriceIn: p.In, PriceOut: p.Out, Windows: toCfgWindows(p.Windows)}
 			_ = saveConfig(c)
 		},
+		// Persist a newly verified / pasted local endpoint + any key it needed, so a
+		// custom or key-protected upstream survives a restart (the TUI mirror of the save
+		// in `roger share`; the host owns the config write).
+		SaveUpstream: func(upstream, key string) {
+			c := loadConfig()
+			if c.Share == nil {
+				c.Share = &Share{}
+			}
+			c.Share.Upstream = upstream
+			c.Share.UpstreamKey = key
+			_ = saveConfig(c)
+		},
 		// Seed + persist the windowshade compact-mode choice so [m] sticks across launches
 		// (the host owns the config write; the TUI does no disk I/O).
 		Compact: cfg.Compact,
@@ -317,6 +329,9 @@ func tuiHooks(cfg config) tui.Hooks {
 	h.ShareMaxOnAir = cfg.shareMaxOnAir()
 	if cfg.Share != nil {
 		h.ShareModel, h.SharePriceI, h.SharePriceO = cfg.Share.Model, cfg.Share.PriceIn, cfg.Share.PriceOut
+		// Seed the saved/verified upstream + its key so the TUI reuses a custom / keyed
+		// endpoint on its first scan (matches bare `roger share`), instead of re-hunting.
+		h.ShareUpstream, h.ShareUpstreamKey = cfg.Share.Upstream, cfg.Share.UpstreamKey
 	}
 	// Seed the editor with prices set in a previous session.
 	if len(cfg.Prices) > 0 {

--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -114,6 +114,11 @@ type Share struct {
 	PriceIn  float64 `json:"price_in,omitempty"`
 	PriceOut float64 `json:"price_out,omitempty"`
 	Upstream string  `json:"upstream,omitempty"` // saved/verified local endpoint (the (e) source)
+	// UpstreamKey is the bearer key a key-protected local server requires (vLLM
+	// --api-key, a LiteLLM master key, llama.cpp --api-key, LM Studio's API-key
+	// toggle). Saved so a keyed upstream is not re-prompted every launch; sent as a
+	// Bearer when the agent forwards jobs. Empty for the common no-auth local server.
+	UpstreamKey string `json:"upstream_key,omitempty"`
 	// MaxOnAir is the SOFT local cap on how many bands may be ON AIR at once from this
 	// CLI (the share.max_on_air knob). It is a deliberate "reset the CLI" guard read
 	// ONCE at startup: changing it requires a restart. <=0 means "use the default" (see
@@ -560,7 +565,7 @@ func cmdShare(cfg config, args []string) error {
 	node := fs.String("node", "", "station callsign (e.g. brave-otter); persisted. default: your saved/auto station")
 	model := fs.String("model", defModelFlag, "model to expose (default: first detected)")
 	upstream := fs.String("upstream", "", "local OpenAI endpoint (default: auto-detect)")
-	upKey := fs.String("upstream-key", "", "bearer key for the upstream (optional)")
+	upKey := fs.String("upstream-key", "", "bearer key for the upstream (optional; auto-detected from env / saved)")
 	region := fs.String("region", "home", "region")
 	parallel := fs.Int("parallel", 4, "concurrent poll workers (per-node concurrency)")
 	// FREE BY DEFAULT (price 0/0): a bare `roger share` goes on air with NO login
@@ -636,18 +641,39 @@ needs no login. When you earn, payouts are 120-day hold, $25 min, monthly.
 	ctxEstimated := false
 	// A saved/verified upstream (from the guided fallback) is the (e) source: probe
 	// it first so a non-default / custom-port server is remembered, not re-hunted.
-	savedUp := ""
+	savedUp, savedKey := "", ""
 	if cfg.Share != nil {
-		savedUp = cfg.Share.Upstream
+		savedUp, savedKey = cfg.Share.Upstream, cfg.Share.UpstreamKey
+	}
+	// A saved upstream key belongs to the SAVED endpoint: reuse it on a bare re-share
+	// (or an explicit --upstream pointing at that same endpoint), but NEVER default it
+	// onto a DIFFERENT --upstream - that would send a stale bearer to another server.
+	if *upKey == "" && savedKey != "" && (up == "" || sameEndpoint(up, savedUp)) {
+		*upKey = savedKey
 	}
 	if up == "" {
-		found := detect.DetectWith(savedUp)
+		// Saved keyed upstream: try it WITH its key first (the broad DetectFull scan does
+		// not carry the saved key), so a custom keyed endpoint is reused without a re-prompt.
+		var found []detect.Found
+		var needKey []string
+		if savedUp != "" && *upKey != "" {
+			if f, st := detect.ProbeKey(savedUp, *upKey); st == detect.Reachable {
+				found = []detect.Found{f}
+			}
+		}
 		if len(found) == 0 {
-			// GUIDED FALLBACK: nothing is running. Walk the user through it instead of
-			// erroring out - pick your tool for a one-liner, or paste an endpoint we
-			// verify. Non-interactive runs still get the clear "start one or --upstream".
-			picked, ok := guidedUpstream(cfg.Broker)
+			found, needKey = detect.DetectFull(savedUp)
+		}
+		if len(found) == 0 {
+			// GUIDED FALLBACK: nothing usable. Walk the user through it instead of
+			// erroring out - pick your tool for a one-liner, paste an endpoint we verify,
+			// or (when a server is there but key-protected) paste its API key. A
+			// non-interactive run still gets the clear "start one or --upstream".
+			picked, ok := guidedUpstream(cfg.Broker, needKey)
 			if !ok {
+				if len(needKey) > 0 {
+					return fmt.Errorf("found a local server at %s but it needs an API key - pass --upstream-key <key> (or set OPENAI_API_KEY)", needKey[0])
+				}
 				return fmt.Errorf("no local LLM detected (tried Ollama/LM Studio/llama.cpp/vLLM/Jan/LiteLLM and your open ports). Start one, then `roger share`, or pass --upstream <url>")
 			}
 			found = []detect.Found{picked}
@@ -664,6 +690,12 @@ needs no login. When you earn, payouts are 120-day hold, $25 min, monthly.
 			}
 		}
 		up = pick.Chat
+		// A key-protected upstream the detector authenticated to (from env or the guided
+		// paste) carries its working key on the Found; adopt it unless --upstream-key was
+		// given explicitly, so the agent forwards jobs with the same Bearer.
+		if *upKey == "" && pick.Key != "" {
+			*upKey = pick.Key
+		}
 		if mdl == "" && len(pick.Models) > 0 {
 			mdl = pick.Models[0]
 		}
@@ -674,15 +706,27 @@ needs no login. When you earn, payouts are 120-day hold, $25 min, monthly.
 		if ctxLen == 0 {
 			ctxLen, ctxEstimated = detect.ResolveCtx(pick.Ctx, mdl)
 		}
-		// Remember the verified upstream so a custom-port / guided-fallback endpoint is
-		// not re-hunted next launch (the (e) saved-config source).
-		if pick.BaseURL != "" && pick.BaseURL != savedUp {
+		// Remember the verified upstream (and any key it needed) so a custom-port /
+		// guided-fallback / key-protected endpoint is not re-hunted or re-prompted next
+		// launch (the (e) saved-config source).
+		if (pick.BaseURL != "" && pick.BaseURL != savedUp) || (*upKey != "" && (cfg.Share == nil || *upKey != cfg.Share.UpstreamKey)) {
 			c := loadConfig()
 			if c.Share == nil {
 				c.Share = &Share{}
 			}
-			c.Share.Upstream = pick.BaseURL
+			if pick.BaseURL != "" {
+				c.Share.Upstream = pick.BaseURL
+			}
+			c.Share.UpstreamKey = *upKey
 			_ = saveConfig(c)
+		}
+	} else if *upKey == "" {
+		// Explicit --upstream with no key resolved: best-effort harvest a working key
+		// from the environment (OPENAI_API_KEY / friends) for THIS endpoint and confirm
+		// reachability - but NEVER block here, the agent self-heals if the server is
+		// momentarily down (the same reason the explicit path skips a hard preflight).
+		if f, st := detect.ProbeKey(up, ""); st == detect.Reachable && f.Key != "" {
+			*upKey = f.Key
 		}
 	}
 	if mdl == "" {
@@ -1440,6 +1484,14 @@ func printLimits(c config) {
 		fmt.Printf("  %-22s %s\n", m, limitStr(c.Limits.Models[m]))
 	}
 	fmt.Printf("  %-22s %s\n", "· default (any other)", limitStr(d))
+}
+
+// sameEndpoint reports whether two upstream URLs point at the same server, comparing
+// their normalized chat-completions form so a base / /v1 / full-chat spelling of the
+// SAME endpoint matches. Used to decide when a saved upstream key may be reused (only
+// for its own endpoint - never sprayed onto a different --upstream).
+func sameEndpoint(a, b string) bool {
+	return b != "" && normalizeUpstream(a) == normalizeUpstream(b)
 }
 
 // normalizeUpstream turns a user-supplied --upstream into the OpenAI-compatible

--- a/cmd/rogerai/main_test.go
+++ b/cmd/rogerai/main_test.go
@@ -100,6 +100,37 @@ func TestNormalizeUpstream(t *testing.T) {
 	}
 }
 
+// TestSameEndpoint guards the saved-key reuse rule: a saved upstream key may be
+// reused only for the SAME endpoint (any base / /v1 / chat spelling of it), and must
+// NOT be considered a match for a different --upstream (which would leak the bearer).
+func TestSameEndpoint(t *testing.T) {
+	const saved = "http://127.0.0.1:8060/v1"
+	// Same server, different spellings -> match (reuse the saved key).
+	for _, same := range []string{
+		"http://127.0.0.1:8060",
+		"http://127.0.0.1:8060/v1",
+		"http://127.0.0.1:8060/v1/chat/completions",
+	} {
+		if !sameEndpoint(same, saved) {
+			t.Errorf("sameEndpoint(%q, %q) = false, want true", same, saved)
+		}
+	}
+	// A different endpoint -> NO match (never send the saved key there).
+	for _, diff := range []string{
+		"http://127.0.0.1:1234/v1",
+		"http://other.host:8060/v1",
+		"https://api.example.com/v1",
+	} {
+		if sameEndpoint(diff, saved) {
+			t.Errorf("sameEndpoint(%q, %q) = true, want false (would leak the saved key)", diff, saved)
+		}
+	}
+	// An empty saved upstream never matches (nothing to reuse).
+	if sameEndpoint("http://127.0.0.1:8060", "") {
+		t.Error("sameEndpoint with empty saved should be false")
+	}
+}
+
 // TestParseMonthlyCap verifies the `roger limit --monthly` value parsing: a dollar
 // amount (with or without a leading $), the clear spellings (0/off/none/unlimited),
 // and the invalid cases.

--- a/cmd/rogerai/onboard.go
+++ b/cmd/rogerai/onboard.go
@@ -218,6 +218,7 @@ func promptUpstreamKey(needKey []string) (detect.Found, bool) {
 		if err := huh.NewInput().
 			Title("Found a local server at " + base + " that needs an API key").
 			Description("Paste its API key (e.g. your vLLM --api-key / LiteLLM master key), or leave blank to skip.").
+			EchoMode(huh.EchoModePassword). // bearer credential: mask it (no terminal echo / scrollback leak)
 			Value(&key).Run(); err != nil {
 			return detect.Found{}, false
 		}
@@ -272,6 +273,7 @@ func guidedUpstream(broker string, needKey []string) (detect.Found, bool) {
 				if err := huh.NewInput().
 					Title("That endpoint needs an API key").
 					Description("Paste the API key it expects (sent as a Bearer to your local server).").
+					EchoMode(huh.EchoModePassword). // bearer credential: mask it (no terminal echo / scrollback leak)
 					Value(&key).Run(); err == nil && strings.TrimSpace(key) != "" {
 					f, st = detect.ProbeKey(url, strings.TrimSpace(key))
 				}

--- a/cmd/rogerai/onboard.go
+++ b/cmd/rogerai/onboard.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/huh"
@@ -128,11 +129,12 @@ func runWizard(cfg config, opts wizardOpts) (config, bool, error) {
 // onboarded. It does NOT start serving - it sets the user up; `roger share`
 // (or `/share` in the TUI) goes on air.
 func finishShare(cfg config, earn bool, opts wizardOpts) (config, bool, error) {
-	found := detect.Detect()
+	found, needKey := detect.DetectFull()
 	if len(found) == 0 {
-		// GUIDED FALLBACK: walk the user through starting a tool or pasting an endpoint
-		// instead of dead-ending. Non-interactive / declined -> the plain hint.
-		if picked, ok := guidedUpstream(cfg.Broker); ok {
+		// GUIDED FALLBACK: walk the user through starting a tool, pasting an endpoint, or
+		// (when a key-protected server is detected) entering its API key, instead of
+		// dead-ending. Non-interactive / declined -> the plain hint.
+		if picked, ok := guidedUpstream(cfg.Broker, needKey); ok {
 			found = []detect.Found{picked}
 		} else {
 			fmt.Println("no local LLM detected (tried Ollama / LM Studio / llama.cpp / vLLM / Jan / LiteLLM and your open ports).")
@@ -151,7 +153,7 @@ func finishShare(cfg config, earn bool, opts wizardOpts) (config, bool, error) {
 		return cfg, false, err
 	}
 
-	sh := Share{Model: model, Port: port, Upstream: pick.BaseURL}
+	sh := Share{Model: model, Port: port, Upstream: pick.BaseURL, UpstreamKey: pick.Key}
 	if earn {
 		// Earn path: tell the user UP FRONT that earning needs a GitHub login and
 		// pre-disclose the payout terms (F3 / #2) - BEFORE collecting a price - so the
@@ -200,12 +202,44 @@ var startOneLiner = map[string]string{
 // guidedUpstream is the interactive guided fallback when detection finds nothing:
 // it asks what the user is running, prints that tool's start one-liner (so they
 // can launch it and we re-detect), or takes a pasted endpoint and verifies it
-// serves /v1/models. Returns (verified server, true) on success. A non-interactive
-// run returns ok=false so the caller prints the plain "start one / --upstream"
-// hint instead of hanging.
-func guidedUpstream(broker string) (detect.Found, bool) {
+// serves /v1/models. needKey carries base URLs of servers that ARE running but are
+// key-protected (a 401/403 the env keys didn't satisfy): for those we ask for an API
+// key first, since that is the most likely fix. Returns (verified server, true) on
+// success. A non-interactive run returns ok=false so the caller prints the plain
+// "start one / --upstream" hint instead of hanging.
+// promptUpstreamKey asks for an API key for each detected-but-key-protected base URL
+// (a 401/403 the env keys didn't satisfy) and returns the first that verifies with
+// the pasted key. Shared by the initial needKey pass and the post-rescan path. A
+// blank entry skips that endpoint; an input error or no match returns ok=false so the
+// caller falls through to the tool menu.
+func promptUpstreamKey(needKey []string) (detect.Found, bool) {
+	for _, base := range needKey {
+		key := ""
+		if err := huh.NewInput().
+			Title("Found a local server at " + base + " that needs an API key").
+			Description("Paste its API key (e.g. your vLLM --api-key / LiteLLM master key), or leave blank to skip.").
+			Value(&key).Run(); err != nil {
+			return detect.Found{}, false
+		}
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		if f, st := detect.ProbeKey(base, strings.TrimSpace(key)); st == detect.Reachable {
+			fmt.Printf("verified %s - serves %d model(s)\n", f.BaseURL, len(f.Models))
+			return f, true
+		}
+		fmt.Printf("that key did not unlock %s - check it and try again, or pick a tool below.\n", base)
+	}
+	return detect.Found{}, false
+}
+
+func guidedUpstream(broker string, needKey []string) (detect.Found, bool) {
 	if !interactive() {
 		return detect.Found{}, false
+	}
+	// A detected-but-key-protected server is the clearest fix: ask for its key first.
+	if f, ok := promptUpstreamKey(needKey); ok {
+		return f, true
 	}
 	for {
 		choice := "other"
@@ -231,7 +265,18 @@ func guidedUpstream(broker string) (detect.Found, bool) {
 				Value(&url).Run(); err != nil {
 				return detect.Found{}, false
 			}
-			if f, ok := detect.Probe(url); ok {
+			f, st := detect.ProbeKey(url, "")
+			if st == detect.NeedsKey {
+				// The endpoint is there but key-protected: ask for the key and re-verify.
+				key := ""
+				if err := huh.NewInput().
+					Title("That endpoint needs an API key").
+					Description("Paste the API key it expects (sent as a Bearer to your local server).").
+					Value(&key).Run(); err == nil && strings.TrimSpace(key) != "" {
+					f, st = detect.ProbeKey(url, strings.TrimSpace(key))
+				}
+			}
+			if st == detect.Reachable {
 				fmt.Printf("verified %s - serves %d model(s)\n", f.BaseURL, len(f.Models))
 				return f, true
 			}
@@ -247,9 +292,15 @@ func guidedUpstream(broker string) (detect.Found, bool) {
 			Value(&again).Run(); err != nil || !again {
 			return detect.Found{}, false
 		}
-		if found := detect.Detect(); len(found) > 0 {
+		found, needKey := detect.DetectFull()
+		if len(found) > 0 {
 			fmt.Printf("found %s at %s\n", found[0].Name, found[0].BaseURL)
 			return found[0], true
+		}
+		// The tool may have come up key-protected (e.g. vLLM --api-key): ask for the key
+		// rather than reporting "still nothing".
+		if f, ok := promptUpstreamKey(needKey); ok {
+			return f, true
 		}
 		fmt.Println("still nothing on the default ports / your open ports - give it a moment, or paste the URL.")
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -505,6 +505,20 @@ func heartbeatUntil(broker, nodeID string, rereg *reregistrar, sess *Session) {
 	}
 }
 
+// redactUpstreamKey strips the node's upstream bearer key from bytes about to be
+// relayed back to the broker/consumer. Standard OpenAI-compatible servers never echo
+// the request Authorization header into their response, but a misconfigured proxy /
+// debug endpoint can put it in an error body - this is defense-in-depth so the node
+// operator's OWN upstream key can never leave the machine in a job result. A no-op
+// when no key is configured (and never called with an empty key, which would match
+// everywhere).
+func redactUpstreamKey(b []byte, key string) []byte {
+	if key == "" {
+		return b
+	}
+	return bytes.ReplaceAll(b, []byte(key), []byte("[redacted]"))
+}
+
 func isStream(body []byte) bool {
 	var p struct {
 		Stream bool `json:"stream"`
@@ -538,7 +552,9 @@ func serveStream(cfg Config, offer protocol.ModelOffer, priv ed25519.PrivateKey,
 		sc := bufio.NewScanner(resp.Body)
 		sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
 		for sc.Scan() {
-			line := sc.Bytes()
+			// Redact the node's own upstream key before it leaves the machine, in case the
+			// upstream echoed the request Authorization header into an SSE error chunk.
+			line := redactUpstreamKey(sc.Bytes(), cfg.UpstreamKey)
 			pw.Write(line)
 			pw.Write([]byte{'\n'})
 			if bytes.Contains(line, []byte(`"usage"`)) {
@@ -617,6 +633,9 @@ func serve(cfg Config, offer protocol.ModelOffer, priv ed25519.PrivateKey, up *h
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
+	// Belt-and-suspenders: never relay the node's own upstream key, in case the
+	// upstream echoed the request Authorization header into its response body.
+	respBody = redactUpstreamKey(respBody, cfg.UpstreamKey)
 
 	var parsed struct {
 		Usage struct {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -444,3 +444,82 @@ func TestEffectivePriceFor(t *testing.T) {
 		t.Fatalf("cross-model mapping = %v/%v override=%v, want our requested 0.2/0.3 unaffected", in, out, override)
 	}
 }
+
+func TestRedactUpstreamKey(t *testing.T) {
+	if got := redactUpstreamKey([]byte("x sk-secret y"), "sk-secret"); string(got) != "x [redacted] y" {
+		t.Errorf("redact = %q, want %q", got, "x [redacted] y")
+	}
+	// An empty key must be a no-op (a ReplaceAll on "" would match everywhere and mangle
+	// the body) - guards the common no-auth upstream.
+	if got := redactUpstreamKey([]byte("untouched body"), ""); string(got) != "untouched body" {
+		t.Errorf("empty key should be a no-op, got %q", got)
+	}
+}
+
+// TestServeRedactsUpstreamKey: when a (misconfigured) upstream echoes the request
+// Authorization header into its response body, serve must strip the node's key before
+// relaying the body - and the redaction must not corrupt usage metering.
+func TestServeRedactsUpstreamKey(t *testing.T) {
+	const key = "sk-upstream-secret"
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"echoed_auth":"` + r.Header.Get("Authorization") + `","usage":{"prompt_tokens":3,"completion_tokens":5}}`))
+	}))
+	defer up.Close()
+
+	_, priv, _ := ed25519.GenerateKey(nil)
+	cfg := Config{Upstream: up.URL, UpstreamKey: key, NodeID: "n", Model: "m"}
+	res := serve(cfg, protocol.ModelOffer{}, priv, &http.Client{}, protocol.Job{ID: "j", Body: json.RawMessage(`{"model":"m"}`)})
+
+	if bytes.Contains(res.Body, []byte(key)) {
+		t.Fatalf("upstream key leaked in relayed body: %s", res.Body)
+	}
+	if !bytes.Contains(res.Body, []byte("[redacted]")) {
+		t.Errorf("expected a redaction marker, got: %s", res.Body)
+	}
+	if res.Receipt.PromptTokens != 3 || res.Receipt.CompletionTokens != 5 {
+		t.Errorf("usage = %d/%d, want 3/5 (redaction must not corrupt the body)", res.Receipt.PromptTokens, res.Receipt.CompletionTokens)
+	}
+}
+
+// TestServeStreamRedactsUpstreamKey: the streaming path must strip the node's key from
+// any SSE chunk before piping it to the broker, while still metering usage.
+func TestServeStreamRedactsUpstreamKey(t *testing.T) {
+	const key = "sk-upstream-secret"
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "data: {\"echoed_auth\":\""+r.Header.Get("Authorization")+"\"}\n")
+		io.WriteString(w, "data: {\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":11}}\n")
+		io.WriteString(w, "data: [DONE]\n")
+	}))
+	defer up.Close()
+
+	var mu2 sync.Mutex
+	var streamed bytes.Buffer
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/agent/stream") {
+			mu2.Lock()
+			io.Copy(&streamed, r.Body)
+			mu2.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer broker.Close()
+
+	_, priv, _ := ed25519.GenerateKey(nil)
+	cfg := Config{Upstream: up.URL, UpstreamKey: key, Broker: broker.URL, NodeID: "n", Model: "m"}
+	rec := serveStream(cfg, protocol.ModelOffer{}, priv, "tok", protocol.Job{ID: "j", Body: json.RawMessage(`{"model":"m","stream":true}`)})
+
+	mu2.Lock()
+	got := streamed.String()
+	mu2.Unlock()
+	if strings.Contains(got, key) {
+		t.Fatalf("upstream key leaked in streamed body: %s", got)
+	}
+	if !strings.Contains(got, "[redacted]") {
+		t.Errorf("expected a redaction marker in the stream, got: %s", got)
+	}
+	if rec.PromptTokens != 7 || rec.CompletionTokens != 11 {
+		t.Errorf("stream usage = %d/%d, want 7/11", rec.PromptTokens, rec.CompletionTokens)
+	}
+}

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -225,11 +225,19 @@ func detectWith(priority []candidate) (found []Found, needKey []string) {
 			continue
 		}
 		seen[base] = true
-		// Try this candidate's own paired key first (e.g. OPENAI_API_KEY for an
-		// OPENAI_BASE_URL endpoint), then the rest of the env keys.
+		// Harvested env keys are retried (as Bearer) on a 401/403 — but ONLY against
+		// candidates we have a reason to trust: a configured / known-default / env-derived
+		// endpoint. A BLIND port-scan hit ("port:N") could be ANY local service, so we never
+		// spray the user's API keys at it; if it 401s we surface it via needKey instead, so
+		// the user explicitly supplies a key for a server they actually recognize.
 		tryKeys := keys
+		if strings.HasPrefix(c.name, "port:") {
+			tryKeys = nil
+		}
+		// Try this candidate's own paired key first (e.g. OPENAI_API_KEY for an
+		// OPENAI_BASE_URL endpoint), then the rest of the (trusted-candidate) env keys.
 		if c.key != "" {
-			tryKeys = append([]string{c.key}, keys...)
+			tryKeys = append([]string{c.key}, tryKeys...)
 		}
 		models, ctx, usedKey, res := probeModels(base, tryKeys)
 		switch res {

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -23,6 +23,7 @@ package detect
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"sort"
@@ -38,7 +39,19 @@ type Found struct {
 	Chat    string         // .../v1/chat/completions
 	Models  []string       // served model ids from GET /v1/models (+ native discovery)
 	Ctx     map[string]int // per-model context length when the server reports it
+	Key     string         // bearer key the upstream required (discovered from env), if any
 }
+
+// Status is the tri-state result of probing a single endpoint: a 401/403 means an
+// OpenAI-compatible server IS there but needs a key we couldn't supply - distinct
+// from "nothing listening" - so the caller can ask for a key instead of giving up.
+type Status int
+
+const (
+	Unreachable Status = iota // no OpenAI-compatible server answered
+	Reachable                 // serves /v1/models (the Found is populated)
+	NeedsKey                  // server present but 401/403 and no known key worked
+)
 
 // Common local OpenAI-compatible servers, by default port. Any server exposing
 // GET /v1/models works; this just enables zero-config detection. Users can always
@@ -61,14 +74,46 @@ var probes = []struct{ name, base string }{
 // the first paint of /share), so we give each probe a tight budget.
 var httpClient = &http.Client{Timeout: 1500 * time.Millisecond}
 
+// authGet / authPost are the ONE place a probe request is built, so a discovered
+// upstream key is attached uniformly as a Bearer (a key-protected local server -
+// vLLM --api-key, a LiteLLM master key, llama.cpp --api-key, LM Studio's API-key
+// toggle - returns 401 to an unauthenticated GET /v1/models and would otherwise be
+// invisible). An empty key sends no header (the no-auth common case).
+func authGet(url, key string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	return httpClient.Do(req)
+}
+
+func authPost(url, key, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	return httpClient.Do(req)
+}
+
 // maxEnumPorts caps how many real listening ports the cross-platform enumerator
 // returns, so a host with hundreds of open ports can't blow up the probe fan-out.
 // The documented defaults + env vars already cover the common servers; this is the
 // "found it on a custom port" tail, which is small in practice.
 const maxEnumPorts = 64
 
-// candidate is a base URL to probe, with a friendly label for the source.
-type candidate struct{ name, base string }
+// candidate is a base URL to probe, with a friendly label for the source and an
+// optional sibling API key (e.g. OPENAI_API_KEY paired with OPENAI_BASE_URL) tried
+// first when the endpoint answers 401/403.
+type candidate struct{ name, base, key string }
 
 // enumPorts / envCands are indirections over the real listening-port enumerator
 // and the env-var source, so tests can make detection deterministic (the host's
@@ -77,45 +122,83 @@ type candidate struct{ name, base string }
 var (
 	enumPorts = listeningPorts
 	envCands  = envCandidates
+	envKeysFn = envKeys
 )
 
 // Detect gathers candidate endpoints from every source (defaults, env, Ollama
 // native, real listening ports), probes each for GET /v1/models, and returns the
 // reachable OpenAI-compatible servers, de-duplicated by base URL.
 func Detect() []Found {
-	return detectWith(nil)
+	found, _ := detectWith(nil)
+	return found
 }
 
 // DetectWith is Detect plus explicit extra base URLs to probe first (the (e)
 // source: --upstream / a saved config endpoint). Each is normalized to a /v1
 // base. The explicit endpoints win on de-dup so their friendly name is kept.
 func DetectWith(extra ...string) []Found {
+	found, _ := detectWith(priorityCands(extra))
+	return found
+}
+
+// DetectFull is DetectWith that ALSO returns the base URLs of servers that are
+// present but answered 401/403 with no usable key (the needKey list), so the
+// caller can prompt for an API key instead of reporting "nothing detected".
+func DetectFull(extra ...string) (found []Found, needKey []string) {
+	return detectWith(priorityCands(extra))
+}
+
+// priorityCands normalizes explicit --upstream/config URLs into priority candidates
+// probed before the defaults (so an explicit endpoint wins de-dup and keeps its
+// "configured" name).
+func priorityCands(extra []string) []candidate {
 	cands := make([]candidate, 0, len(extra))
 	for _, u := range extra {
 		if b := toV1Base(u); b != "" {
 			cands = append(cands, candidate{name: "configured", base: b})
 		}
 	}
-	return detectWith(cands)
+	return cands
 }
 
 // Probe verifies that a single user-supplied endpoint serves /v1/models, and
 // returns it as a Found (the guided-fallback "paste a URL" path). ok is false
 // when the URL is unreachable or not OpenAI-compatible.
 func Probe(rawURL string) (Found, bool) {
-	base := toV1Base(rawURL)
-	if base == "" {
-		return Found{}, false
-	}
-	models, ctx, ok := probeModels(base)
-	if !ok {
-		return Found{}, false
-	}
-	return Found{Name: "configured", BaseURL: base, Chat: base + "/chat/completions", Models: models, Ctx: ctx}, true
+	f, st := ProbeKey(rawURL, "")
+	return f, st == Reachable
 }
 
-// detectWith runs the full pipeline with optional priority candidates first.
-func detectWith(priority []candidate) []Found {
+// ProbeKey is Probe with an explicit key tried first (the user pasted one), falling
+// back to keys the environment exports. It returns the tri-state Status so the
+// guided fallback can tell "needs a key" (prompt for one) apart from "unreachable".
+func ProbeKey(rawURL, key string) (Found, Status) {
+	base := toV1Base(rawURL)
+	if base == "" {
+		return Found{}, Unreachable
+	}
+	keys := envKeysFn()
+	if key != "" {
+		keys = append([]string{key}, keys...)
+	}
+	models, ctx, usedKey, res := probeModels(base, keys)
+	switch res {
+	case probeOK:
+		f := Found{Name: "configured", BaseURL: base, Chat: base + "/chat/completions", Models: models, Ctx: ctx, Key: usedKey}
+		mergeOllamaNative(&f, base)
+		enrichCtx(&f, base)
+		return f, Reachable
+	case probeAuth:
+		return Found{BaseURL: base}, NeedsKey
+	default:
+		return Found{}, Unreachable
+	}
+}
+
+// detectWith runs the full pipeline with optional priority candidates first. It
+// returns the reachable servers plus the base URLs of any that need a key we don't
+// have (so the caller can ask for one).
+func detectWith(priority []candidate) (found []Found, needKey []string) {
 	cands := priority
 	// (a) documented default endpoints.
 	for _, p := range probes {
@@ -130,44 +213,97 @@ func detectWith(priority []candidate) []Found {
 		cands = append(cands, candidate{name: "port:" + strconv.Itoa(port), base: "http://127.0.0.1:" + strconv.Itoa(port) + "/v1"})
 	}
 
+	// Keys the user's tooling exports, tried (as Bearer) against any candidate that
+	// answers 401/403 - so a key-protected local server whose key is already in the
+	// environment is detected with zero extra config.
+	keys := envKeysFn()
 	seen := map[string]bool{}
-	var out []Found
+	needSeen := map[string]bool{}
 	for _, c := range cands {
 		base := strings.TrimRight(c.base, "/")
 		if base == "" || seen[base] {
 			continue
 		}
 		seen[base] = true
-		models, ctx, ok := probeModels(base)
-		if !ok {
-			continue
+		// Try this candidate's own paired key first (e.g. OPENAI_API_KEY for an
+		// OPENAI_BASE_URL endpoint), then the rest of the env keys.
+		tryKeys := keys
+		if c.key != "" {
+			tryKeys = append([]string{c.key}, keys...)
 		}
-		f := Found{Name: c.name, BaseURL: base, Chat: base + "/chat/completions", Models: models, Ctx: ctx}
-		// (c) native fleet discovery: an Ollama base also exposes /api/tags and
-		// /api/ps, which list models installed-but-swapped-out (a fresh /v1/models
-		// only shows what is loaded). Union those in so the whole fleet is offerable.
-		mergeOllamaNative(&f, base)
-		// Real per-model CONTEXT detection beyond /v1/models. Ollama reports its true
-		// trained window on /api/show + the loaded num_ctx on /api/ps; llama.cpp reports
-		// the real loaded n_ctx on /props; LM Studio reports loaded/max ctx on
-		// /api/v0/models. These are more accurate than the optional /v1/models keys (and
-		// Ollama omits ctx from /v1/models entirely), so a node advertises the REAL
-		// served window instead of falling back to the 32768 last-resort default.
-		enrichCtx(&f, base)
-		out = append(out, f)
+		models, ctx, usedKey, res := probeModels(base, tryKeys)
+		switch res {
+		case probeOK:
+			f := Found{Name: c.name, BaseURL: base, Chat: base + "/chat/completions", Models: models, Ctx: ctx, Key: usedKey}
+			// (c) native fleet discovery: an Ollama base also exposes /api/tags and
+			// /api/ps, which list models installed-but-swapped-out (a fresh /v1/models
+			// only shows what is loaded). Union those in so the whole fleet is offerable.
+			mergeOllamaNative(&f, base)
+			// Real per-model CONTEXT detection beyond /v1/models. Ollama reports its true
+			// trained window on /api/show + the loaded num_ctx on /api/ps; llama.cpp reports
+			// the real loaded n_ctx on /props; LM Studio reports loaded/max ctx on
+			// /api/v0/models. These are more accurate than the optional /v1/models keys (and
+			// Ollama omits ctx from /v1/models entirely), so a node advertises the REAL
+			// served window instead of falling back to the 32768 last-resort default.
+			enrichCtx(&f, base)
+			found = append(found, f)
+		case probeAuth:
+			// Present but key-protected and no env key fit: surface it so the caller can
+			// ask the user to paste a key rather than report "nothing detected".
+			if !needSeen[base] {
+				needSeen[base] = true
+				needKey = append(needKey, base)
+			}
+		}
 	}
-	return out
+	return found, needKey
 }
 
-// probeModels does GET base/models and parses the served model ids + per-model
-// context length (the keys vary by server). ok is false on any non-200 / error.
-func probeModels(base string) (models []string, ctx map[string]int, ok bool) {
-	resp, err := httpClient.Get(base + "/models")
-	if err != nil || resp.StatusCode != 200 {
-		if resp != nil {
-			resp.Body.Close()
+// probeResult is probeModels' tri-state: a usable server, a key-protected one, or
+// nothing OpenAI-compatible.
+type probeResult int
+
+const (
+	probeMiss probeResult = iota // unreachable / not OpenAI-compatible
+	probeOK                      // 200: models parsed (usedKey is the key that worked, "" if none needed)
+	probeAuth                    // 401/403: server present but no supplied key worked
+)
+
+// probeModels does GET base/models, first with no auth, and - only when the server
+// answers 401/403 - retries with each candidate key until one returns 200. It
+// returns the parsed model ids, per-model context length, the key that worked (""
+// when none was needed), and the tri-state result.
+func probeModels(base string, keys []string) (models []string, ctx map[string]int, usedKey string, res probeResult) {
+	models, ctx, code := getModels(base, "")
+	switch {
+	case code == 200:
+		return models, ctx, "", probeOK
+	case code == 401 || code == 403:
+		for _, k := range keys {
+			if k == "" {
+				continue
+			}
+			if m, c, code2 := getModels(base, k); code2 == 200 {
+				return m, c, k, probeOK
+			}
 		}
-		return nil, nil, false
+		return nil, nil, "", probeAuth
+	default:
+		return nil, nil, "", probeMiss
+	}
+}
+
+// getModels performs one GET base/models with the optional key and parses the model
+// ids + per-model context length. status is the HTTP status code, or 0 on a
+// transport error (treated as unreachable by the caller).
+func getModels(base, key string) (models []string, ctx map[string]int, status int) {
+	resp, err := authGet(base+"/models", key)
+	if err != nil {
+		return nil, nil, 0
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, nil, resp.StatusCode
 	}
 	// Many OpenAI-compatible servers (vLLM, llama.cpp, LM Studio, TGI) report a
 	// per-model context length on /v1/models under one of these common keys.
@@ -182,7 +318,6 @@ func probeModels(base string) (models []string, ctx map[string]int, ok bool) {
 		} `json:"data"`
 	}
 	_ = json.NewDecoder(resp.Body).Decode(&d)
-	resp.Body.Close()
 	ctx = map[string]int{}
 	for _, m := range d.Data {
 		if m.ID == "" {
@@ -193,28 +328,57 @@ func probeModels(base string) (models []string, ctx map[string]int, ok bool) {
 			ctx[m.ID] = c
 		}
 	}
-	return models, ctx, true
+	return models, ctx, 200
 }
 
 // envCandidates derives base URLs from environment variables the user's existing
-// tooling already exports, so a non-default endpoint is found without a scan.
+// tooling already exports, so a non-default endpoint is found without a scan. Where
+// the same tooling also exports an API key, that key is paired with the endpoint so
+// a key-protected server is reached on the first try.
 func envCandidates() []candidate {
 	var out []candidate
-	add := func(name, raw string) {
+	add := func(name, raw, key string) {
 		if b := toV1Base(raw); b != "" {
-			out = append(out, candidate{name: name, base: b})
+			out = append(out, candidate{name: name, base: b, key: strings.TrimSpace(key)})
 		}
 	}
-	// The OpenAI SDK convention (both spellings are in the wild).
-	add("env:OPENAI_BASE_URL", os.Getenv("OPENAI_BASE_URL"))
-	add("env:OPENAI_API_BASE", os.Getenv("OPENAI_API_BASE"))
+	// The OpenAI SDK convention (both spellings are in the wild); OPENAI_API_KEY is
+	// the de-facto key for OpenAI-compatible servers behind these bases.
+	openaiKey := os.Getenv("OPENAI_API_KEY")
+	add("env:OPENAI_BASE_URL", os.Getenv("OPENAI_BASE_URL"), openaiKey)
+	add("env:OPENAI_API_BASE", os.Getenv("OPENAI_API_BASE"), openaiKey)
 	// Ollama: OLLAMA_HOST may be "host:port", ":11434", or a full URL.
 	if h := strings.TrimSpace(os.Getenv("OLLAMA_HOST")); h != "" {
-		add("env:OLLAMA_HOST", ollamaHostURL(h))
+		add("env:OLLAMA_HOST", ollamaHostURL(h), os.Getenv("OLLAMA_API_KEY"))
 	}
 	// LM Studio exports a few spellings depending on version.
+	lmKey := os.Getenv("LMSTUDIO_API_KEY")
 	for _, k := range []string{"LMSTUDIO_BASE_URL", "LMSTUDIO_API_BASE", "LMSTUDIO_HOST"} {
-		add("env:"+k, os.Getenv(k))
+		add("env:"+k, os.Getenv(k), lmKey)
+	}
+	return out
+}
+
+// envKeys returns API keys the user's tooling already exports, tried (as a Bearer)
+// against any candidate that answers 401/403. OPENAI_API_KEY is the de-facto key for
+// OpenAI-compatible servers; the rest are the common tool-specific spellings. This
+// is what makes a key-protected local server (vLLM --api-key, a LiteLLM master key,
+// llama.cpp --api-key, LM Studio's API-key toggle) detectable with zero extra config
+// whenever its key already lives in the environment.
+func envKeys() []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, name := range []string{
+		"OPENAI_API_KEY",
+		"LITELLM_MASTER_KEY", "LITELLM_API_KEY",
+		"LMSTUDIO_API_KEY",
+		"VLLM_API_KEY",
+		"OLLAMA_API_KEY",
+	} {
+		if v := strings.TrimSpace(os.Getenv(name)); v != "" && !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
 	}
 	return out
 }
@@ -243,7 +407,7 @@ func mergeOllamaNative(f *Found, base string) {
 		have[m] = true
 	}
 	addNames := func(path string) {
-		resp, err := httpClient.Get(root + path)
+		resp, err := authGet(root+path, f.Key)
 		if err != nil || resp.StatusCode != 200 {
 			if resp != nil {
 				resp.Body.Close()
@@ -315,7 +479,7 @@ func enrichCtx(f *Found, base string) {
 // non-Ollama base simply has neither endpoint and is left untouched.
 func enrichOllamaCtx(f *Found, root string) {
 	// /api/ps: currently-loaded models carry context_length = the live num_ctx.
-	if resp, err := httpClient.Get(root + "/api/ps"); err == nil && resp.StatusCode == 200 {
+	if resp, err := authGet(root+"/api/ps", f.Key); err == nil && resp.StatusCode == 200 {
 		var d struct {
 			Models []struct {
 				Name      string `json:"name"`
@@ -345,7 +509,7 @@ func enrichOllamaCtx(f *Found, root string) {
 			continue
 		}
 		body := strings.NewReader(`{"model":` + strconv.Quote(id) + `}`)
-		resp, err := httpClient.Post(root+"/api/show", "application/json", body)
+		resp, err := authPost(root+"/api/show", f.Key, "application/json", body)
 		if err != nil || resp.StatusCode != 200 {
 			if resp != nil {
 				resp.Body.Close()
@@ -385,7 +549,7 @@ func ollamaContextFromInfo(info map[string]json.RawMessage) int {
 // optional /v1/models n_ctx). llama.cpp serves a single model, so the value applies
 // to every model id this base advertises that lacks a detected ctx.
 func enrichLlamaCppCtx(f *Found, root string) {
-	resp, err := httpClient.Get(root + "/props")
+	resp, err := authGet(root+"/props", f.Key)
 	if err != nil || resp.StatusCode != 200 {
 		if resp != nil {
 			resp.Body.Close()
@@ -413,7 +577,7 @@ func enrichLlamaCppCtx(f *Found, root string) {
 // preferring loaded_context_length (the live window) over max_context_length (the
 // model cap). A non-LM-Studio base has no /api/v0/models and is left untouched.
 func enrichLMStudioCtx(f *Found, root string) {
-	resp, err := httpClient.Get(root + "/api/v0/models")
+	resp, err := authGet(root+"/api/v0/models", f.Key)
 	if err != nil || resp.StatusCode != 200 {
 		if resp != nil {
 			resp.Body.Close()

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -189,6 +189,92 @@ func TestProbeVerifiesEndpoint(t *testing.T) {
 	}
 }
 
+// keyedServer mimics an OpenAI-compatible server that requires a Bearer key: it
+// 401s GET /v1/models without the right Authorization header and serves the models
+// with it.
+func keyedServer(wantKey string, models ...string) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+wantKey {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		var data []map[string]string
+		for _, m := range models {
+			data = append(data, map[string]string{"id": m})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestDetectKeyedUpstreamFromEnv: a key-protected local server is detected when its
+// key is in the environment (the zero-config harvest) and the working key is carried
+// on the Found so the on-air agent can reuse it.
+func TestDetectKeyedUpstreamFromEnv(t *testing.T) {
+	defer quietSources(t)()
+	srv := keyedServer("sk-secret", "keyed-model")
+	defer srv.Close()
+	t.Setenv("OPENAI_API_KEY", "sk-secret")
+
+	old := probes
+	probes = []struct{ name, base string }{{"test", srv.URL + "/v1"}}
+	defer func() { probes = old }()
+
+	found := Detect()
+	if len(found) != 1 {
+		t.Fatalf("keyed upstream with env key should be detected, got %+v", found)
+	}
+	if len(found[0].Models) != 1 || found[0].Models[0] != "keyed-model" {
+		t.Errorf("models = %v", found[0].Models)
+	}
+	if found[0].Key != "sk-secret" {
+		t.Errorf("Found.Key = %q, want the working key so the agent can reuse it", found[0].Key)
+	}
+}
+
+// TestDetectFullSurfacesNeedsKey: a key-protected server with NO usable key is not
+// returned as usable, but its base URL surfaces in needKey so the caller can prompt.
+func TestDetectFullSurfacesNeedsKey(t *testing.T) {
+	defer quietSources(t)()
+	srv := keyedServer("sk-secret", "keyed-model")
+	defer srv.Close()
+	// No OPENAI_API_KEY in the environment for this test.
+	t.Setenv("OPENAI_API_KEY", "")
+
+	old := probes
+	probes = []struct{ name, base string }{{"test", srv.URL + "/v1"}}
+	defer func() { probes = old }()
+
+	found, needKey := DetectFull()
+	if len(found) != 0 {
+		t.Fatalf("a server we can't authenticate to is not usable, got %+v", found)
+	}
+	if len(needKey) != 1 || needKey[0] != srv.URL+"/v1" {
+		t.Fatalf("needKey should surface the key-protected base, got %v", needKey)
+	}
+}
+
+// TestProbeKeyTriState: ProbeKey distinguishes reachable, needs-key, and unreachable.
+func TestProbeKeyTriState(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	srv := keyedServer("sk-secret", "pasted-keyed")
+	defer srv.Close()
+
+	// Right key -> reachable, models served, key carried.
+	if f, st := ProbeKey(srv.URL, "sk-secret"); st != Reachable || len(f.Models) != 1 || f.Key != "sk-secret" {
+		t.Errorf("ProbeKey(correct) = %v, %+v", st, f)
+	}
+	// No key -> needs key (server is present).
+	if _, st := ProbeKey(srv.URL, ""); st != NeedsKey {
+		t.Errorf("ProbeKey(no key) status = %v, want NeedsKey", st)
+	}
+	// Dead endpoint -> unreachable.
+	if _, st := ProbeKey("http://127.0.0.1:1", "anything"); st != Unreachable {
+		t.Errorf("ProbeKey(dead) status = %v, want Unreachable", st)
+	}
+}
+
 // TestToV1Base normalizes the inputs detection + the wizard accept.
 func TestToV1Base(t *testing.T) {
 	cases := map[string]string{

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -255,6 +255,29 @@ func TestDetectFullSurfacesNeedsKey(t *testing.T) {
 	}
 }
 
+// TestDetectDoesNotSprayEnvKeysToPortScans: a BLIND port-scan hit (candidate named
+// "port:N") must never receive the user's harvested env API keys on a 401 — an arbitrary
+// local service could be listening there. The key-protected server stays unauthenticated
+// and surfaces via needKey instead, even though the matching key IS in the environment.
+func TestDetectDoesNotSprayEnvKeysToPortScans(t *testing.T) {
+	defer quietSources(t)()
+	srv := keyedServer("sk-secret", "keyed-model")
+	defer srv.Close()
+	t.Setenv("OPENAI_API_KEY", "sk-secret") // the working key is in the env...
+
+	old := probes
+	probes = []struct{ name, base string }{{"port:9999", srv.URL + "/v1"}} // ...but this hit is a blind scan
+	defer func() { probes = old }()
+
+	found, needKey := DetectFull()
+	if len(found) != 0 {
+		t.Fatalf("env key must NOT be sprayed at a blind port-scan candidate; got %+v", found)
+	}
+	if len(needKey) != 1 || needKey[0] != srv.URL+"/v1" {
+		t.Fatalf("a key-protected port-scan hit should surface via needKey, got %v", needKey)
+	}
+}
+
 // TestProbeKeyTriState: ProbeKey distinguishes reachable, needs-key, and unreachable.
 func TestProbeKeyTriState(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")

--- a/internal/tui/arrow_nav_test.go
+++ b/internal/tui/arrow_nav_test.go
@@ -25,8 +25,8 @@ func keyRight() tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRight} }
 func browseModel(t *testing.T) tea.Model {
 	t.Helper()
 	old := detectShares
-	detectShares = func(extra ...string) []detect.Found {
-		return []detect.Found{{Name: "t", Chat: "http://x/v1/chat/completions", Models: []string{"gpt-oss-20b"}}}
+	detectShares = func(extra ...string) ([]detect.Found, []string) {
+		return []detect.Found{{Name: "t", Chat: "http://x/v1/chat/completions", Models: []string{"gpt-oss-20b"}}}, nil
 	}
 	t.Cleanup(func() { detectShares = old })
 	mm := New("http://broker.local", "tester")

--- a/internal/tui/liveliness_test.go
+++ b/internal/tui/liveliness_test.go
@@ -124,8 +124,8 @@ func TestPresetBarRenders(t *testing.T) {
 func TestPresetKeysSwitchMode(t *testing.T) {
 	// Deterministic detection so [2] SHARE opens the provider table, not a network scan.
 	old := detectShares
-	detectShares = func(extra ...string) []detect.Found {
-		return []detect.Found{{Name: "t", Chat: "http://x/v1/chat/completions", Models: []string{"gpt-oss-20b"}}}
+	detectShares = func(extra ...string) ([]detect.Found, []string) {
+		return []detect.Found{{Name: "t", Chat: "http://x/v1/chat/completions", Models: []string{"gpt-oss-20b"}}}, nil
 	}
 	defer func() { detectShares = old }()
 

--- a/internal/tui/maskkey_test.go
+++ b/internal/tui/maskkey_test.go
@@ -1,0 +1,37 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestMaskKey: the last 4 CHARACTERS stay intact and the rest become bullets, including
+// for non-ASCII keys (the regression: byte-slicing k[len(k)-4:] could split a multi-byte
+// rune and emit garbled/invalid UTF-8).
+func TestMaskKey(t *testing.T) {
+	if got := maskKey("sk-abcd1234"); got != strings.Repeat("•", 7)+"1234" {
+		t.Errorf("maskKey ascii = %q, want 7 bullets + 1234", got)
+	}
+	if got := maskKey("abc"); got != "•••" {
+		t.Errorf("maskKey short = %q, want all bullets", got)
+	}
+	if got := maskKey(""); got != "" {
+		t.Errorf("maskKey empty = %q", got)
+	}
+
+	// A key ending in multi-byte runes: the tail must be the last 4 RUNES, intact + valid.
+	k := "secret-naïve-Ωπ"
+	r := []rune(k)
+	wantTail := string(r[len(r)-4:])
+	got := maskKey(k)
+	if !utf8.ValidString(got) {
+		t.Fatalf("maskKey produced invalid UTF-8 for a multi-byte key: %q", got)
+	}
+	if !strings.HasSuffix(got, wantTail) {
+		t.Errorf("maskKey(%q) = %q, want it to end with the last 4 runes %q", k, got, wantTail)
+	}
+	if utf8.RuneCountInString(got) != len(r) {
+		t.Errorf("maskKey should preserve the rune count: got %d, want %d", utf8.RuneCountInString(got), len(r))
+	}
+}

--- a/internal/tui/share_test.go
+++ b/internal/tui/share_test.go
@@ -162,8 +162,8 @@ func TestDisconnectVsQuit(t *testing.T) {
 func TestSectionToggle(t *testing.T) {
 	// Deterministic: pretend one model is detected so s -> the provider table (SHARE).
 	old := detectShares
-	detectShares = func(extra ...string) []detect.Found {
-		return []detect.Found{{Name: "test", BaseURL: "http://x/v1", Chat: "http://x/v1/chat/completions", Models: []string{"gpt-oss-20b"}}}
+	detectShares = func(extra ...string) ([]detect.Found, []string) {
+		return []detect.Found{{Name: "test", BaseURL: "http://x/v1", Chat: "http://x/v1/chat/completions", Models: []string{"gpt-oss-20b"}}}, nil
 	}
 	defer func() { detectShares = old }()
 
@@ -267,7 +267,7 @@ func TestGuidedFallbackWizard(t *testing.T) {
 	// Force "nothing detected" so the guided fallback opens deterministically (the
 	// real detector would scan the host's open ports).
 	old := detectShares
-	detectShares = func(extra ...string) []detect.Found { return nil }
+	detectShares = func(extra ...string) ([]detect.Found, []string) { return nil, nil }
 	defer func() { detectShares = old }()
 
 	mm := New("http://127.0.0.1:1", "tester")
@@ -477,7 +477,7 @@ func TestNoColorNonTTYRender(t *testing.T) {
 // crash, no bogus share).
 func TestShareSetupPasteVerifyFailure(t *testing.T) {
 	old := detectShares
-	detectShares = func(extra ...string) []detect.Found { return nil }
+	detectShares = func(extra ...string) ([]detect.Found, []string) { return nil, nil }
 	defer func() { detectShares = old }()
 
 	mm := New("http://127.0.0.1:1", "tester")
@@ -531,9 +531,9 @@ func TestShareDetectionIsAsync(t *testing.T) {
 	// detectShares must NOT be called inside Update (it would block the loop). Track it.
 	old := detectShares
 	called := false
-	detectShares = func(extra ...string) []detect.Found {
+	detectShares = func(extra ...string) ([]detect.Found, []string) {
 		called = true
-		return []detect.Found{{Name: "test", BaseURL: "http://x/v1", Chat: "http://x/v1/chat/completions", Models: []string{"gpt-oss-20b"}}}
+		return []detect.Found{{Name: "test", BaseURL: "http://x/v1", Chat: "http://x/v1/chat/completions", Models: []string{"gpt-oss-20b"}}}, nil
 	}
 	defer func() { detectShares = old }()
 
@@ -593,7 +593,7 @@ func TestShareDetectionIsAsync(t *testing.T) {
 // detection, not before.
 func TestShareDetectionEmptyEntersWizard(t *testing.T) {
 	old := detectShares
-	detectShares = func(extra ...string) []detect.Found { return nil }
+	detectShares = func(extra ...string) ([]detect.Found, []string) { return nil, nil }
 	defer func() { detectShares = old }()
 
 	mm := New("http://broker.local", "tester")
@@ -769,5 +769,63 @@ func TestShareEditorLivePreview(t *testing.T) {
 	prev = stripANSI(m.editorLivePreview())
 	if !strings.Contains(prev, "FREE") {
 		t.Errorf("wrapping free window preview = %q, want FREE", prev)
+	}
+}
+
+// TestSaveUpstreamHook: loading a freshly verified keyed upstream persists its base
+// URL + key via SaveUpstream exactly once, and re-detecting the SAME endpoint does
+// NOT rewrite config (only a real change fires the hook).
+func TestSaveUpstreamHook(t *testing.T) {
+	var savedUp, savedKey string
+	var calls int
+	hooks := Hooks{SaveUpstream: func(upstream, key string) {
+		calls++
+		savedUp, savedKey = upstream, key
+	}}
+	m := NewWithHooks("http://broker.local", "tester", nil, hooks)
+
+	// A newly detected key-protected server -> persisted once.
+	keyed := detect.Found{
+		Name: "vllm", BaseURL: "http://127.0.0.1:8000/v1",
+		Chat: "http://127.0.0.1:8000/v1/chat/completions",
+		Models: []string{"qwen3"}, Key: "sk-secret",
+	}
+	m.loadShareRows([]detect.Found{keyed})
+	if calls != 1 || savedUp != "http://127.0.0.1:8000/v1" || savedKey != "sk-secret" {
+		t.Fatalf("first load: calls=%d up=%q key=%q, want 1 / base / sk-secret", calls, savedUp, savedKey)
+	}
+
+	// Re-detecting the same endpoint+key is a no-op (no config churn).
+	m.loadShareRows([]detect.Found{keyed})
+	if calls != 1 {
+		t.Errorf("re-detecting the same endpoint rewrote config: calls=%d, want 1", calls)
+	}
+
+	// A changed key (e.g. the server's key rotated) persists again.
+	rotated := keyed
+	rotated.Key = "sk-rotated"
+	m.loadShareRows([]detect.Found{rotated})
+	if calls != 2 || savedKey != "sk-rotated" {
+		t.Errorf("rotated key: calls=%d key=%q, want 2 / sk-rotated", calls, savedKey)
+	}
+}
+
+// TestSaveUpstreamHookSeededNoChurn: a config-seeded upstream/key (ShareUpstream*)
+// that re-detects to the same values must NOT rewrite config on the first scan.
+func TestSaveUpstreamHookSeededNoChurn(t *testing.T) {
+	var calls int
+	hooks := Hooks{
+		ShareUpstream:    "http://127.0.0.1:8000/v1",
+		ShareUpstreamKey: "sk-secret",
+		SaveUpstream:     func(upstream, key string) { calls++ },
+	}
+	m := NewWithHooks("http://broker.local", "tester", nil, hooks)
+	m.loadShareRows([]detect.Found{{
+		BaseURL: "http://127.0.0.1:8000/v1",
+		Chat:    "http://127.0.0.1:8000/v1/chat/completions",
+		Models:  []string{"qwen3"}, Key: "sk-secret",
+	}})
+	if calls != 0 {
+		t.Errorf("re-detecting the seeded endpoint should not persist: calls=%d, want 0", calls)
 	}
 }

--- a/internal/tui/share_test.go
+++ b/internal/tui/share_test.go
@@ -787,7 +787,7 @@ func TestSaveUpstreamHook(t *testing.T) {
 	// A newly detected key-protected server -> persisted once.
 	keyed := detect.Found{
 		Name: "vllm", BaseURL: "http://127.0.0.1:8000/v1",
-		Chat: "http://127.0.0.1:8000/v1/chat/completions",
+		Chat:   "http://127.0.0.1:8000/v1/chat/completions",
 		Models: []string{"qwen3"}, Key: "sk-secret",
 	}
 	m.loadShareRows([]detect.Found{keyed})

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -53,6 +53,17 @@ type Hooks struct {
 	ShareModel  string               // saved onboarding model (default offer)
 	SharePriceI float64              // saved input price (0 = free)
 	SharePriceO float64              // saved output price (0 = free)
+	// ShareUpstream + ShareUpstreamKey seed the saved/verified local endpoint (and any
+	// bearer key it needs) from the host config, so a custom / key-protected upstream
+	// saved during onboarding is probed FIRST and reused on the TUI's first /share scan -
+	// not re-hunted or re-prompted. Empty for the common auto-detected no-auth server.
+	ShareUpstream    string
+	ShareUpstreamKey string
+	// SaveUpstream persists a newly verified local endpoint + any bearer key it needed
+	// (auto-detected or pasted in the guided fallback), so a custom / key-protected
+	// upstream survives a restart and is reused on the next scan - the TUI mirror of the
+	// CLI's save in `roger share`. nil = session-only (the host owns the disk write).
+	SaveUpstream func(upstream, key string)
 	// ShareMaxOnAir is the SOFT local cap on how many bands may be ON AIR at once (the
 	// share.max_on_air config knob), read once at startup. The [2] SHARE selector shows
 	// the ON AIR n/max slots and BLOCKS flipping another row on air at the cap. <=0 means
@@ -264,8 +275,11 @@ func rowSel(sel bool, plain string, width int) string {
 
 // detectShares is the indirection over local-LLM detection used by the SHARE
 // flows, so tests can make it deterministic (the real Detect scans the host's open
-// ports). Production uses detect.DetectWith.
-var detectShares = func(extra ...string) []detect.Found { return detect.DetectWith(extra...) }
+// ports). Production uses detect.DetectFull, which also reports key-protected
+// servers (needKey) so the guided fallback can ask for a key instead of dead-ending.
+var detectShares = func(extra ...string) (found []detect.Found, needKey []string) {
+	return detect.DetectFull(extra...)
+}
 
 // marketMedianOut is the indirection over the live per-model market-median lookup
 // used by the editor's fat-finger guard (the TUI mirror of the CLI softPriceWarn),
@@ -281,8 +295,19 @@ var marketMedianOut = func(broker, model string) (float64, bool) {
 // Update handler folds into the provider table. detectShares stays injectable so
 // tests can make this deterministic (a test can also feed sharesDetectedMsg
 // directly to exercise the handler).
-func detectSharesCmd(extra string) tea.Cmd {
-	return func() tea.Msg { return sharesDetectedMsg{found: detectShares(extra)} }
+func detectSharesCmd(extra, key string) tea.Cmd {
+	return func() tea.Msg {
+		// A saved keyed upstream is reused without a re-prompt: try it WITH its key first
+		// (the broad scan does not carry the key), then fall back to full detection. This
+		// mirrors the CLI's bare-`roger share` reuse of a saved keyed endpoint.
+		if extra != "" && key != "" {
+			if f, st := detect.ProbeKey(extra, key); st == detect.Reachable {
+				return sharesDetectedMsg{found: []detect.Found{f}}
+			}
+		}
+		found, needKey := detectShares(extra)
+		return sharesDetectedMsg{found: found, needKey: needKey}
+	}
 }
 
 type offer struct {
@@ -605,7 +630,12 @@ type model struct {
 	shareRows   []shareRow                // the provider table rows (detected models)
 	shareCursor int                       // selected row in the provider table
 	shareUp     string                    // the local upstream chat URL backing the shares
-	quitReturn  mode                      // the mode to restore if the on-air quit-guard is declined
+	shareKey    string                    // bearer key the headline upstream needs (env/paste), if any
+	// shareSavedUp/Key track what was last PERSISTED via Hooks.SaveUpstream (the /v1
+	// base + key), so a re-detection that lands the same endpoint doesn't rewrite config.
+	shareSavedUp  string
+	shareSavedKey string
+	quitReturn    mode // the mode to restore if the on-air quit-guard is declined
 	// station is the live, slugged broadcast callsign every band's node id is derived
 	// from (`<station>-<model>`). Seeded from Hooks.Station; the `n` rename in [2] SHARE
 	// edits it (renaming buffer = stationEdit while renaming==true) and persists via
@@ -656,6 +686,11 @@ type model struct {
 	setupCursor int    // selected option in the setup wizard
 	setupPaste  string // the pasted-URL buffer (when the "Other" option is chosen)
 	setupErr    string // last paste-verify error
+	// setupAwaitKey + setupKey drive the second input step when a pasted endpoint is
+	// reachable but KEY-PROTECTED (a 401/403): the input flips to collecting the API
+	// key, which we send as a Bearer to re-verify and then carry onto the share row.
+	setupAwaitKey bool
+	setupKey      string
 	// payout: a lightweight, lazily-fetched snapshot of the operator's Connect/KYC
 	// state + payable balance, surfaced as a one-line hint in the ON-AIR / SHARE
 	// earnings surface ("$X payable - run `roger payout`" or "complete KYC: ...").
@@ -719,6 +754,7 @@ type shareRow struct {
 	ctx          int
 	ctxEstimated bool   // ctx is the estimated default (no real window detected), not measured
 	upstream     string // the normalized chat-completions URL backing THIS row's model
+	upstreamKey  string // bearer key THIS row's key-protected upstream needs (env/paste), if any
 }
 
 // ---- messages ----
@@ -738,7 +774,10 @@ type freqResolvedMsg struct {
 // the event loop (see detectSharesCmd). The Update handler turns it into provider
 // rows + clears the loading flag, so the SHARE table never blocks the UI while the
 // host's open ports are probed.
-type sharesDetectedMsg struct{ found []detect.Found }
+type sharesDetectedMsg struct {
+	found   []detect.Found
+	needKey []string // base URLs present but key-protected (401/403), for the guided prompt
+}
 
 // balanceMsg carries the wallet read: the balance plus whether the broker says the
 // caller is logged in (has a real account wallet). Balance is shown only when in.
@@ -801,6 +840,14 @@ func NewWithHooks(broker, user string, limits *LimitStore, hooks Hooks) model {
 	if m.station == "" {
 		m.station = agent.GenerateStation()
 	}
+	// Seed the saved/verified upstream (and any key it needs) so the first /share scan
+	// probes that endpoint first and reuses a saved keyed upstream without re-prompting
+	// (detectSharesCmd carries the key). normalizeUpstream accepts the saved /v1 base.
+	m.shareUp = normalizeUpstream(hooks.ShareUpstream)
+	m.shareKey = hooks.ShareUpstreamKey
+	// What is already on disk, so a re-detection landing the same endpoint is a no-op
+	// (only a NEW upstream/key triggers a SaveUpstream write).
+	m.shareSavedUp, m.shareSavedKey = hooks.ShareUpstream, hooks.ShareUpstreamKey
 	// Seed the windowshade compact mode from the saved config so the [m] choice sticks.
 	m.compact = hooks.Compact
 	// Seed per-model pricing the user set in a previous session.
@@ -928,7 +975,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case sharesDetectedMsg:
-		return m.onSharesDetected(msg.found)
+		return m.onSharesDetected(msg.found, msg.needKey)
 	case balanceMsg:
 		m.loggedIn = msg.loggedIn
 		if msg.loggedIn {
@@ -1656,7 +1703,7 @@ func (m model) doShare(args []string) (tea.Model, tea.Cmd) {
 		m.sharePending = args[0] // `/share <model>` shortcut: flip it on air after detect
 	}
 	m.status = stDim.Render("scanning the band for local models…")
-	return m, detectSharesCmd(m.shareUp)
+	return m, detectSharesCmd(m.shareUp, m.shareKey)
 }
 
 // onSharesDetected folds an async detection result into the provider table: it
@@ -1665,15 +1712,22 @@ func (m model) doShare(args []string) (tea.Model, tea.Cmd) {
 // setup wizard when nothing was found. An empty re-detect from inside the table
 // (setupOnEmpty=false) stays on the table with a clear note rather than yanking the
 // user into the wizard mid-list.
-func (m model) onSharesDetected(found []detect.Found) (tea.Model, tea.Cmd) {
+func (m model) onSharesDetected(found []detect.Found, needKey []string) (tea.Model, tea.Cmd) {
 	m.shareLoading = false
 	if len(found) == 0 {
 		if m.setupOnEmpty {
-			// GUIDED FALLBACK: nothing detected -> the in-TUI setup wizard (pick a tool for
-			// a one-liner, or paste a URL we verify), not a dead-end status line. If we were
-			// already in the wizard (a re-scan / named-tool pick that found nothing), keep
-			// the wizard but flag the empty result inline.
+			// GUIDED FALLBACK: nothing usable detected -> the in-TUI setup wizard (pick a
+			// tool for a one-liner, or paste a URL we verify), not a dead-end status line.
+			// When a server IS there but key-protected (401/403), drop straight onto the
+			// paste row with its URL pre-filled and ask for the key - the most likely fix.
 			nm := m.enterShareSetup()
+			if len(needKey) > 0 {
+				nm.setupCursor = len(setupOptions) - 1 // the "Other - paste a URL" row
+				nm.setupPaste = needKey[0]
+				nm.setupAwaitKey = true
+				nm.status = stDim.Render(needKey[0] + " needs an API key - type it and press enter")
+				return nm, nil
+			}
 			if m.shareRescan {
 				note := m.setupHint
 				if note == "" {
@@ -1724,6 +1778,15 @@ func (m *model) loadShareRows(found []detect.Found) {
 	}
 	if len(found) > 0 {
 		m.shareUp = normalizeUpstream(found[0].Chat)
+		m.shareKey = found[0].Key
+		// Persist a newly verified endpoint + key so a custom / key-protected upstream is
+		// reused next launch (mirrors the CLI's save in `roger share`). Only on a real
+		// change, so re-scanning the already-saved endpoint doesn't rewrite config.
+		if m.hooks.SaveUpstream != nil && found[0].BaseURL != "" &&
+			(found[0].BaseURL != m.shareSavedUp || found[0].Key != m.shareSavedKey) {
+			m.shareSavedUp, m.shareSavedKey = found[0].BaseURL, found[0].Key
+			m.hooks.SaveUpstream(found[0].BaseURL, found[0].Key)
+		}
 	}
 	seen := map[string]bool{}
 	rows := make([]shareRow, 0)
@@ -1738,7 +1801,11 @@ func (m *model) loadShareRows(found []detect.Found) {
 			// window when the upstream reported it, else the estimated default (flagged) -
 			// so the TUI and CLI agree and the duplicated 32768 literal is gone.
 			ctxLen, ctxEst := detect.ResolveCtx(srv.Ctx, mdl)
-			rows = append(rows, shareRow{model: mdl, ctx: ctxLen, ctxEstimated: ctxEst, upstream: up})
+			// Carry the upstream's working key (discovered from env, or pasted in the
+			// guided fallback) so this row goes ON AIR with the same Bearer the detector
+			// authenticated with - a key-protected local server is otherwise served jobs
+			// it 401s.
+			rows = append(rows, shareRow{model: mdl, ctx: ctxLen, ctxEstimated: ctxEst, upstream: up, upstreamKey: srv.Key})
 		}
 	}
 	// Put the saved onboarding model first so the obvious default is at the cursor.
@@ -1799,6 +1866,10 @@ func (m *model) toggleShareAt(i int) {
 	if up == "" {
 		up = m.shareUp
 	}
+	upKey := row.upstreamKey
+	if upKey == "" {
+		upKey = m.shareKey
+	}
 	// Unique, STABLE, PRIVACY-PRESERVING node id per band: <station>-<model>, derived
 	// through the SAME helper the CLI `roger share` uses. The station is the friendly
 	// callsign (never the hostname); the per-model slug keeps each band a DISTINCT broker
@@ -1806,7 +1877,7 @@ func (m *model) toggleShareAt(i int) {
 	// model (the shares map is keyed by model), so no same-model disambiguation is needed.
 	node := agent.ShareNodeID(m.station, row.model, 0)
 	sess, err := agent.Start(agent.Config{
-		Broker: m.broker, Upstream: up, NodeID: node,
+		Broker: m.broker, Upstream: up, UpstreamKey: upKey, NodeID: node,
 		Region: "home", HW: m.hooks.HW, Model: row.model,
 		PriceIn: priceIn, PriceOut: priceOut, Ctx: row.ctx, CtxEstimated: row.ctxEstimated, Parallel: 4,
 		Schedule: schedToProtocol(p.Windows),
@@ -1867,12 +1938,16 @@ func (m *model) togglePrivateAt(i int) {
 	if up == "" {
 		up = m.shareUp
 	}
+	upKey := row.upstreamKey
+	if upKey == "" {
+		upKey = m.shareKey
+	}
 	// Same unique/stable/privacy-preserving node id as the public-share path (private
 	// just flips visibility): <station>-<model> via the shared helper, so a private band
 	// also gets its own broker node and carries the friendly station, not the hostname.
 	node := agent.ShareNodeID(m.station, row.model, 0)
 	sess, err := agent.Start(agent.Config{
-		Broker: m.broker, Upstream: up, NodeID: node,
+		Broker: m.broker, Upstream: up, UpstreamKey: upKey, NodeID: node,
 		Region: "home", HW: m.hooks.HW, Model: row.model,
 		PriceIn: p.In, PriceOut: p.Out, Ctx: row.ctx, CtxEstimated: row.ctxEstimated, Parallel: 4,
 		Private: goPrivate, Schedule: schedToProtocol(p.Windows),
@@ -2073,7 +2148,7 @@ func (m *model) onShareKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.setupHint = ""
 		m.sharePending = ""
 		m.status = stDim.Render("re-scanning the band for local models…")
-		return m, detectSharesCmd(m.shareUp)
+		return m, detectSharesCmd(m.shareUp, m.shareKey)
 	}
 	return m, nil
 }
@@ -2125,6 +2200,8 @@ func (m model) enterShareSetup() model {
 	m.setupCursor = 0
 	m.setupPaste = ""
 	m.setupErr = ""
+	m.setupAwaitKey = false
+	m.setupKey = ""
 	m.status = stDim.Render("no local model found - pick what you're running, or paste a URL")
 	return m
 }
@@ -2161,12 +2238,14 @@ func (m *model) onShareSetupKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.setupCursor--
 		}
 		m.setupErr = ""
+		m.setupAwaitKey = false
 		return m, nil
 	case "down", "j":
 		if m.setupCursor < len(setupOptions)-1 {
 			m.setupCursor++
 		}
 		m.setupErr = ""
+		m.setupAwaitKey = false
 		return m, nil
 	case "r":
 		// Re-scan (after the user started their tool in another terminal). ASYNC: enter
@@ -2180,7 +2259,7 @@ func (m *model) onShareSetupKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.sharePending = ""
 		m.setupErr = ""
 		m.status = stDim.Render("re-scanning the band for local models…")
-		return m, detectSharesCmd(m.shareUp)
+		return m, detectSharesCmd(m.shareUp, m.shareKey)
 	case "enter":
 		if pasting {
 			url := strings.TrimSpace(m.setupPaste)
@@ -2188,15 +2267,28 @@ func (m *model) onShareSetupKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.setupErr = "paste your endpoint, e.g. http://127.0.0.1:8081"
 				return m, nil
 			}
-			if f, ok := detect.Probe(url); ok {
+			// Verify with whatever key has been typed (empty on the first pass). A
+			// key-protected server flips into the key-entry step rather than failing; the
+			// next enter re-verifies with the typed key, which loadShareRows then carries
+			// onto the row so on-air uses the same Bearer.
+			f, st := detect.ProbeKey(url, strings.TrimSpace(m.setupKey))
+			switch st {
+			case detect.Reachable:
 				m.shareUp = normalizeUpstream(f.Chat)
 				m.loadShareRows([]detect.Found{f})
 				m.mode = modeShare
+				m.setupAwaitKey = false
 				m.status = stLive.Render("verified " + f.BaseURL + " - " + plural(len(m.shareRows), "model") + " ready")
 				return m, nil
+			case detect.NeedsKey:
+				m.setupAwaitKey = true
+				m.setupErr = ""
+				m.status = stDim.Render(url + " needs an API key - type it and press enter")
+				return m, nil
+			default:
+				m.setupErr = "no OpenAI-compatible server at " + url + " (no /v1/models) - check it and try again"
+				return m, nil
 			}
-			m.setupErr = "no OpenAI-compatible server at " + url + " (no /v1/models) - check it and try again"
-			return m, nil
 		}
 		// A named tool: ASYNC re-detect (maybe it's already up). If nothing comes back we
 		// return to the wizard with this tool's start one-liner; a found result lands the
@@ -2208,16 +2300,26 @@ func (m *model) onShareSetupKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.sharePending = ""
 		m.setupHint = "start it, then press r to re-scan:  " + setupOptions[m.setupCursor].oneLiner
 		m.status = stDim.Render("checking for " + setupOptions[m.setupCursor].label + "…")
-		return m, detectSharesCmd(m.shareUp)
+		return m, detectSharesCmd(m.shareUp, m.shareKey)
 	case "backspace":
-		if pasting && m.setupPaste != "" {
-			m.setupPaste = m.setupPaste[:len(m.setupPaste)-1]
+		if pasting {
+			if m.setupAwaitKey {
+				if m.setupKey != "" {
+					m.setupKey = m.setupKey[:len(m.setupKey)-1]
+				}
+			} else if m.setupPaste != "" {
+				m.setupPaste = m.setupPaste[:len(m.setupPaste)-1]
+			}
 		}
 		return m, nil
 	default:
 		if pasting {
 			if s := k.String(); len(s) == 1 {
-				m.setupPaste += s
+				if m.setupAwaitKey {
+					m.setupKey += s
+				} else {
+					m.setupPaste += s
+				}
 			}
 		}
 		return m, nil
@@ -6254,6 +6356,19 @@ func (m model) editorLivePreview() string {
 	return label + body + stDim.Render("  ("+src+")")
 }
 
+// maskKey renders an API key as bullets (keeping a short tail visible so the user
+// can confirm what they typed) so the secret never sits in plaintext on screen.
+func maskKey(k string) string {
+	n := len([]rune(k))
+	if n == 0 {
+		return ""
+	}
+	if n <= 4 {
+		return strings.Repeat("•", n)
+	}
+	return strings.Repeat("•", n-4) + k[len(k)-4:]
+}
+
 // shareSetupView is the in-TUI guided fallback when no local model was detected: a
 // k9s-styled option list (pick a tool for a start one-liner, or paste a URL we
 // verify). It carries the same selection-cursor + contextual-footer feel as the
@@ -6299,7 +6414,20 @@ func (m model) shareSetupView(w int) string {
 		if narrow {
 			tail = ""
 		}
-		b.WriteString("\n  " + stPrompt.Render("url › ") + stSelText.Render(m.setupPaste+"▏") + tail + "\n")
+		urlCaret := "▏"
+		if m.setupAwaitKey {
+			urlCaret = "" // caret moves to the key line below while entering the key
+		}
+		b.WriteString("\n  " + stPrompt.Render("url › ") + stSelText.Render(m.setupPaste+urlCaret) + tail + "\n")
+		// Second input step: a key-protected endpoint (401/403) asks for its API key,
+		// masked so a shoulder-surf doesn't leak it. Sent as a Bearer to re-verify.
+		if m.setupAwaitKey {
+			ktail := stDim.Render("   needs an API key  ·  ⏎ verifies with it")
+			if narrow {
+				ktail = ""
+			}
+			b.WriteString("  " + stPrompt.Render("key › ") + stSelText.Render(maskKey(m.setupKey)+"▏") + ktail + "\n")
+		}
 	} else {
 		hint := stDim.Render("started your tool? press ") + stKey.Render("r") + stDim.Render(" to re-scan")
 		b.WriteString("\n  " + hint + "\n")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1867,7 +1867,10 @@ func (m *model) toggleShareAt(i int) {
 		up = m.shareUp
 	}
 	upKey := row.upstreamKey
-	if upKey == "" {
+	// Only fall back to the headline key when this row's upstream IS the headline upstream.
+	// A keyless row on a DIFFERENT detected server must NOT receive the saved/headline
+	// bearer (that would spray a stale key onto the wrong endpoint).
+	if upKey == "" && normalizeUpstream(up) == normalizeUpstream(m.shareUp) {
 		upKey = m.shareKey
 	}
 	// Unique, STABLE, PRIVACY-PRESERVING node id per band: <station>-<model>, derived
@@ -1939,7 +1942,10 @@ func (m *model) togglePrivateAt(i int) {
 		up = m.shareUp
 	}
 	upKey := row.upstreamKey
-	if upKey == "" {
+	// Only fall back to the headline key when this row's upstream IS the headline upstream.
+	// A keyless row on a DIFFERENT detected server must NOT receive the saved/headline
+	// bearer (that would spray a stale key onto the wrong endpoint).
+	if upKey == "" && normalizeUpstream(up) == normalizeUpstream(m.shareUp) {
 		upKey = m.shareKey
 	}
 	// Same unique/stable/privacy-preserving node id as the public-share path (private
@@ -2239,6 +2245,7 @@ func (m *model) onShareSetupKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.setupErr = ""
 		m.setupAwaitKey = false
+		m.setupKey = "" // leaving the key step: drop any typed key so it can't be reused on another URL
 		return m, nil
 	case "down", "j":
 		if m.setupCursor < len(setupOptions)-1 {
@@ -2246,6 +2253,7 @@ func (m *model) onShareSetupKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.setupErr = ""
 		m.setupAwaitKey = false
+		m.setupKey = ""
 		return m, nil
 	case "r":
 		// Re-scan (after the user started their tool in another terminal). ASYNC: enter
@@ -2267,17 +2275,23 @@ func (m *model) onShareSetupKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.setupErr = "paste your endpoint, e.g. http://127.0.0.1:8081"
 				return m, nil
 			}
-			// Verify with whatever key has been typed (empty on the first pass). A
-			// key-protected server flips into the key-entry step rather than failing; the
-			// next enter re-verifies with the typed key, which loadShareRows then carries
-			// onto the row so on-air uses the same Bearer.
-			f, st := detect.ProbeKey(url, strings.TrimSpace(m.setupKey))
+			// Verify with the typed key ONLY when we are in the key-entry step. On the first
+			// pass (no key step yet) we probe with NO key — a key-protected server flips into
+			// the key step rather than failing, and only the next enter re-verifies with the
+			// typed key. This stops a stale key (typed for a previous URL) being sent as a
+			// Bearer to a different pasted URL. loadShareRows then carries the verified key.
+			key := ""
+			if m.setupAwaitKey {
+				key = strings.TrimSpace(m.setupKey)
+			}
+			f, st := detect.ProbeKey(url, key)
 			switch st {
 			case detect.Reachable:
 				m.shareUp = normalizeUpstream(f.Chat)
 				m.loadShareRows([]detect.Found{f})
 				m.mode = modeShare
 				m.setupAwaitKey = false
+				m.setupKey = ""
 				m.status = stLive.Render("verified " + f.BaseURL + " - " + plural(len(m.shareRows), "model") + " ready")
 				return m, nil
 			case detect.NeedsKey:
@@ -6366,7 +6380,9 @@ func maskKey(k string) string {
 	if n <= 4 {
 		return strings.Repeat("•", n)
 	}
-	return strings.Repeat("•", n-4) + k[len(k)-4:]
+	// Rune-slice the last 4 CHARACTERS (byte-slicing k[len(k)-4:] can split a multi-byte
+	// rune for a non-ASCII key and render a garbled tail).
+	return strings.Repeat("•", n-4) + string([]rune(k)[n-4:])
 }
 
 // shareSetupView is the in-TUI guided fallback when no local model was detected: a


### PR DESCRIPTION
## Problem

`roger share` made you a provider by auto-detecting a local OpenAI-compatible server. But if that server requires an API key (vLLM `--api-key`, a LiteLLM master key, `llama-server --api-key`, LM Studio's API-key toggle, or anything behind a reverse proxy), it returns **401/403** to the unauthenticated `GET /v1/models` probe — which detection treated identically to "nothing listening." So a running, keyed server was **invisible**: no models, no questions, just "no local LLM detected."

A key was only honored on the request-forwarding path, only via the unsaved `--upstream-key` flag — detection, onboarding, and the TUI were all key-blind.

## What this does

End-to-end support for key-protected local upstreams, in three layers:

### `feat(detect)`
- Probe is now **tri-state** (`probeOK` / `probeAuth` / `probeMiss`): a 401/403 is a positive "server present, needs a key" signal.
- **Harvest API keys from the environment** (`OPENAI_API_KEY` + common tool-specific spellings) and retry a 401 with each — a keyed server whose key is already in env is detected with zero extra config.
- Carry the working key on `Found.Key`, threaded (via `authGet`/`authPost`) through native fleet + context enrichment.
- New `DetectFull` (reports present-but-locked bases) and `ProbeKey`/`Status`. Old `Detect`/`DetectWith`/`Probe` kept as back-compat wrappers.

### `feat(cli)`
- `Share.UpstreamKey` saved to config; `--upstream-key` defaults from it **only for the saved endpoint** (matched via `sameEndpoint`) — **never sprayed onto a different `--upstream`**, so a stale bearer can't leak to another server.
- Bare `roger share` reuses a saved keyed upstream by probing it **with its key first**.
- Best-effort env-key harvest for an explicit `--upstream` (non-fatal, preserving self-heal).
- Guided fallback prompts for a key when a server is detected but locked, including after "start it, then re-scan".

### `feat(tui)`
- Upstream key threaded onto each provider row and into both `agent.Start` calls (the TUI previously had **no** key path).
- Saved upstream + key seeded from config and tried with its key first on the first scan — reused on restart without a re-prompt.
- Guided paste detects a locked endpoint, prompts for the key (**masked**), re-verifies; auto-scan pre-fills the locked URL into the wizard.
- New `SaveUpstream` hook persists a newly verified/pasted endpoint + key, **only on a real change** (no config churn on same-endpoint re-scan).

## Notes
- A key is now persisted into the share config file — worth confirming that file's permissions, since it holds an upstream secret.

## Testing
- New tests: keyed-from-env detection, `DetectFull` needKey surfacing, `ProbeKey` tri-state, `sameEndpoint` leak-prevention, `SaveUpstream` fires-once / no-churn / re-fires-on-rotation.
- Each commit builds independently (back-compat wrappers keep the detect→cli→tui order green; verified the CLI-only tree builds with the TUI changes stashed).
- `go build ./...` + `go vet` clean; detect / TUI-share / CLI-share suites green. Pre-existing `history_test.go` / `onair_lock_test.go` failures reproduce on `main` (on-disk test pollution), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)