### PR TITLE
feat: browser web console (live twin of the TUI)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,26 @@
-.PHONY: build demo clean kill test check site site-serve smoke smoke-live
+.PHONY: build demo clean kill test check site site-serve smoke smoke-live beta
 GOTOOLCHAIN := local
 export GOTOOLCHAIN
 
+# VERSION stamps the client semver into the binary (main.Version) at link time.
+# Default: the source fallback in cmd/rogerai/main.go. Override for a release/beta:
+#   make build VERSION=4.8.0
+#   make beta  VERSION=4.8.0-beta.1
+VERSION ?=
+VERSION_LDFLAGS := $(if $(VERSION),-X main.Version=$(VERSION),)
+
 build:
 	go build -o bin/rogerai-broker    ./cmd/rogerai-broker
-	go build -o bin/roger             ./cmd/rogerai
+	go build -ldflags "$(VERSION_LDFLAGS)" -o bin/roger ./cmd/rogerai
 	ln -sf roger bin/rogerai          # back-compat alias: the command is `roger`, `rogerai` still works
 	go build -o bin/tokenizer-sidecar ./cmd/tokenizer-sidecar
+
+# beta: a single stamped, trimmed binary for the host platform, named by its semver
+# (e.g. bin/roger-4.8.0-beta.1). Requires VERSION, which must be a semver.
+beta:
+	@test -n "$(VERSION)" || { echo "usage: make beta VERSION=4.8.0-beta.1"; exit 1; }
+	CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.Version=$(VERSION)" -o bin/roger-$(VERSION) ./cmd/rogerai
+	@echo "built bin/roger-$(VERSION)"
 
 # Build the marketing + account site: resolve the shared chrome partials
 # (web/src/_partials/{head,brand,nav,footer}.html) into every page and copy

--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -78,6 +78,7 @@ type config struct {
 	Share     *Share                `json:"share,omitempty"`        // saved provider config (the wizard's earn/free choice)
 	Prices    map[string]SharePrice `json:"share_prices,omitempty"` // per-model price + schedule from the in-TUI editor
 	Compact   bool                  `json:"compact,omitempty"`      // windowshade compact-mode toggle (the in-TUI [m] choice, persisted)
+	Webui     *bool                 `json:"webui,omitempty"`        // browser node console: nil/true = on (default), false = off; --no-webui overrides off for a run
 	// Station is this install's friendly, NON-SENSITIVE broadcast callsign (e.g.
 	// `brave-otter-37`). It is the public-facing identity in /discover - NOT the
 	// hostname - so it never leaks the machine name. Auto-generated once and persisted
@@ -398,12 +399,24 @@ func main() {
 	// A subtle, cached (~daily), non-blocking update banner. Computed once here so
 	// the TUI does no network at startup; the cache refreshes in the background.
 	notice := update.CachedNotice(Version)
+	// Global browser-console flags (--no-webui / --webui / --webui-port=N) are not
+	// subcommands; strip them here so the dispatcher reads the real command, and resolve
+	// whether the console comes up (ON by default; saved config or --no-webui opts out).
+	rest, webuiOn, webuiPort := stripWebuiFlags(os.Args[1:], cfg.webuiEnabled(), defaultWebuiPort)
+	os.Args = append([]string{os.Args[0]}, rest...)
 	if len(os.Args) < 2 {
 		// First run: a tiny guided wizard (consume vs share, free vs earn) before the
 		// app. Non-interactive / already-onboarded runs skip it and launch straight in.
 		cfg = maybeOnboard(cfg)
-		// no args -> launch the interactive radio TUI with the in-TUI flow hooks
-		if err := tui.RunWithHooks(cfg.Broker, cfg.User, tuiLimits(cfg), notice, tuiHooks(cfg)); err != nil {
+		// no args -> launch the interactive radio TUI with the in-TUI flow hooks, plus the
+		// browser console (unless disabled) over the SAME shared node controller, so a
+		// change in either front-end shows up in the other.
+		hooks := tuiHooks(cfg)
+		ctrl := tui.NewController(cfg.Broker, hooks)
+		if webuiOn {
+			startWebConsole(cfg, ctrl, webuiPort)
+		}
+		if err := tui.RunWithController(cfg.Broker, cfg.User, tuiLimits(cfg), notice, hooks, ctrl); err != nil {
 			fmt.Fprintln(os.Stderr, "error:", err)
 			os.Exit(1)
 		}
@@ -1539,7 +1552,8 @@ func normalizeUpstream(u string) string {
 func usage() {
 	fmt.Printf(`rogerai - a two-way radio for GPUs. run with no args for the interactive app.
 
-  roger                         open the app (browse, tune in, chat)
+  roger                         open the app (browse, tune in, chat) + browser console
+  roger --no-webui              open the app WITHOUT the browser console
   roger search                list models, cheapest first
   roger use <model>           local OpenAI endpoint for your bots  (alias: connect · --max-out $ caps spend)
   roger balance               your wallet balance

--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -31,8 +31,14 @@ import (
 )
 
 // Version is the client version (compared against the latest GitHub release for
-// the update check / `roger upgrade`). Keep in sync with releases.
-const Version = "4.7.0"
+// the update check / `roger upgrade`). It is a var (not a const) so a release/beta
+// build can stamp a semver via the linker without editing source:
+//
+//	go build -ldflags "-X main.Version=4.8.0-beta.1" ./cmd/rogerai
+//
+// The default below is the fallback for a plain `go build`. Keep it in sync with
+// releases. Use semver, optionally with a prerelease suffix (e.g. 4.8.0-beta.1).
+var Version = "4.7.0"
 
 // The production broker is the default - `rogerai` works out of the box, no config.
 // Override per-session with ROGER_BROKER=... or persist with `roger config set broker`.

--- a/cmd/rogerai/webconsole.go
+++ b/cmd/rogerai/webconsole.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rogerai-fyi/roger/internal/node"
+	"github.com/rogerai-fyi/roger/internal/tui"
+	"github.com/rogerai-fyi/roger/internal/webui"
+)
+
+// defaultWebuiPort is where the browser node console binds first; if it's taken the
+// server scans upward (webui.Listen), so a busy port never dead-ends.
+const defaultWebuiPort = "4180"
+
+// webuiEnabled reports whether the browser console should come up. It is ON by default;
+// the saved config can opt out (config.Webui=false), and the --no-webui flag forces it
+// off for a single run (--webui forces it on). The flags are consumed by stripWebuiFlags.
+func (c config) webuiEnabled() bool { return c.Webui == nil || *c.Webui }
+
+// stripWebuiFlags removes the global --no-webui / --webui / --webui-port=N flags from a
+// raw argv tail and reports the resulting enabled state + port. They are global (not tied
+// to a subcommand), so the dispatcher filters them before reading os.Args[1]; a real
+// command keeps all its own args.
+func stripWebuiFlags(args []string, enabled bool, port string) (rest []string, outEnabled bool, outPort string) {
+	outEnabled, outPort = enabled, port
+	for _, a := range args {
+		switch {
+		case a == "--no-webui":
+			outEnabled = false
+		case a == "--webui":
+			outEnabled = true
+		case strings.HasPrefix(a, "--webui-port="):
+			if p := strings.TrimPrefix(a, "--webui-port="); p != "" {
+				outPort = p
+			}
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return rest, outEnabled, outPort
+}
+
+// startWebConsole stands up the localhost browser console over ctrl (the SAME controller
+// the TUI/daemon drives), printing the tokenized URL and opening the browser. It returns
+// immediately; the server runs in a background goroutine for the life of the process. A
+// bind failure is non-fatal — the terminal front-end carries on.
+func startWebConsole(cfg config, ctrl *node.Controller, port string) {
+	s := webui.New(ctrl, webui.Options{Broker: cfg.Broker, User: cfg.User, ClientID: gitHubClientID()})
+	ln, url, err := s.Listen("127.0.0.1:" + port)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "web console: could not bind a localhost port:", err)
+		return
+	}
+	fmt.Printf("web console → %s\n", url)
+	go func() { _ = s.Serve(ln) }()
+	// Open the browser only on a real interactive terminal (the helper self-gates), so a
+	// headless `roger share` daemon prints the URL but never hijacks a browser.
+	tui.OpenURL(url)
+}

--- a/cmd/rogerai/webconsole_test.go
+++ b/cmd/rogerai/webconsole_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripWebuiFlags(t *testing.T) {
+	tt := []struct {
+		name        string
+		args        []string
+		inEnabled   bool
+		wantRest    []string
+		wantEnabled bool
+		wantPort    string
+	}{
+		{"no flags keeps args + default", []string{"share", "gpt-oss"}, true, []string{"share", "gpt-oss"}, true, defaultWebuiPort},
+		{"--no-webui disables, leaves command", []string{"--no-webui", "share"}, true, []string{"share"}, false, defaultWebuiPort},
+		{"--webui forces on", []string{"--webui"}, false, nil, true, defaultWebuiPort},
+		{"--webui-port overrides", []string{"--webui-port=5000"}, true, nil, true, "5000"},
+		{"flags mixed with a command", []string{"share", "--no-webui", "--webui-port=4200"}, true, []string{"share"}, false, "4200"},
+		{"bare no-flag run stays enabled", nil, true, nil, true, defaultWebuiPort},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			rest, enabled, port := stripWebuiFlags(tc.args, tc.inEnabled, defaultWebuiPort)
+			if !reflect.DeepEqual(rest, tc.wantRest) {
+				t.Errorf("rest = %#v, want %#v", rest, tc.wantRest)
+			}
+			if enabled != tc.wantEnabled {
+				t.Errorf("enabled = %v, want %v", enabled, tc.wantEnabled)
+			}
+			if port != tc.wantPort {
+				t.Errorf("port = %q, want %q", port, tc.wantPort)
+			}
+		})
+	}
+}
+
+func TestWebuiEnabledDefault(t *testing.T) {
+	if !(config{}).webuiEnabled() {
+		t.Error("webui should be ON by default (Webui nil)")
+	}
+	on, off := true, false
+	if !(config{Webui: &on}).webuiEnabled() {
+		t.Error("Webui=true should be on")
+	}
+	if (config{Webui: &off}).webuiEnabled() {
+		t.Error("Webui=false should be off")
+	}
+}

--- a/internal/client/console.go
+++ b/internal/client/console.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// This file exposes data-form readers used by the localhost web console (internal/webui),
+// which renders these surfaces itself rather than printing them. They wrap the same broker
+// calls the CLI/TUI already use, so there is one code path per surface.
+
+// Discover fetches the broker's current open-market offer list. Exported data form of the
+// internal failover discover.
+func Discover(broker string) ([]Offer, error) { return discover(broker) }
+
+// BalanceInfo is the signed wallet read: the balance, whether the broker recognizes a real
+// account (logged in), and the month-to-date spend cap + spend.
+type BalanceInfo struct {
+	Balance      float64 `json:"balance"`
+	LoggedIn     bool    `json:"logged_in"`
+	MonthlyCap   float64 `json:"monthly_cap"`
+	MonthlySpend float64 `json:"monthly_spend"`
+}
+
+// FetchBalance reads the signed wallet balance for user from broker — the data form of the
+// CLI's Balance print and the TUI's fetchBalance.
+func FetchBalance(broker, user string) (BalanceInfo, error) {
+	req, _ := http.NewRequest(http.MethodGet, broker+"/balance", nil)
+	SignRequest(req, nil)
+	req.Header.Set("X-Roger-User", user)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return BalanceInfo{}, err
+	}
+	defer resp.Body.Close()
+	var b BalanceInfo
+	if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
+		return BalanceInfo{}, err
+	}
+	return b, nil
+}

--- a/internal/node/controller.go
+++ b/internal/node/controller.go
@@ -1,0 +1,459 @@
+// Package node holds the live operator state of a Roger sharing node — the set of
+// locally-detected models, which of them are ON AIR (each a running agent.Session),
+// their price + schedule, the station callsign, and the headline link status — behind
+// a single mutex so MULTIPLE front-ends can drive one node concurrently.
+//
+// The terminal TUI (internal/tui) and the browser web console (internal/webui) both
+// hold the SAME *Controller: a toggle in the browser flips the TUI row and vice-versa,
+// because there is exactly one owner of the session registry. The headless `roger share`
+// daemon uses the same type, so the web console attaches to it too. Everything here is
+// UI-free: mutating methods return structured results (ToggleResult/PrivateResult) that
+// each front-end renders in its own idiom (lipgloss for the TUI, JSON for the web).
+package node
+
+import (
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/rogerai-fyi/roger/internal/agent"
+	"github.com/rogerai-fyi/roger/internal/detect"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// DefaultMaxOnAir is the SOFT local on-air cap used when the host supplies none. A
+// local UX guard so an operator does not over-subscribe their host; the broker's
+// per-owner cap is the real backstop.
+const DefaultMaxOnAir = 4
+
+// SchedWindow is one editable time-of-use price window (times "HH:MM" UTC). Free
+// zeroes the in-window price.
+type SchedWindow struct {
+	Start, End string
+	In, Out    float64
+	Free       bool
+}
+
+// Pricing is the per-model saved price + schedule the editor produces. The host
+// persists it; on-air it is applied when the model goes live.
+type Pricing struct {
+	In, Out float64
+	Windows []SchedWindow
+}
+
+// ShareRow is one locally-detected model in the provider catalog. Each row carries
+// its OWN upstream (the server that actually serves it) + the bearer key that server
+// needs, so a multi-endpoint box shares each model against the right backend.
+type ShareRow struct {
+	Model        string
+	Ctx          int
+	CtxEstimated bool
+	Upstream     string
+	UpstreamKey  string
+}
+
+// Hooks are the host-supplied persistence closures (disk I/O lives in the CLI, not
+// here). All are nil-safe: a nil hook just skips persistence.
+type Hooks struct {
+	SaveUpstream func(upstream, key string)
+	SavePrice    func(model string, p Pricing)
+	SaveStation  func(station string)
+}
+
+// Config seeds a Controller with the immutable-ish node identity + defaults the host
+// resolves once at startup.
+type Config struct {
+	Broker      string
+	HW          string
+	Station     string
+	ShareModel  string  // the onboarding default model (sorted first; carries the saved price)
+	SharePriceI float64 // saved onboarding price for ShareModel
+	SharePriceO float64
+	MaxOnAir    int                // 0 -> DefaultMaxOnAir
+	Upstream    string             // saved/verified upstream base or chat URL (headline default)
+	UpstreamKey string             // bearer key the saved upstream needs, if any
+	Prices      map[string]Pricing // saved per-model pricing from a previous session
+	Hooks       Hooks
+}
+
+// Controller is the single, concurrency-safe owner of a node's live share state.
+type Controller struct {
+	mu sync.Mutex
+
+	broker      string
+	hw          string
+	station     string
+	shareModel  string
+	sharePriceI float64
+	sharePriceO float64
+	maxOnAir    int
+	hooks       Hooks
+
+	rows     []ShareRow
+	sessions map[string]*agent.Session
+	private  map[string]bool
+	prices   map[string]Pricing
+
+	upstream    string // headline upstream (found[0]) — fallback for rows that predate per-row upstreams
+	upstreamKey string
+	savedUp     string // last endpoint persisted via Hooks.SaveUpstream (change detection)
+	savedKey    string
+
+	loggedIn bool // updated by the front-ends; gates priced/private shares
+}
+
+// New builds a Controller from cfg. The session/price/private registries start empty;
+// the host calls LoadRows after the first detection scan.
+func New(cfg Config) *Controller {
+	c := &Controller{
+		broker:      cfg.Broker,
+		hw:          cfg.HW,
+		station:     cfg.Station,
+		shareModel:  cfg.ShareModel,
+		sharePriceI: cfg.SharePriceI,
+		sharePriceO: cfg.SharePriceO,
+		maxOnAir:    cfg.MaxOnAir,
+		hooks:       cfg.Hooks,
+		sessions:    map[string]*agent.Session{},
+		private:     map[string]bool{},
+		prices:      map[string]Pricing{},
+		// Seed the saved/verified upstream so the first scan probes it first and a saved
+		// keyed upstream is reused without re-prompting. savedUp/Key mirror what is already
+		// on disk so a re-detection of the same endpoint is a no-op (no SaveUpstream write).
+		upstream:    NormalizeUpstream(cfg.Upstream),
+		upstreamKey: cfg.UpstreamKey,
+		savedUp:     cfg.Upstream,
+		savedKey:    cfg.UpstreamKey,
+	}
+	for k, v := range cfg.Prices {
+		c.prices[k] = v
+	}
+	return c
+}
+
+// SetLoggedIn records the operator's current login state so priced/private shares are
+// gated correctly. Front-ends push this whenever their login state changes.
+func (c *Controller) SetLoggedIn(v bool) {
+	c.mu.Lock()
+	c.loggedIn = v
+	c.mu.Unlock()
+}
+
+// SetPrices seeds the saved per-model pricing (from the host's config) without going
+// through the editor. Used once at startup so on-air uses the operator's saved prices.
+func (c *Controller) SetPrices(p map[string]Pricing) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.prices = map[string]Pricing{}
+	for k, v := range p {
+		c.prices[k] = v
+	}
+}
+
+// LoadRows replaces the detected-model catalog from a detection scan. It also adopts
+// the headline upstream + key from the first server and persists a newly-verified
+// endpoint (mirrors the CLI's save in `roger share`), only on a real change so a
+// re-scan of the already-saved endpoint never rewrites config.
+func (c *Controller) LoadRows(found []detect.Found) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(found) > 0 {
+		c.upstream = NormalizeUpstream(found[0].Chat)
+		c.upstreamKey = found[0].Key
+		if c.hooks.SaveUpstream != nil && found[0].BaseURL != "" &&
+			(found[0].BaseURL != c.savedUp || found[0].Key != c.savedKey) {
+			c.savedUp, c.savedKey = found[0].BaseURL, found[0].Key
+			c.hooks.SaveUpstream(found[0].BaseURL, found[0].Key)
+		}
+	}
+	seen := map[string]bool{}
+	rows := make([]ShareRow, 0)
+	for _, srv := range found {
+		up := NormalizeUpstream(srv.Chat)
+		for _, mdl := range srv.Models {
+			if mdl == "" || seen[mdl] {
+				continue
+			}
+			seen[mdl] = true
+			// One ctx resolver shared with the CLI/TUI: the real detected window when the
+			// upstream reported it, else the estimated default (flagged).
+			ctxLen, ctxEst := detect.ResolveCtx(srv.Ctx, mdl)
+			rows = append(rows, ShareRow{Model: mdl, Ctx: ctxLen, CtxEstimated: ctxEst, Upstream: up, UpstreamKey: srv.Key})
+		}
+	}
+	// Saved onboarding model first, so the obvious default is at the cursor.
+	if def := c.shareModel; def != "" {
+		sort.SliceStable(rows, func(i, j int) bool { return rows[i].Model == def && rows[j].Model != def })
+	}
+	c.rows = rows
+}
+
+// SetRows replaces the detected-model catalog directly (bypassing a detection scan).
+// Used where the rows are already known — e.g. a unit test, or a host that resolves the
+// catalog itself.
+func (c *Controller) SetRows(rows []ShareRow) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rows = append([]ShareRow(nil), rows...)
+}
+
+// ToggleResult describes what a ToggleOnAir call did, so each front-end can render its
+// own status line without the controller importing a UI.
+type ToggleResult struct {
+	Model       string
+	WentOff     bool    // was on air, now stopped
+	Priced      bool    // started priced (vs FREE)
+	PriceOut    float64 // for the "$x/1M out" label
+	AtLimit     bool    // blocked: soft on-air cap reached
+	LoginNeeded bool    // blocked: priced share needs login
+	Err         error   // agent.Start failed
+}
+
+// ToggleOnAir flips the on-air state of model: an off-air model starts an in-process
+// agent.Session against its upstream at the saved/free price; an on-air model stops.
+// Ports the TUI's toggleShareAt (login-gate, soft max-on-air cap, node-id derivation).
+func (c *Controller) ToggleOnAir(model string) ToggleResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	res := ToggleResult{Model: model}
+	row, ok := c.rowFor(model)
+	if !ok {
+		return res
+	}
+	if sess := c.sessions[model]; sess != nil {
+		sess.Stop()
+		delete(c.sessions, model)
+		res.WentOff = true
+		return res
+	}
+	if c.atLimitLocked() {
+		res.AtLimit = true
+		return res
+	}
+	p := c.pricingForLocked(model)
+	priced := p.In > 0 || p.Out > 0 || len(p.Windows) > 0
+	if priced && !c.loggedIn {
+		res.LoginNeeded = true
+		return res
+	}
+	sess, err := c.startLocked(row, p, false)
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	c.sessions[model] = sess
+	res.Priced = p.In > 0 || p.Out > 0
+	res.PriceOut = p.Out
+	return res
+}
+
+// PrivateResult describes what a TogglePrivate call did.
+type PrivateResult struct {
+	Model       string
+	NowPrivate  bool
+	Code        string // freshly-minted one-time frequency code (empty if none minted)
+	Display     string // cosmetic band display
+	AtLimit     bool
+	LoginNeeded bool
+	Err         error
+}
+
+// TogglePrivate flips a row's PRIVATE-band state, (re)starting its session with the new
+// visibility. Going private is login-gated (an earning-adjacent per-owner resource).
+// Ports the TUI's togglePrivateAt.
+func (c *Controller) TogglePrivate(model string) PrivateResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	res := PrivateResult{Model: model}
+	row, ok := c.rowFor(model)
+	if !ok {
+		return res
+	}
+	if !c.loggedIn {
+		res.LoginNeeded = true
+		return res
+	}
+	goPrivate := !c.private[model]
+	wasOn := c.sessions[model] != nil
+	if !wasOn && c.atLimitLocked() {
+		res.AtLimit = true
+		return res
+	}
+	if sess := c.sessions[model]; sess != nil {
+		sess.Stop()
+		delete(c.sessions, model)
+	}
+	p := c.pricingForLocked(model)
+	sess, err := c.startLocked(row, p, goPrivate)
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	c.sessions[model] = sess
+	c.private[model] = goPrivate
+	res.NowPrivate = goPrivate
+	if goPrivate {
+		_, code, display := sess.Band()
+		res.Code, res.Display = code, display
+	}
+	return res
+}
+
+// startLocked launches an agent.Session for row at pricing p (caller holds the lock).
+// Same unique/stable/privacy-preserving node id the CLI uses: <station>-<model>.
+func (c *Controller) startLocked(row ShareRow, p Pricing, private bool) (*agent.Session, error) {
+	up := row.Upstream
+	if up == "" {
+		up = c.upstream
+	}
+	upKey := row.UpstreamKey
+	if upKey == "" {
+		upKey = c.upstreamKey
+	}
+	node := agent.ShareNodeID(c.station, row.Model, 0)
+	return agent.Start(agent.Config{
+		Broker: c.broker, Upstream: up, UpstreamKey: upKey, NodeID: node,
+		Region: "home", HW: c.hw, Model: row.Model,
+		PriceIn: p.In, PriceOut: p.Out, Ctx: row.Ctx, CtxEstimated: row.CtxEstimated, Parallel: 4,
+		Private: private, Schedule: SchedToProtocol(p.Windows),
+	})
+}
+
+// SetPricing records a per-model price + schedule (from the editor) and persists it.
+// Does not restart a live session — the next on-air toggle applies it.
+func (c *Controller) SetPricing(model string, p Pricing) {
+	c.mu.Lock()
+	c.prices[model] = p
+	hook := c.hooks.SavePrice
+	c.mu.Unlock()
+	if hook != nil {
+		hook(model, p)
+	}
+}
+
+// PricingFor returns the price a model would share at: its edited price, else the saved
+// onboarding price for the default model, else free.
+func (c *Controller) PricingFor(model string) Pricing {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.pricingForLocked(model)
+}
+
+func (c *Controller) pricingForLocked(model string) Pricing {
+	if p, ok := c.prices[model]; ok {
+		return p
+	}
+	if model == c.shareModel {
+		return Pricing{In: c.sharePriceI, Out: c.sharePriceO}
+	}
+	return Pricing{}
+}
+
+// Rename sets the station callsign and persists it. The new callsign applies to bands
+// put on air AFTER the rename (a live session keeps its node id until it cycles).
+func (c *Controller) Rename(station string) {
+	c.mu.Lock()
+	c.station = station
+	hook := c.hooks.SaveStation
+	c.mu.Unlock()
+	if hook != nil {
+		hook(station)
+	}
+}
+
+// Detect runs an async-safe local-LLM scan (used by the re-detect action). It does not
+// mutate the catalog; the caller passes the result to LoadRows.
+func (c *Controller) Detect(extra, key string) (found []detect.Found, needKey []string) {
+	if extra != "" {
+		if f, st := detect.ProbeKey(extra, key); st == detect.Reachable {
+			return []detect.Found{f}, nil
+		}
+	}
+	return detect.DetectFull(extra)
+}
+
+// StopAll takes every model off air (clean exit / `/share off`).
+func (c *Controller) StopAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for mdl, sess := range c.sessions {
+		if sess != nil {
+			sess.Stop()
+		}
+		delete(c.sessions, mdl)
+	}
+}
+
+// Adopt registers an already-started session under model, so a host that launched the
+// agent.Session itself (or a test) can hand it to the controller and have it counted,
+// surfaced in snapshots, and stopped on StopAll. Replaces any existing session for model.
+func (c *Controller) Adopt(model string, sess *agent.Session) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sessions[model] = sess
+}
+
+// rowFor returns the catalog row for model (caller holds the lock).
+func (c *Controller) rowFor(model string) (ShareRow, bool) {
+	for _, r := range c.rows {
+		if r.Model == model {
+			return r, true
+		}
+	}
+	return ShareRow{}, false
+}
+
+// MaxOnAir is the effective soft on-air cap.
+func (c *Controller) MaxOnAir() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.maxOnAirLocked()
+}
+
+func (c *Controller) maxOnAirLocked() int {
+	if c.maxOnAir > 0 {
+		return c.maxOnAir
+	}
+	return DefaultMaxOnAir
+}
+
+func (c *Controller) atLimitLocked() bool { return c.onAirCountLocked() >= c.maxOnAirLocked() }
+
+func (c *Controller) onAirCountLocked() int {
+	n := 0
+	for _, s := range c.sessions {
+		if s != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// NormalizeUpstream canonicalizes a base/chat URL to the chat-completions endpoint the
+// agent posts to. Shared by the controller, the TUI, and the CLI so they agree.
+func NormalizeUpstream(u string) string {
+	u = strings.TrimRight(strings.TrimSpace(u), "/")
+	switch {
+	case u == "":
+		return u
+	case strings.HasSuffix(u, "/chat/completions"):
+		return u
+	case strings.HasSuffix(u, "/v1"):
+		return u + "/chat/completions"
+	default:
+		return u + "/v1/chat/completions"
+	}
+}
+
+// SchedToProtocol converts editable windows into the wire protocol.PriceWindow the
+// agent publishes. Empty -> no schedule.
+func SchedToProtocol(ws []SchedWindow) []protocol.PriceWindow {
+	if len(ws) == 0 {
+		return nil
+	}
+	out := make([]protocol.PriceWindow, 0, len(ws))
+	for _, w := range ws {
+		out = append(out, protocol.PriceWindow{Start: w.Start, End: w.End, In: w.In, Out: w.Out, Free: w.Free})
+	}
+	return out
+}

--- a/internal/node/controller.go
+++ b/internal/node/controller.go
@@ -131,12 +131,33 @@ func New(cfg Config) *Controller {
 	return c
 }
 
-// SetLoggedIn records the operator's current login state so priced/private shares are
-// gated correctly. Front-ends push this whenever their login state changes.
+// SetLoggedIn records that a front-end observed the operator as logged in. It is
+// RAISE-ONLY: passing true marks the node logged in, passing false is a no-op. This lets
+// BOTH front-ends push their best knowledge every refresh without one clobbering the
+// other (the TUI ticks SetLoggedIn(false) before its first balance read; a web login must
+// survive that). An actual sign-out goes through Logout.
 func (c *Controller) SetLoggedIn(v bool) {
+	if !v {
+		return
+	}
 	c.mu.Lock()
-	c.loggedIn = v
+	c.loggedIn = true
 	c.mu.Unlock()
+}
+
+// Logout explicitly clears the logged-in state (an operator sign-out from either
+// front-end). Priced/private shares re-lock until the next login.
+func (c *Controller) Logout() {
+	c.mu.Lock()
+	c.loggedIn = false
+	c.mu.Unlock()
+}
+
+// LoggedIn reports the current login state.
+func (c *Controller) LoggedIn() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.loggedIn
 }
 
 // SetPrices seeds the saved per-model pricing (from the host's config) without going

--- a/internal/node/controller.go
+++ b/internal/node/controller.go
@@ -327,10 +327,7 @@ func (c *Controller) startLocked(row ShareRow, p Pricing, private bool) (*agent.
 	if up == "" {
 		up = c.upstream
 	}
-	upKey := row.UpstreamKey
-	if upKey == "" {
-		upKey = c.upstreamKey
-	}
+	upKey := pickUpstreamKey(up, row.UpstreamKey, c.upstream, c.upstreamKey)
 	node := agent.ShareNodeID(c.station, row.Model, 0)
 	return agent.Start(agent.Config{
 		Broker: c.broker, Upstream: up, UpstreamKey: upKey, NodeID: node,
@@ -338,6 +335,20 @@ func (c *Controller) startLocked(row ShareRow, p Pricing, private bool) (*agent.
 		PriceIn: p.In, PriceOut: p.Out, Ctx: row.Ctx, CtxEstimated: row.CtxEstimated, Parallel: 4,
 		Private: private, Schedule: SchedToProtocol(p.Windows),
 	})
+}
+
+// pickUpstreamKey chooses the bearer to send to a row's upstream: the row's OWN key if it
+// has one, else the headline key ONLY when the row's upstream IS the headline upstream.
+// A keyless row on a DIFFERENT detected server gets no key — never spray the saved/headline
+// bearer onto the wrong endpoint (mirrors the CLI's sameEndpoint gate).
+func pickUpstreamKey(rowUpstream, rowKey, headlineUpstream, headlineKey string) string {
+	if rowKey != "" {
+		return rowKey
+	}
+	if NormalizeUpstream(rowUpstream) == NormalizeUpstream(headlineUpstream) {
+		return headlineKey
+	}
+	return ""
 }
 
 // SetPricing records a per-model price + schedule (from the editor) and persists it.

--- a/internal/node/controller_test.go
+++ b/internal/node/controller_test.go
@@ -88,6 +88,26 @@ func TestSoftMaxOnAirCap(t *testing.T) {
 	}
 }
 
+func TestPickUpstreamKey(t *testing.T) {
+	const headUp, headKey = "http://127.0.0.1:8080/v1/chat/completions", "sk-headline"
+	// A row with its OWN key always uses it.
+	if got := pickUpstreamKey("http://127.0.0.1:9999/v1/chat/completions", "sk-own", headUp, headKey); got != "sk-own" {
+		t.Errorf("row with own key = %q, want sk-own", got)
+	}
+	// A keyless row on the headline upstream inherits the headline key.
+	if got := pickUpstreamKey(headUp, "", headUp, headKey); got != headKey {
+		t.Errorf("keyless row on headline upstream = %q, want the headline key", got)
+	}
+	// A keyless row on a DIFFERENT upstream gets NO key — the headline bearer is not sprayed.
+	if got := pickUpstreamKey("http://127.0.0.1:9999/v1/chat/completions", "", headUp, headKey); got != "" {
+		t.Errorf("keyless row on a different upstream = %q, want empty (no spray)", got)
+	}
+	// Equivalent spellings of the same endpoint still count as the same (normalized).
+	if got := pickUpstreamKey("http://127.0.0.1:8080/v1", "", headUp, headKey); got != headKey {
+		t.Errorf("keyless row on the same endpoint (different spelling) = %q, want the headline key", got)
+	}
+}
+
 func TestDefaultMaxOnAir(t *testing.T) {
 	c := newCtrl(t, Config{})
 	if c.MaxOnAir() != DefaultMaxOnAir {

--- a/internal/node/controller_test.go
+++ b/internal/node/controller_test.go
@@ -1,0 +1,181 @@
+package node
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/detect"
+)
+
+// fakeBroker is a minimal broker that lets agent.Start succeed (register ok) and stay
+// on air (heartbeat ok), so a Controller can really start/stop sessions in a test.
+func fakeBroker(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func newCtrl(t *testing.T, cfg Config) *Controller {
+	if cfg.Broker == "" {
+		cfg.Broker = fakeBroker(t)
+	}
+	if cfg.Station == "" {
+		cfg.Station = "amber-fox"
+	}
+	c := New(cfg)
+	c.SetRows([]ShareRow{
+		{Model: "free-1", Ctx: 8192, Upstream: "http://127.0.0.1:0/v1/chat/completions"},
+		{Model: "free-2", Ctx: 8192, Upstream: "http://127.0.0.1:0/v1/chat/completions"},
+		{Model: "paid", Ctx: 8192, Upstream: "http://127.0.0.1:0/v1/chat/completions"},
+	})
+	c.SetPricing("paid", Pricing{Out: 2})
+	return c
+}
+
+func TestToggleOnAirStartsAndStops(t *testing.T) {
+	c := newCtrl(t, Config{})
+	res := c.ToggleOnAir("free-1")
+	if res.Err != nil || res.WentOff || res.AtLimit || res.LoginNeeded {
+		t.Fatalf("first toggle should go on air cleanly, got %+v", res)
+	}
+	if c.OnAirCount() != 1 {
+		t.Fatalf("on-air count = %d, want 1", c.OnAirCount())
+	}
+	if _, on := c.Headline(); !on {
+		t.Fatal("headline should report on air")
+	}
+	off := c.ToggleOnAir("free-1")
+	if !off.WentOff {
+		t.Fatalf("second toggle should go off air, got %+v", off)
+	}
+	if c.OnAirCount() != 0 {
+		t.Fatalf("on-air count after off = %d, want 0", c.OnAirCount())
+	}
+}
+
+func TestPricedShareLoginGated(t *testing.T) {
+	c := newCtrl(t, Config{})
+	if res := c.ToggleOnAir("paid"); !res.LoginNeeded {
+		t.Fatalf("priced share without login should be gated, got %+v", res)
+	}
+	if c.OnAirCount() != 0 {
+		t.Fatal("a gated priced share must not go on air")
+	}
+	c.SetLoggedIn(true)
+	res := c.ToggleOnAir("paid")
+	if res.Err != nil || res.LoginNeeded || !res.Priced || res.PriceOut != 2 {
+		t.Fatalf("logged-in priced share should start priced, got %+v", res)
+	}
+}
+
+func TestSoftMaxOnAirCap(t *testing.T) {
+	c := newCtrl(t, Config{MaxOnAir: 1})
+	if res := c.ToggleOnAir("free-1"); res.Err != nil {
+		t.Fatalf("first on air: %+v", res)
+	}
+	if res := c.ToggleOnAir("free-2"); !res.AtLimit {
+		t.Fatalf("second on air at cap 1 should be blocked, got %+v", res)
+	}
+	if c.OnAirCount() != 1 {
+		t.Fatalf("on-air count = %d, want 1 (cap held)", c.OnAirCount())
+	}
+}
+
+func TestDefaultMaxOnAir(t *testing.T) {
+	c := newCtrl(t, Config{})
+	if c.MaxOnAir() != DefaultMaxOnAir {
+		t.Fatalf("default cap = %d, want %d", c.MaxOnAir(), DefaultMaxOnAir)
+	}
+}
+
+func TestSnapshotRedactsUpstreamKey(t *testing.T) {
+	const secret = "sk-super-secret-key"
+	c := newCtrl(t, Config{Upstream: "http://127.0.0.1:1234/v1", UpstreamKey: secret})
+	snap := c.Snapshot()
+	if snap.Upstream == "" {
+		t.Fatal("snapshot should carry the (non-secret) upstream endpoint")
+	}
+	blob, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(blob), secret) {
+		t.Fatalf("snapshot JSON leaked the upstream key:\n%s", blob)
+	}
+	// The key is still reachable in-process (the agent needs it to authenticate).
+	if c.UpstreamKey() != secret {
+		t.Fatalf("UpstreamKey() = %q, want the live key", c.UpstreamKey())
+	}
+}
+
+func TestSetPricingPersists(t *testing.T) {
+	var got *Pricing
+	var gotModel string
+	c := newCtrl(t, Config{Hooks: Hooks{SavePrice: func(m string, p Pricing) { gotModel = m; cp := p; got = &cp }}})
+	c.SetPricing("free-1", Pricing{In: 1, Out: 3})
+	if got == nil || got.Out != 3 || gotModel != "free-1" {
+		t.Fatalf("SavePrice hook = (%q,%+v), want free-1 out 3", gotModel, got)
+	}
+	if p := c.PricingFor("free-1"); p.Out != 3 {
+		t.Fatalf("PricingFor = %+v, want out 3", p)
+	}
+}
+
+func TestRenamePersists(t *testing.T) {
+	var got string
+	c := newCtrl(t, Config{Hooks: Hooks{SaveStation: func(s string) { got = s }}})
+	c.Rename("violet-owl")
+	if got != "violet-owl" || c.Station() != "violet-owl" {
+		t.Fatalf("rename: hook=%q station=%q, want violet-owl", got, c.Station())
+	}
+}
+
+func TestLoadRowsFlattensAndPersistsUpstream(t *testing.T) {
+	var savedUp, savedKey string
+	c := New(Config{Station: "amber-fox", Hooks: Hooks{SaveUpstream: func(u, k string) { savedUp, savedKey = u, k }}})
+	c.LoadRows([]detect.Found{{
+		BaseURL: "http://127.0.0.1:8081/v1", Chat: "http://127.0.0.1:8081/v1/chat/completions",
+		Key: "sk-1", Models: []string{"a", "b", "a"}, // dup a -> de-duped
+	}})
+	if rows := c.Rows(); len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 (de-duped)", len(rows))
+	}
+	if savedUp != "http://127.0.0.1:8081/v1" || savedKey != "sk-1" {
+		t.Fatalf("SaveUpstream = (%q,%q), want the verified endpoint+key", savedUp, savedKey)
+	}
+	// Re-loading the same endpoint is a no-op (no rewrite).
+	savedUp = ""
+	c.LoadRows([]detect.Found{{BaseURL: "http://127.0.0.1:8081/v1", Chat: "http://127.0.0.1:8081/v1/chat/completions", Key: "sk-1", Models: []string{"a"}}})
+	if savedUp != "" {
+		t.Fatal("re-loading the already-saved endpoint should not rewrite config")
+	}
+}
+
+// TestConcurrentToggle exercises the lock: two front-ends (the TUI goroutine and the
+// web server) toggling the same node concurrently must never race. Run with -race.
+func TestConcurrentToggle(t *testing.T) {
+	c := newCtrl(t, Config{MaxOnAir: 10})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.ToggleOnAir("free-1")
+			c.Snapshot()
+			c.ToggleOnAir("free-2")
+			c.OnAirCount()
+		}()
+	}
+	wg.Wait()
+	c.StopAll()
+	if c.OnAirCount() != 0 {
+		t.Fatalf("after StopAll, on air = %d, want 0", c.OnAirCount())
+	}
+}

--- a/internal/node/snapshot.go
+++ b/internal/node/snapshot.go
@@ -1,0 +1,176 @@
+package node
+
+import "github.com/rogerai-fyi/roger/internal/agent"
+
+// Snapshot is a consistent, JSON-able read of the node's live state, taken under the
+// lock. The web console renders it (GET /api/state + the SSE stream) and the TUI uses
+// the same accessors to refresh its render cache. The upstream KEY is never included —
+// same defense-in-depth as agent.redactUpstreamKey — only the (non-secret) endpoint is.
+type Snapshot struct {
+	Station  string    `json:"station"`
+	OnAir    int       `json:"on_air"`
+	MaxOnAir int       `json:"max_on_air"`
+	LoggedIn bool      `json:"logged_in"`
+	Upstream string    `json:"upstream"`
+	Rows     []RowView `json:"rows"`
+	Totals   Totals    `json:"totals"`
+}
+
+// RowView is one model in the share table: its catalog facts plus live counters when
+// on air. Link is "off" | "connecting" | "on-air" | "reconnecting".
+type RowView struct {
+	Model        string  `json:"model"`
+	Ctx          int     `json:"ctx"`
+	CtxEstimated bool    `json:"ctx_estimated"`
+	OnAir        bool    `json:"on_air"`
+	Private      bool    `json:"private"`
+	Link         string  `json:"link"`
+	PriceIn      float64 `json:"price_in"`
+	PriceOut     float64 `json:"price_out"`
+	Scheduled    bool    `json:"scheduled"`
+	Served       int64   `json:"served"`
+	OutTokens    int64   `json:"out_tokens"`
+	Earnings     float64 `json:"earnings"`
+	Node         string  `json:"node,omitempty"`
+	BandDisplay  string  `json:"band_display,omitempty"`
+}
+
+// Totals sum every live band (the ON-AIR panel footer).
+type Totals struct {
+	Requests  int64   `json:"requests"`
+	OutTokens int64   `json:"out_tokens"`
+	Earnings  float64 `json:"earnings"`
+}
+
+func linkLabel(s agent.LinkState) string {
+	switch s {
+	case agent.LinkOnAir:
+		return "on-air"
+	case agent.LinkReconnecting:
+		return "reconnecting"
+	default:
+		return "connecting"
+	}
+}
+
+// Snapshot takes a consistent read of the whole node under the lock.
+func (c *Controller) Snapshot() Snapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	snap := Snapshot{
+		Station:  c.station,
+		OnAir:    c.onAirCountLocked(),
+		MaxOnAir: c.maxOnAirLocked(),
+		LoggedIn: c.loggedIn,
+		Upstream: c.upstream,
+		Rows:     make([]RowView, 0, len(c.rows)),
+	}
+	for _, r := range c.rows {
+		p := c.pricingForLocked(r.Model)
+		rv := RowView{
+			Model:        r.Model,
+			Ctx:          r.Ctx,
+			CtxEstimated: r.CtxEstimated,
+			Private:      c.private[r.Model],
+			Link:         "off",
+			PriceIn:      p.In,
+			PriceOut:     p.Out,
+			Scheduled:    len(p.Windows) > 0,
+		}
+		if sess := c.sessions[r.Model]; sess != nil {
+			rv.OnAir = true
+			rv.Link = linkLabel(sess.Link())
+			in, out := sess.Price()
+			rv.PriceIn, rv.PriceOut = in, out
+			reqs, toks := sess.Served()
+			rv.Served, rv.OutTokens = reqs, toks
+			rv.Earnings = sess.Earnings()
+			rv.Node = sess.Node()
+			_, _, rv.BandDisplay = sess.Band()
+			snap.Totals.Requests += reqs
+			snap.Totals.OutTokens += toks
+			snap.Totals.Earnings += sess.Earnings()
+		}
+		snap.Rows = append(snap.Rows, rv)
+	}
+	return snap
+}
+
+// --- accessors the TUI uses to refresh its single-goroutine render cache ---
+
+// Rows returns a copy of the detected-model catalog.
+func (c *Controller) Rows() []ShareRow {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]ShareRow, len(c.rows))
+	copy(out, c.rows)
+	return out
+}
+
+// Sessions returns a copy of the live on-air session registry (map copy; the *Session
+// values are shared pointers, which is intended — they're the live counters).
+func (c *Controller) Sessions() map[string]*agent.Session {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]*agent.Session, len(c.sessions))
+	for k, v := range c.sessions {
+		out[k] = v
+	}
+	return out
+}
+
+// Private returns a copy of the per-model private-band flags.
+func (c *Controller) Private() map[string]bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]bool, len(c.private))
+	for k, v := range c.private {
+		out[k] = v
+	}
+	return out
+}
+
+// Prices returns a copy of the per-model saved pricing.
+func (c *Controller) Prices() map[string]Pricing {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]Pricing, len(c.prices))
+	for k, v := range c.prices {
+		out[k] = v
+	}
+	return out
+}
+
+// Station returns the current callsign.
+func (c *Controller) Station() string { c.mu.Lock(); defer c.mu.Unlock(); return c.station }
+
+// Upstream returns the headline upstream chat URL (never the key).
+func (c *Controller) Upstream() string { c.mu.Lock(); defer c.mu.Unlock(); return c.upstream }
+
+// UpstreamKey returns the headline upstream bearer key. In-process only — never
+// serialized into a Snapshot or sent to a client.
+func (c *Controller) UpstreamKey() string { c.mu.Lock(); defer c.mu.Unlock(); return c.upstreamKey }
+
+// SavedUpstream returns the last endpoint+key persisted via Hooks.SaveUpstream (the
+// TUI's change-detection state).
+func (c *Controller) SavedUpstream() (up, key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.savedUp, c.savedKey
+}
+
+// Headline returns any live session (for the header badge + ON-AIR panel) and whether
+// the node is on air at all.
+func (c *Controller) Headline() (*agent.Session, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, s := range c.sessions {
+		if s != nil {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+// OnAirCount is how many models are currently on air.
+func (c *Controller) OnAirCount() int { c.mu.Lock(); defer c.mu.Unlock(); return c.onAirCountLocked() }

--- a/internal/tui/arrow_nav_test.go
+++ b/internal/tui/arrow_nav_test.go
@@ -103,7 +103,7 @@ func TestArrowCycleWraps(t *testing.T) {
 func TestArrowDoesNotCycleInScheduleEditor(t *testing.T) {
 	mm := New("http://broker.local", "tester")
 	mm.width, mm.height = 100, 30
-	mm.shareRows = []shareRow{{model: "gpt-oss-20b"}}
+	mm.setShareRows([]shareRow{{model: "gpt-oss-20b"}})
 	mm.shareCursor = 0
 	mm.mode = modeShare
 	var m tea.Model = mm

--- a/internal/tui/compact_test.go
+++ b/internal/tui/compact_test.go
@@ -52,7 +52,7 @@ func TestCompactToggleInShareAndLimits(t *testing.T) {
 	// SHARE table.
 	m := browseSeed(100)
 	m.mode = modeShare
-	m.shareRows = []shareRow{{model: "gpt-oss-20b", ctx: 32768}}
+	m.setShareRows([]shareRow{{model: "gpt-oss-20b", ctx: 32768}})
 	var tm tea.Model = m
 	tm, _ = tm.Update(keyMsg("m"))
 	if !asModel(tm).compact {
@@ -180,7 +180,7 @@ func seedFor(w int, md mode, compact bool) model {
 	m.mode = md
 	switch md {
 	case modeShare:
-		m.shareRows = []shareRow{{model: "gpt-oss-20b", ctx: 32768}, {model: "qwen3-coder-30b", ctx: 65536}}
+		m.setShareRows([]shareRow{{model: "gpt-oss-20b", ctx: 32768}, {model: "qwen3-coder-30b", ctx: 65536}})
 	case modeLimits:
 		m.editField = -1
 		m.limModels = []string{"gpt-oss-20b"}

--- a/internal/tui/liveliness_test.go
+++ b/internal/tui/liveliness_test.go
@@ -85,10 +85,10 @@ func TestToggleShareUsesRowUpstream(t *testing.T) {
 
 	mm := New(broker.URL, "tester")
 	mm.shareUp = "http://127.0.0.1:8060/v1/chat/completions" // headline default
-	mm.shareRows = []shareRow{
+	mm.setShareRows([]shareRow{
 		{model: "gpt-oss-20b", ctx: 32768, upstream: "http://127.0.0.1:8060/v1/chat/completions"},
 		{model: "qwen3-vl-8b", ctx: 32768, upstream: "http://127.0.0.1:8081/v1/chat/completions"},
-	}
+	})
 	mm.shareCursor = 1 // the qwen3-vl-8b row, served by :8081 (NOT shareUp)
 	mm.toggleShareAt(1)
 	sess := mm.shares["qwen3-vl-8b"]

--- a/internal/tui/onair_limit_test.go
+++ b/internal/tui/onair_limit_test.go
@@ -56,7 +56,7 @@ func TestShareSlotHeaderAndBlock(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	srv := fakeBroker(t)
 	mm := NewWithHooks(srv.URL, "tester", nil, Hooks{ShareMaxOnAir: 2})
-	mm.shareRows = freeRows(3) // m1,m2,m3 on distinct upstreams
+	mm.setShareRows(freeRows(3)) // m1,m2,m3 on distinct upstreams
 
 	// Fill the 2 slots: m1 and m2 on air.
 	mm.toggleShareAt(0)
@@ -111,7 +111,7 @@ func TestShareSlotHeaderAndBlock(t *testing.T) {
 func TestShareSlotHeaderNarrowSafe(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	mm := NewWithHooks("http://broker.local", "tester", nil, Hooks{ShareMaxOnAir: 4})
-	mm.shareRows = freeRows(2)
+	mm.setShareRows(freeRows(2))
 	for _, w := range []int{40, 60, 88, 120} {
 		v := mm.shareView(w)
 		if strings.Contains(v, "\x1b[") {

--- a/internal/tui/onair_panel_test.go
+++ b/internal/tui/onair_panel_test.go
@@ -26,7 +26,6 @@ func okBroker(t *testing.T) *httptest.Server {
 // out price so the panel renders the priced (not FREE) form for it.
 func startShares(t *testing.T, mm *model, broker string, n int) {
 	t.Helper()
-	mm.shares = map[string]*agent.Session{}
 	for i := 0; i < n; i++ {
 		model := fmt.Sprintf("model-%02d", i)
 		sess, err := agent.Start(agent.Config{
@@ -38,9 +37,9 @@ func startShares(t *testing.T, mm *model, broker string, n int) {
 			t.Fatalf("agent.Start %s: %v", model, err)
 		}
 		t.Cleanup(sess.Stop)
-		mm.shares[model] = sess
+		mm.ctrl.Adopt(model, sess)
 	}
-	mm.refreshShareHeadline()
+	mm.syncShareCache()
 }
 
 // TestOnAirPanelListsAllBands: the on-air panel renders ONE row per live band plus a

--- a/internal/tui/payout_hint_test.go
+++ b/internal/tui/payout_hint_test.go
@@ -14,7 +14,7 @@ func shareModelWithPayout(w int, snap payoutSnapshot) model {
 	mm.width, mm.height = w, 30
 	mm.mode = modeShare
 	mm.ghLogin = "octocat" // logged in -> loggedInState() true
-	mm.shareRows = []shareRow{{model: "gpt-oss-20b", ctx: 32768}}
+	mm.setShareRows([]shareRow{{model: "gpt-oss-20b", ctx: 32768}})
 	mm.payout = snap
 	return mm
 }

--- a/internal/tui/share_test.go
+++ b/internal/tui/share_test.go
@@ -17,10 +17,10 @@ func TestShareViewNarrowSafe(t *testing.T) {
 		mm := New("http://broker.local", "tester")
 		mm.width, mm.height = w, 30
 		mm.mode = modeShare
-		mm.shareRows = []shareRow{
+		mm.setShareRows([]shareRow{
 			{model: "gpt-oss-20b", ctx: 32768},
 			{model: "qwen3-coder-30b-a3b-instruct", ctx: 32768},
-		}
+		})
 		var m tea.Model = mm
 		m, _ = m.Update(balanceMsg{balance: 5, loggedIn: true})
 		m, _ = m.Update(tickMsg{})
@@ -91,10 +91,10 @@ func TestShareViewK9s(t *testing.T) {
 	mm := New("http://broker.local", "tester")
 	mm.width, mm.height = 100, 30
 	mm.mode = modeShare
-	mm.shareRows = []shareRow{
+	mm.setShareRows([]shareRow{
 		{model: "gpt-oss-20b", ctx: 32768},
 		{model: "llama-3.3-70b", ctx: 32768},
-	}
+	})
 	mm.shareCursor = 1
 	var m tea.Model = mm
 	v := m.View()
@@ -191,7 +191,7 @@ func TestSharePriceEditorLoginGate(t *testing.T) {
 	mm := New("http://broker.local", "tester")
 	mm.width, mm.height = 100, 30
 	mm.mode = modeShare
-	mm.shareRows = []shareRow{{model: "gpt-oss-20b", ctx: 32768}}
+	mm.setShareRows([]shareRow{{model: "gpt-oss-20b", ctx: 32768}})
 	var m tea.Model = mm
 	m, _ = m.Update(balanceMsg{loggedIn: false})
 	pm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
@@ -211,7 +211,7 @@ func TestSharePriceEditorLoginGate(t *testing.T) {
 	lm := NewWithHooks("http://broker.local", "tester", nil, hooks)
 	lm.width, lm.height = 100, 30
 	lm.mode = modeShare
-	lm.shareRows = []shareRow{{model: "gpt-oss-20b", ctx: 32768}}
+	lm.setShareRows([]shareRow{{model: "gpt-oss-20b", ctx: 32768}})
 	var l tea.Model = lm
 	l, _ = l.Update(balanceMsg{balance: 5, loggedIn: true})
 	l, _ = l.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
@@ -246,7 +246,7 @@ func TestShareScheduleWindow(t *testing.T) {
 	lm := NewWithHooks("http://broker.local", "tester", nil, hooks)
 	lm.width, lm.height = 100, 30
 	lm.mode = modeShare
-	lm.shareRows = []shareRow{{model: "m", ctx: 8192}}
+	lm.setShareRows([]shareRow{{model: "m", ctx: 8192}})
 	var l tea.Model = lm
 	l, _ = l.Update(balanceMsg{balance: 5, loggedIn: true})
 	l, _ = l.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}}) // open editor
@@ -321,7 +321,7 @@ func TestAllModesRenderSafe(t *testing.T) {
 			// Seed the bits each mode needs so it renders its real body, not an empty case.
 			mm.connected = &offer{NodeID: "nyx", Model: "gpt-oss-20b", PriceOut: 0.3, Online: true}
 			mm.q = quote{b: band{model: "gpt-oss-20b", online: true, stations: 1, cheapest: mm.connected}, typical: 800}
-			mm.shareRows = []shareRow{{model: "gpt-oss-20b", ctx: 32768}}
+			mm.setShareRows([]shareRow{{model: "gpt-oss-20b", ctx: 32768}})
 			mm.limModels = []string{"gpt-oss-20b"}
 			mm.edModel = "gpt-oss-20b"
 			mm.edWindows = []SchedWindow{{Start: "18:00", End: "22:00"}}
@@ -381,7 +381,7 @@ func TestScheduleWindowEditEndAndPrice(t *testing.T) {
 	lm := NewWithHooks("http://broker.local", "tester", nil, hooks)
 	lm.width, lm.height = 100, 30
 	lm.mode = modeShare
-	lm.shareRows = []shareRow{{model: "m", ctx: 8192}}
+	lm.setShareRows([]shareRow{{model: "m", ctx: 8192}})
 	var l tea.Model = lm
 	l, _ = l.Update(balanceMsg{balance: 5, loggedIn: true})
 
@@ -455,7 +455,7 @@ func TestNoColorNonTTYRender(t *testing.T) {
 			mm.mode = md
 			mm.connected = &offer{NodeID: "nyx", Model: "m", PriceOut: 0.3, Online: true}
 			mm.q = quote{b: band{model: "m", online: true, stations: 1, cheapest: mm.connected}, typical: 800}
-			mm.shareRows = []shareRow{{model: "m", ctx: 32768}}
+			mm.setShareRows([]shareRow{{model: "m", ctx: 32768}})
 			mm.limModels = []string{"m"}
 			mm.edModel = "m"
 			mm.edWindows = []SchedWindow{{Start: "18:00", End: "22:00", In: 0.1, Out: 0.2}}
@@ -653,8 +653,7 @@ func TestShareEditorValidationBlocksBadInput(t *testing.T) {
 	// Malformed HH:MM window time ("25:99" never matches at runtime).
 	t.Run("bad-hhmm", func(t *testing.T) {
 		var saved *Pricing
-		m := New("http://broker.local", "tester")
-		m.hooks = Hooks{SavePrice: func(_ string, p Pricing) { c := p; saved = &c }}
+		m := NewWithHooks("http://broker.local", "tester", nil, Hooks{SavePrice: func(_ string, p Pricing) { c := p; saved = &c }})
 		m.edModel = "m"
 		m.edPriceOut = "1"
 		m.edWindows = []SchedWindow{{Start: "25:99", End: "03:30"}}
@@ -698,8 +697,7 @@ func TestShareEditorValidationBlocksBadInput(t *testing.T) {
 	// A clean price + valid window saves and clears the error.
 	t.Run("clean-saves", func(t *testing.T) {
 		var saved *Pricing
-		m := New("http://broker.local", "tester")
-		m.hooks = Hooks{SavePrice: func(_ string, p Pricing) { c := p; saved = &c }}
+		m := NewWithHooks("http://broker.local", "tester", nil, Hooks{SavePrice: func(_ string, p Pricing) { c := p; saved = &c }})
 		m.edModel = "m"
 		m.edPriceOut = "0.7"
 		m.edWindows = []SchedWindow{{Start: "03:00", End: "03:30", Free: true}}

--- a/internal/tui/smoke_test.go
+++ b/internal/tui/smoke_test.go
@@ -409,7 +409,8 @@ func TestOnAirQuitGuard(t *testing.T) {
 		t.Fatalf("agent.Start: %v", err)
 	}
 	defer sess.Stop()
-	mm.shares = map[string]*agent.Session{"m": sess}
+	mm.ctrl.Adopt("m", sess)
+	mm.syncShareCache()
 	mm.refreshShareHeadline()
 	if mm.onAirCount() != 1 {
 		t.Fatalf("onAirCount = %d, want 1", mm.onAirCount())

--- a/internal/tui/station_rename_test.go
+++ b/internal/tui/station_rename_test.go
@@ -36,7 +36,7 @@ func TestStationRenamePersistsAndDisplays(t *testing.T) {
 	})
 	mm.width, mm.height = 100, 30
 	mm.mode = modeShare
-	mm.shareRows = []shareRow{{model: "gpt-oss-20b", ctx: 32768}}
+	mm.setShareRows([]shareRow{{model: "gpt-oss-20b", ctx: 32768}})
 	var m tea.Model = mm
 
 	// Enter rename mode - the buffer seeds with the current callsign so the owner can
@@ -87,7 +87,7 @@ func TestStationRenameCancel(t *testing.T) {
 		SaveStation: func(s string) { saved = s },
 	})
 	mm.mode = modeShare
-	mm.shareRows = []shareRow{{model: "gpt-oss-20b", ctx: 32768}}
+	mm.setShareRows([]shareRow{{model: "gpt-oss-20b", ctx: 32768}})
 	var m tea.Model = mm
 	m, _ = m.Update(keyRunes("n"))
 	m, _ = m.Update(keyRunes("zzz"))
@@ -106,7 +106,7 @@ func TestStationRenameCancel(t *testing.T) {
 func TestStationRenameBlankKeepsCurrent(t *testing.T) {
 	mm := NewWithHooks("http://broker.local", "tester", nil, Hooks{Station: "brave-otter"})
 	mm.mode = modeShare
-	mm.shareRows = []shareRow{{model: "gpt-oss-20b", ctx: 32768}}
+	mm.setShareRows([]shareRow{{model: "gpt-oss-20b", ctx: 32768}})
 	var m tea.Model = mm
 	m, _ = m.Update(keyRunes("n"))
 	m, _ = m.Update(keyRunes("   "))

--- a/internal/tui/truthful_status_test.go
+++ b/internal/tui/truthful_status_test.go
@@ -39,7 +39,8 @@ func TestProviderStatusTruthfulOnAir(t *testing.T) {
 		t.Fatalf("agent.Start: %v", err)
 	}
 	defer sess.Stop()
-	mm.shares = map[string]*agent.Session{"m": sess}
+	mm.ctrl.Adopt("m", sess)
+	mm.syncShareCache()
 	mm.refreshShareHeadline()
 	waitBadge(t, &mm, "ON AIR")
 }
@@ -66,7 +67,8 @@ func TestProviderStatusTruthfulReconnecting(t *testing.T) {
 		t.Fatalf("agent.Start: %v", err)
 	}
 	defer sess.Stop()
-	mm.shares = map[string]*agent.Session{"m": sess}
+	mm.ctrl.Adopt("m", sess)
+	mm.syncShareCache()
 	mm.refreshShareHeadline()
 
 	waitBadge(t, &mm, "RECONNECTING")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -32,6 +32,7 @@ import (
 	"github.com/rogerai-fyi/roger/internal/client"
 	"github.com/rogerai-fyi/roger/internal/detect"
 	"github.com/rogerai-fyi/roger/internal/glyphs"
+	"github.com/rogerai-fyi/roger/internal/node"
 	"github.com/rogerai-fyi/roger/internal/protocol"
 )
 
@@ -626,8 +627,14 @@ type model struct {
 	// model, each independently flippable on/off air. shares holds the live session
 	// per on-air model; shareRows is the rendered model list; shareCursor is the
 	// highly-visible reverse-video selection cursor.
-	shares      map[string]*agent.Session // model -> live in-process session (on air)
-	shareRows   []shareRow                // the provider table rows (detected models)
+	// ctrl is the SINGLE, mutex-guarded owner of the live share state (sessions, rows,
+	// prices, private flags, station, upstream). The web console (internal/webui) holds
+	// the SAME *node.Controller, so a toggle in the browser flips a TUI row and vice-versa.
+	// The fields below (shares/shareRows/...) are a TUI-goroutine-private render CACHE,
+	// refreshed from the controller by syncShareCache(); every mutation goes through ctrl.
+	ctrl        *node.Controller
+	shares      map[string]*agent.Session // model -> live in-process session (on air) [cache]
+	shareRows   []shareRow                // the provider table rows (detected models) [cache]
 	shareCursor int                       // selected row in the provider table
 	shareUp     string                    // the local upstream chat URL backing the shares
 	shareKey    string                    // bearer key the headline upstream needs (env/paste), if any
@@ -730,19 +737,15 @@ const (
 
 // SchedWindow is the TUI's editable view of a time-of-use price window (mirrors
 // protocol.PriceWindow). Times are "HH:MM" UTC; Free zeroes the price in-window.
-type SchedWindow struct {
-	Start, End string
-	In, Out    float64
-	Free       bool
-}
+// SchedWindow and Pricing are aliases for the canonical types in internal/node, so
+// the controller, the TUI editor, and the host config all speak one type. (Aliases,
+// not new types, so existing Pricing{...}/SchedWindow{...} literals keep compiling.)
+type SchedWindow = node.SchedWindow
 
 // Pricing is the per-model saved price + schedule the editor produces. The host
-// persists it (and feeds it back as Hooks.SavedPricing); on-air it is applied
-// when a model goes live.
-type Pricing struct {
-	In, Out float64
-	Windows []SchedWindow
-}
+// persists it (and feeds it back as Hooks.SavedPrices); on-air it is applied when a
+// model goes live.
+type Pricing = node.Pricing
 
 // shareRow is one model in the k9s-style provider table: a locally-detected model
 // plus its share status. Live metrics are read off the session when on air. Each
@@ -836,27 +839,30 @@ func NewWithHooks(broker, user string, limits *LimitStore, hooks Hooks) model {
 	// Seed the live broadcast station from the host (the saved/auto-generated callsign),
 	// slugged so it matches the node id exactly. Falls back to a fresh callsign if the
 	// host supplied none, so the TUI never derives a hostname-based id.
-	m.station = agent.SlugStation(hooks.Station)
-	if m.station == "" {
-		m.station = agent.GenerateStation()
+	station := agent.SlugStation(hooks.Station)
+	if station == "" {
+		station = agent.GenerateStation()
 	}
-	// Seed the saved/verified upstream (and any key it needs) so the first /share scan
-	// probes that endpoint first and reuses a saved keyed upstream without re-prompting
-	// (detectSharesCmd carries the key). normalizeUpstream accepts the saved /v1 base.
-	m.shareUp = normalizeUpstream(hooks.ShareUpstream)
-	m.shareKey = hooks.ShareUpstreamKey
-	// What is already on disk, so a re-detection landing the same endpoint is a no-op
-	// (only a NEW upstream/key triggers a SaveUpstream write).
-	m.shareSavedUp, m.shareSavedKey = hooks.ShareUpstream, hooks.ShareUpstreamKey
+	// Build the SINGLE shared controller that owns the live share state. The web console
+	// (when on) holds this same pointer, so both front-ends drive one node. The model's
+	// share fields below are a render cache refreshed from it by syncShareCache().
+	m.ctrl = node.New(node.Config{
+		Broker: broker, HW: hooks.HW, Station: station,
+		ShareModel: hooks.ShareModel, SharePriceI: hooks.SharePriceI, SharePriceO: hooks.SharePriceO,
+		MaxOnAir:    hooks.ShareMaxOnAir,
+		Upstream:    hooks.ShareUpstream,
+		UpstreamKey: hooks.ShareUpstreamKey,
+		Prices:      hooks.SavedPrices,
+		Hooks: node.Hooks{
+			SaveUpstream: hooks.SaveUpstream,
+			SavePrice:    hooks.SavePrice,
+			SaveStation:  hooks.SaveStation,
+		},
+	})
+	m.ctrl.SetLoggedIn(m.loggedInState())
 	// Seed the windowshade compact mode from the saved config so the [m] choice sticks.
 	m.compact = hooks.Compact
-	// Seed per-model pricing the user set in a previous session.
-	if len(hooks.SavedPrices) > 0 {
-		m.prices = map[string]Pricing{}
-		for mdl, p := range hooks.SavedPrices {
-			m.prices[mdl] = p
-		}
-	}
+	m.syncShareCache() // populate the render cache (station, prices, upstream) from the controller
 	return m
 }
 
@@ -890,6 +896,11 @@ func (m model) Init() tea.Cmd {
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Refresh the share render cache from the shared controller FIRST, so anything the web
+	// console changed (a model toggled on air, a price edited, a rename) shows up in the
+	// terminal on the next message — most visibly the 160ms tick. Every TUI mutation also
+	// re-syncs locally, so this never fights an in-flight keystroke.
+	m.syncShareCache()
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
@@ -1772,48 +1783,49 @@ func (m model) onSharesDetected(found []detect.Found, needKey []string) (tea.Mod
 // server's chat URL is kept as m.shareUp for back-compat (the headline default),
 // but on-air uses each row's own upstream so a model goes live against the server
 // that actually serves it. The first server's models keep priority on a dup id.
+// loadShareRows hands a detection result to the shared controller (which flattens every
+// server × model into the de-duplicated catalog, adopts the headline upstream + key, and
+// persists a newly-verified endpoint) and refreshes the render cache.
 func (m *model) loadShareRows(found []detect.Found) {
-	if m.shares == nil {
-		m.shares = map[string]*agent.Session{}
+	m.ctrl.LoadRows(found)
+	m.syncShareCache()
+}
+
+// setShareRows seeds the catalog directly from already-known rows (the paste-verify path
+// and unit tests), going through the controller so the web console sees the same rows.
+func (m *model) setShareRows(rows []shareRow) {
+	nr := make([]node.ShareRow, len(rows))
+	for i, r := range rows {
+		nr[i] = node.ShareRow{Model: r.model, Ctx: r.ctx, CtxEstimated: r.ctxEstimated, Upstream: r.upstream, UpstreamKey: r.upstreamKey}
 	}
-	if len(found) > 0 {
-		m.shareUp = normalizeUpstream(found[0].Chat)
-		m.shareKey = found[0].Key
-		// Persist a newly verified endpoint + key so a custom / key-protected upstream is
-		// reused next launch (mirrors the CLI's save in `roger share`). Only on a real
-		// change, so re-scanning the already-saved endpoint doesn't rewrite config.
-		if m.hooks.SaveUpstream != nil && found[0].BaseURL != "" &&
-			(found[0].BaseURL != m.shareSavedUp || found[0].Key != m.shareSavedKey) {
-			m.shareSavedUp, m.shareSavedKey = found[0].BaseURL, found[0].Key
-			m.hooks.SaveUpstream(found[0].BaseURL, found[0].Key)
-		}
+	m.ctrl.SetRows(nr)
+	m.syncShareCache()
+}
+
+// syncShareCache refreshes the TUI's single-goroutine render cache (shares/shareRows/
+// sharePrivate/station/prices/shareUp/shareKey/share/onAir) from the shared controller,
+// so a change made in the web console appears in the terminal on the next tick. Every
+// share mutation the TUI makes goes THROUGH the controller, then calls this to re-read.
+func (m *model) syncShareCache() {
+	if m.ctrl == nil {
+		return
 	}
-	seen := map[string]bool{}
-	rows := make([]shareRow, 0)
-	for _, srv := range found {
-		up := normalizeUpstream(srv.Chat)
-		for _, mdl := range srv.Models {
-			if mdl == "" || seen[mdl] {
-				continue
-			}
-			seen[mdl] = true
-			// ONE ctx resolver shared with the CLI (detect.ResolveCtx): the real detected
-			// window when the upstream reported it, else the estimated default (flagged) -
-			// so the TUI and CLI agree and the duplicated 32768 literal is gone.
-			ctxLen, ctxEst := detect.ResolveCtx(srv.Ctx, mdl)
-			// Carry the upstream's working key (discovered from env, or pasted in the
-			// guided fallback) so this row goes ON AIR with the same Bearer the detector
-			// authenticated with - a key-protected local server is otherwise served jobs
-			// it 401s.
-			rows = append(rows, shareRow{model: mdl, ctx: ctxLen, ctxEstimated: ctxEst, upstream: up, upstreamKey: srv.Key})
-		}
-	}
-	// Put the saved onboarding model first so the obvious default is at the cursor.
-	if def := m.hooks.ShareModel; def != "" {
-		sort.SliceStable(rows, func(i, j int) bool { return rows[i].model == def && rows[j].model != def })
+	m.ctrl.SetLoggedIn(m.loggedInState())
+	nr := m.ctrl.Rows()
+	rows := make([]shareRow, len(nr))
+	for i, r := range nr {
+		rows[i] = shareRow{model: r.Model, ctx: r.Ctx, ctxEstimated: r.CtxEstimated, upstream: r.Upstream, upstreamKey: r.UpstreamKey}
 	}
 	m.shareRows = rows
-	if m.shareCursor >= len(rows) {
+	m.shares = m.ctrl.Sessions()
+	m.sharePrivate = m.ctrl.Private()
+	m.prices = m.ctrl.Prices()
+	m.station = m.ctrl.Station()
+	m.shareUp = m.ctrl.Upstream()
+	m.shareKey = m.ctrl.UpstreamKey()
+	m.shareSavedUp, m.shareSavedKey = m.ctrl.SavedUpstream()
+	m.share, m.onAir = m.ctrl.Headline()
+	if m.shareCursor >= len(m.shareRows) {
 		m.shareCursor = 0
 	}
 }
@@ -1827,75 +1839,28 @@ func (m *model) toggleShareAt(i int) {
 	if i < 0 || i >= len(m.shareRows) {
 		return
 	}
-	if m.shares == nil {
-		m.shares = map[string]*agent.Session{}
-	}
-	row := m.shareRows[i]
-	if sess, ok := m.shares[row.model]; ok && sess != nil {
-		sess.Stop()
-		delete(m.shares, row.model)
-		m.refreshShareHeadline()
-		m.status = stDim.Render("off air - stopped sharing ") + stKey.Render(row.model)
-		return
-	}
-	// SOFT local on-air cap (share.max_on_air): block putting ANOTHER band on air once
-	// the slots are full. The user frees a slot by taking one off air (or raises the knob
-	// + restarts). This is local UX to stop over-subscribing the host - the broker's
-	// per-owner cap is the hard backstop. (Toggling an already-on-air row OFF is handled
-	// above, so this only gates a NEW on-air row.)
-	if m.atOnAirLimit() {
+	model := m.shareRows[i].model
+	res := m.ctrl.ToggleOnAir(model)
+	m.syncShareCache()
+	switch {
+	case res.WentOff:
+		m.status = stDim.Render("off air - stopped sharing ") + stKey.Render(model)
+	case res.AtLimit:
+		// SOFT local on-air cap (share.max_on_air): take one off air to free a slot.
 		m.status = m.onAirLimitMsg()
-		return
-	}
-	// Free by default (visible + changeable in the editor). The price + time-of-use
-	// schedule come from pricingFor (an edited price, the saved onboarding price for
-	// the default model, else free).
-	p := m.pricingFor(row.model)
-	priceIn, priceOut := p.In, p.Out
-	// Share-to-EARN needs an account: a priced share requires `roger login` (the
-	// broker 403s a priced node from an unlinked owner). Flash a clear login prompt
-	// instead of a failed start; free sharing stays open to anyone, no login.
-	if (priceIn > 0 || priceOut > 0 || len(p.Windows) > 0) && !m.loggedInState() {
+	case res.LoginNeeded:
+		// Share-to-EARN needs an account (the broker 403s a priced node from an unlinked
+		// owner). Free sharing stays open to anyone, no login.
 		m.status = stEmber.Render("log in to earn - run ") + stKey.Render("/login") + stDim.Render(" (free sharing works without an account)")
-		return
+	case res.Err != nil:
+		m.status = stEmber.Render("! could not put " + model + " on air: " + res.Err.Error())
+	default:
+		kind := "FREE"
+		if res.Priced {
+			kind = dollars(res.PriceOut) + "/1M out"
+		}
+		m.status = stRed.Render(glyphOnAir+" ON AIR ") + stDim.Render("- sharing ") + stKey.Render(model) + stDim.Render(" ("+kind+")")
 	}
-	// Each row goes on air against the server that actually serves it (its own
-	// upstream), falling back to the headline shareUp for a row that predates the
-	// per-row upstream (e.g. a legacy/synthetic row).
-	up := row.upstream
-	if up == "" {
-		up = m.shareUp
-	}
-	upKey := row.upstreamKey
-	// Only fall back to the headline key when this row's upstream IS the headline upstream.
-	// A keyless row on a DIFFERENT detected server must NOT receive the saved/headline
-	// bearer (that would spray a stale key onto the wrong endpoint).
-	if upKey == "" && normalizeUpstream(up) == normalizeUpstream(m.shareUp) {
-		upKey = m.shareKey
-	}
-	// Unique, STABLE, PRIVACY-PRESERVING node id per band: <station>-<model>, derived
-	// through the SAME helper the CLI `roger share` uses. The station is the friendly
-	// callsign (never the hostname); the per-model slug keeps each band a DISTINCT broker
-	// node (no collision -> no token war / re-register storm). instance 0: one row per
-	// model (the shares map is keyed by model), so no same-model disambiguation is needed.
-	node := agent.ShareNodeID(m.station, row.model, 0)
-	sess, err := agent.Start(agent.Config{
-		Broker: m.broker, Upstream: up, UpstreamKey: upKey, NodeID: node,
-		Region: "home", HW: m.hooks.HW, Model: row.model,
-		PriceIn: priceIn, PriceOut: priceOut, Ctx: row.ctx, CtxEstimated: row.ctxEstimated, Parallel: 4,
-		Schedule: schedToProtocol(p.Windows),
-	})
-	if err != nil {
-		m.status = stEmber.Render("! could not put " + row.model + " on air: " + err.Error())
-		return
-	}
-	m.shares[row.model] = sess
-	m.refreshShareHeadline()
-	kind := "FREE"
-	if priceIn > 0 || priceOut > 0 {
-		kind = dollars(priceOut) + "/1M out"
-	}
-	m.status = stRed.Render(glyphOnAir+" ON AIR ") + stDim.Render("- sharing ") + stKey.Render(row.model) + stDim.Render(" ("+kind+")")
 }
 
 // togglePrivateAt flips the PRIVATE-band state of the row at index i. Going private is
@@ -1908,79 +1873,30 @@ func (m *model) togglePrivateAt(i int) {
 	if i < 0 || i >= len(m.shareRows) {
 		return
 	}
-	if !m.loggedInState() {
+	model := m.shareRows[i].model
+	res := m.ctrl.TogglePrivate(model)
+	m.syncShareCache()
+	switch {
+	case res.LoginNeeded:
 		// Login-gated: flash the existing /login line (same copy as the price editor).
 		m.status = stEmber.Render("log in to go private - run ") + stKey.Render("/login") + stDim.Render("  (a private band needs an account)")
-		return
-	}
-	if m.shares == nil {
-		m.shares = map[string]*agent.Session{}
-	}
-	if m.sharePrivate == nil {
-		m.sharePrivate = map[string]bool{}
-	}
-	row := m.shareRows[i]
-	goPrivate := !m.sharePrivate[row.model] // toggling: if currently public -> private
-	wasOn := m.shares[row.model] != nil
-	// SOFT on-air cap: pressing `h` on an OFF-air row puts it on air (on a hidden band),
-	// so the same share.max_on_air guard applies. Re-pinning an already-on-air row's
-	// visibility does not add a slot (it restarts the same band), so only a NEW on-air row
-	// is gated. Checked BEFORE we stop/restart so we never tear down a live band just to
-	// bounce off the cap.
-	if !wasOn && m.atOnAirLimit() {
+	case res.AtLimit:
 		m.status = m.onAirLimitMsg()
-		return
-	}
-	// Stop any current session for this row so we can restart it with the new visibility.
-	if sess, ok := m.shares[row.model]; ok && sess != nil {
-		sess.Stop()
-		delete(m.shares, row.model)
-	}
-	p := m.pricingFor(row.model)
-	up := row.upstream
-	if up == "" {
-		up = m.shareUp
-	}
-	upKey := row.upstreamKey
-	// Only fall back to the headline key when this row's upstream IS the headline upstream.
-	// A keyless row on a DIFFERENT detected server must NOT receive the saved/headline
-	// bearer (that would spray a stale key onto the wrong endpoint).
-	if upKey == "" && normalizeUpstream(up) == normalizeUpstream(m.shareUp) {
-		upKey = m.shareKey
-	}
-	// Same unique/stable/privacy-preserving node id as the public-share path (private
-	// just flips visibility): <station>-<model> via the shared helper, so a private band
-	// also gets its own broker node and carries the friendly station, not the hostname.
-	node := agent.ShareNodeID(m.station, row.model, 0)
-	sess, err := agent.Start(agent.Config{
-		Broker: m.broker, Upstream: up, UpstreamKey: upKey, NodeID: node,
-		Region: "home", HW: m.hooks.HW, Model: row.model,
-		PriceIn: p.In, PriceOut: p.Out, Ctx: row.ctx, CtxEstimated: row.ctxEstimated, Parallel: 4,
-		Private: goPrivate, Schedule: schedToProtocol(p.Windows),
-	})
-	if err != nil {
-		m.status = stEmber.Render("! could not change " + row.model + " visibility: " + err.Error())
-		return
-	}
-	m.shares[row.model] = sess
-	m.sharePrivate[row.model] = goPrivate
-	m.refreshShareHeadline()
-	if !goPrivate {
-		m.status = stDim.Render("back on the OPEN MARKET - ") + stKey.Render(row.model) + stDim.Render(" is public again")
-		return
-	}
-	// Private: surface the one-time frequency code on a card (only when freshly minted;
-	// a re-register returns no code, only the cosmetic display).
-	_, code, display := sess.Band()
-	if code != "" {
-		m.bandCardCode, m.bandCardDisp, m.bandCardModel = code, display, row.model
+	case res.Err != nil:
+		m.status = stEmber.Render("! could not change " + model + " visibility: " + res.Err.Error())
+	case !res.NowPrivate:
+		m.status = stDim.Render("back on the OPEN MARKET - ") + stKey.Render(model) + stDim.Render(" is public again")
+	case res.Code != "":
+		// Private: surface the one-time frequency code on a card (only when freshly minted;
+		// a re-register returns no code, only the cosmetic display).
+		m.bandCardCode, m.bandCardDisp, m.bandCardModel = res.Code, res.Display, model
 		m.mode = modeBandCard
-		m.status = stRed.Render(glyphOnAir+" PRIVATE ") + stDim.Render("- ") + stKey.Render(row.model) + stDim.Render(" is on a hidden band")
-		return
+		m.status = stRed.Render(glyphOnAir+" PRIVATE ") + stDim.Render("- ") + stKey.Render(model) + stDim.Render(" is on a hidden band")
+	default:
+		// No fresh code (already had a band): just mark it private, note the display.
+		m.bandCardDisp = res.Display
+		m.status = stRed.Render(glyphOnAir+" PRIVATE ") + stDim.Render("- ") + stKey.Render(model) + stDim.Render(" on band "+res.Display)
 	}
-	// No fresh code (already had a band): just mark it private, note the display.
-	m.bandCardDisp = display
-	m.status = stRed.Render(glyphOnAir+" PRIVATE ") + stDim.Render("- ") + stKey.Render(row.model) + stDim.Render(" on band "+display)
 }
 
 // onBandCardKey drives the one-time frequency-code card (modeBandCard): `c` copies the
@@ -2043,24 +1959,13 @@ func copyToClipboard(s string) bool {
 // refreshShareHeadline repoints m.share / m.onAir at any still-live session so the
 // header ON-AIR badge and the onAirPanel reflect the current set after a toggle.
 func (m *model) refreshShareHeadline() {
-	m.share, m.onAir = nil, false
-	for _, sess := range m.shares {
-		if sess != nil {
-			m.share, m.onAir = sess, true
-			return
-		}
-	}
+	m.share, m.onAir = m.ctrl.Headline()
 }
 
 // stopAllShares takes every model off air (used by /share off and a clean exit).
 func (m *model) stopAllShares() {
-	for mdl, sess := range m.shares {
-		if sess != nil {
-			sess.Stop()
-		}
-		delete(m.shares, mdl)
-	}
-	m.share, m.onAir = nil, false
+	m.ctrl.StopAll()
+	m.syncShareCache()
 }
 
 // onAirCount is how many models are currently ON AIR (live shares). Drives the
@@ -2180,10 +2085,8 @@ func (m *model) onStationRenameKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.status = stEmber.Render("station unchanged - ") + stKey.Render(m.station) + stDim.Render(" (a callsign needs at least one letter or digit)")
 			return m, nil
 		}
-		m.station = slug
-		if m.hooks.SaveStation != nil {
-			m.hooks.SaveStation(slug)
-		}
+		m.ctrl.Rename(slug) // sets + persists via Hooks.SaveStation; shared with the web console
+		m.syncShareCache()
 		m.status = stLive.Render("station set to ") + stKey.Render(m.station) + stDim.Render(" - applies on the next on-air (re-toggle a row to apply now)")
 		return m, nil
 	case tea.KeyBackspace, tea.KeyDelete:
@@ -2607,14 +2510,11 @@ func (m *model) commitShareEditor() bool {
 		return false
 	}
 	m.edErr = ""
-	if m.prices == nil {
-		m.prices = map[string]Pricing{}
-	}
 	p := Pricing{In: in, Out: out, Windows: append([]SchedWindow(nil), m.edWindows...)}
-	m.prices[m.edModel] = p
-	if m.hooks.SavePrice != nil {
-		m.hooks.SavePrice(m.edModel, p)
-	}
+	// Through the shared controller (it persists via Hooks.SavePrice), so a price the
+	// operator sets in the TUI editor is the same one the web console shows.
+	m.ctrl.SetPricing(m.edModel, p)
+	m.syncShareCache()
 	kind := "FREE"
 	if in > 0 || out > 0 {
 		kind = dollars(out) + "/1M out · " + dollars(in) + "/1M in"
@@ -2656,29 +2556,12 @@ func (m *model) softPriceWarn(out float64) string {
 
 // pricingFor returns the saved (edited) pricing for a model, falling back to the
 // host's saved onboarding price for the default model, else free.
-func (m model) pricingFor(model string) Pricing {
-	if p, ok := m.prices[model]; ok {
-		return p
-	}
-	if model == m.hooks.ShareModel {
-		return Pricing{In: m.hooks.SharePriceI, Out: m.hooks.SharePriceO}
-	}
-	return Pricing{}
-}
+func (m model) pricingFor(model string) Pricing { return m.ctrl.PricingFor(model) }
 
 // schedToProtocol converts the TUI's editable windows into the wire
 // protocol.PriceWindow the agent publishes (times "HH:MM" UTC; Free zeroes the
 // in-window price). Empty in -> no schedule.
-func schedToProtocol(ws []SchedWindow) []protocol.PriceWindow {
-	if len(ws) == 0 {
-		return nil
-	}
-	out := make([]protocol.PriceWindow, 0, len(ws))
-	for _, w := range ws {
-		out = append(out, protocol.PriceWindow{Start: w.Start, End: w.End, In: w.In, Out: w.Out, Free: w.Free})
-	}
-	return out
-}
+func schedToProtocol(ws []SchedWindow) []protocol.PriceWindow { return node.SchedToProtocol(ws) }
 
 // doLogin opens the confirmable [L] panel - it NEVER acts on its own, because
 // arrow-nav across the preset bank can land on [L]. Logged in it offers a log-out
@@ -5909,37 +5792,20 @@ func (m model) payoutHint() string {
 	}
 }
 
-// sharesOnAir counts how many local models are currently on air.
-func (m model) sharesOnAir() int {
-	n := 0
-	for _, s := range m.shares {
-		if s != nil {
-			n++
-		}
-	}
-	return n
-}
+// defaultShareMaxOnAir mirrors the controller's default soft on-air cap (the single
+// source of truth lives in package node).
+const defaultShareMaxOnAir = node.DefaultMaxOnAir
 
-// defaultShareMaxOnAir is the SOFT local on-air cap used when the host supplies no
-// share.max_on_air (Hooks.ShareMaxOnAir <= 0). Local UX guard so a user does not
-// over-subscribe their host; the broker's per-owner cap is the real backstop.
-const defaultShareMaxOnAir = 4
+// sharesOnAir counts how many local models are currently on air.
+func (m model) sharesOnAir() int { return m.ctrl.OnAirCount() }
 
 // maxOnAir is the effective SOFT local cap on simultaneously-on-air bands: the
-// host-supplied share.max_on_air when positive, else the package default. Read from
-// the hook (the host reads it once at startup; changing it requires a restart).
-func (m model) maxOnAir() int {
-	if m.hooks.ShareMaxOnAir > 0 {
-		return m.hooks.ShareMaxOnAir
-	}
-	return defaultShareMaxOnAir
-}
+// host-supplied share.max_on_air when positive, else the controller's default.
+func (m model) maxOnAir() int { return m.ctrl.MaxOnAir() }
 
 // atOnAirLimit reports whether the soft local on-air cap is already reached, so the
 // SHARE selector blocks flipping ANOTHER row on air (taking one off air frees a slot).
-func (m model) atOnAirLimit() bool {
-	return m.sharesOnAir() >= m.maxOnAir()
-}
+func (m model) atOnAirLimit() bool { return m.ctrl.OnAirCount() >= m.ctrl.MaxOnAir() }
 
 // onAirLimitMsg is the clear blocked-at-the-soft-limit message the SHARE selector
 // shows when the user tries to put one more band on air past share.max_on_air.
@@ -6986,19 +6852,7 @@ func tintSignal(raw string, signal int, tps float64, online bool) string {
 // normalizeUpstream turns a detected base/chat URL into the chat-completions URL
 // the agent POSTs to (mirrors cmd/rogerai's helper; kept local so the TUI's
 // in-process /share has no host dependency).
-func normalizeUpstream(u string) string {
-	u = strings.TrimRight(strings.TrimSpace(u), "/")
-	switch {
-	case u == "":
-		return u
-	case strings.HasSuffix(u, "/chat/completions"):
-		return u
-	case strings.HasSuffix(u, "/v1"):
-		return u + "/chat/completions"
-	default:
-		return u + "/v1/chat/completions"
-	}
-}
+func normalizeUpstream(u string) string { return node.NormalizeUpstream(u) }
 
 // plural renders "1 band" / "3 bands": a count with its noun, +s unless n == 1.
 func plural(n int, noun string) string {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1074,6 +1074,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case logoutMsg:
 		m.ghLogin = ""
 		m.loggedIn = false
+		m.ctrl.Logout() // explicit sign-out: clear the shared login (SetLoggedIn is raise-only)
 		m.haveBal = false
 		m.balance = 0
 		m.loginWaiting = false

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -827,26 +827,18 @@ func NewWith(broker, user string, limits *LimitStore) model {
 	return NewWithHooks(broker, user, limits, Hooks{})
 }
 
-// NewWithHooks is NewWith plus the host-supplied hooks for the in-TUI provider /
-// account / money flows.
-func NewWithHooks(broker, user string, limits *LimitStore, hooks Hooks) model {
-	m := newBase(broker, user, limits)
-	m.hooks = hooks
-	// Reflect the locally-linked login at startup so the header shows the right state
-	// before the first /balance comes back. The broker's logged_in flag (from the
-	// signed balance read) is the source of truth and confirms it.
-	m.ghLogin = hooks.LinkedLogin
-	// Seed the live broadcast station from the host (the saved/auto-generated callsign),
-	// slugged so it matches the node id exactly. Falls back to a fresh callsign if the
-	// host supplied none, so the TUI never derives a hostname-based id.
+// NewController builds the shared node controller from the host hooks (the SINGLE owner
+// of the live share state). The host calls this once and hands the SAME *node.Controller
+// to both NewWithHooksController and the web console, so a change in one front-end shows
+// up in the other.
+func NewController(broker string, hooks Hooks) *node.Controller {
+	// The live broadcast station: the saved/auto-generated callsign (NEVER the hostname),
+	// slugged so it matches the node id exactly; a fresh callsign if the host supplied none.
 	station := agent.SlugStation(hooks.Station)
 	if station == "" {
 		station = agent.GenerateStation()
 	}
-	// Build the SINGLE shared controller that owns the live share state. The web console
-	// (when on) holds this same pointer, so both front-ends drive one node. The model's
-	// share fields below are a render cache refreshed from it by syncShareCache().
-	m.ctrl = node.New(node.Config{
+	return node.New(node.Config{
 		Broker: broker, HW: hooks.HW, Station: station,
 		ShareModel: hooks.ShareModel, SharePriceI: hooks.SharePriceI, SharePriceO: hooks.SharePriceO,
 		MaxOnAir:    hooks.ShareMaxOnAir,
@@ -859,6 +851,25 @@ func NewWithHooks(broker, user string, limits *LimitStore, hooks Hooks) model {
 			SaveStation:  hooks.SaveStation,
 		},
 	})
+}
+
+// NewWithHooks is NewWith plus the host-supplied hooks for the in-TUI provider /
+// account / money flows. It builds its own controller; use NewWithHooksController to
+// share one with the web console.
+func NewWithHooks(broker, user string, limits *LimitStore, hooks Hooks) model {
+	return NewWithHooksController(broker, user, limits, hooks, NewController(broker, hooks))
+}
+
+// NewWithHooksController is NewWithHooks over an EXISTING shared controller, so the TUI
+// and the browser console drive one node.
+func NewWithHooksController(broker, user string, limits *LimitStore, hooks Hooks, ctrl *node.Controller) model {
+	m := newBase(broker, user, limits)
+	m.hooks = hooks
+	// Reflect the locally-linked login at startup so the header shows the right state
+	// before the first /balance comes back. The broker's logged_in flag (from the signed
+	// balance read) is the source of truth and confirms it.
+	m.ghLogin = hooks.LinkedLogin
+	m.ctrl = ctrl
 	m.ctrl.SetLoggedIn(m.loggedInState())
 	// Seed the windowshade compact mode from the saved config so the [m] choice sticks.
 	m.compact = hooks.Compact
@@ -6986,7 +6997,13 @@ func RunWithNotice(broker, user string, limits *LimitStore, notice string) error
 // RunWithHooks is RunWithNotice plus the host-supplied hooks that make the in-TUI
 // /share, /login, /topup, /grant flows real actions.
 func RunWithHooks(broker, user string, limits *LimitStore, notice string, hooks Hooks) error {
-	m := NewWithHooks(broker, user, limits, hooks)
+	return RunWithController(broker, user, limits, notice, hooks, NewController(broker, hooks))
+}
+
+// RunWithController is RunWithHooks over an EXISTING shared controller, so the host can
+// stand up the browser web console over the SAME node before launching the TUI.
+func RunWithController(broker, user string, limits *LimitStore, notice string, hooks Hooks, ctrl *node.Controller) error {
+	m := NewWithHooksController(broker, user, limits, hooks, ctrl)
 	m.updateLine = notice
 	_, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	return err

--- a/internal/webui/account.go
+++ b/internal/webui/account.go
@@ -1,0 +1,240 @@
+package webui
+
+import (
+	"net/http"
+
+	"github.com/rogerai-fyi/roger/internal/client"
+)
+
+// The account + browse surfaces reuse internal/client (the same broker calls the CLI/TUI
+// make), so there is one code path per surface and no new shared state. They need a broker
+// (Options.Broker); without one they report "not configured" rather than erroring.
+
+func (s *Server) brokerReady(w http.ResponseWriter) bool {
+	if s.opts.Broker == "" {
+		http.Error(w, "broker not configured", http.StatusServiceUnavailable)
+		return false
+	}
+	return true
+}
+
+// handleAccount returns the wallet + login + payout snapshot in one read (GET).
+func (s *Server) handleAccount(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	out := map[string]any{}
+	if bal, err := client.FetchBalance(s.opts.Broker, s.opts.User); err == nil {
+		out["balance"] = bal.Balance
+		out["logged_in"] = bal.LoggedIn
+		out["monthly_cap"] = bal.MonthlyCap
+		out["monthly_spend"] = bal.MonthlySpend
+		// Keep the shared controller's login state in step with the broker truth (raise-only;
+		// an explicit logout clears it), so a login done anywhere unlocks priced shares.
+		if bal.LoggedIn {
+			s.ctrl.SetLoggedIn(true)
+		}
+	}
+	if st, err := client.FetchPayoutStatus(s.opts.Broker); err == nil {
+		out["payout"] = st
+	}
+	writeJSON(w, out)
+}
+
+// handleLoginBegin starts the GitHub device flow and returns the URL + user code to show.
+// The device handle is held server-side for the matching poll.
+func (s *Server) handleLoginBegin(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	dev, err := client.LoginBegin(s.opts.Broker, s.opts.ClientID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	s.loginMu.Lock()
+	d := dev
+	s.loginDevice = &d
+	s.loginMu.Unlock()
+	writeJSON(w, map[string]any{"verification_uri": dev.VerificationURI, "user_code": dev.UserCode})
+}
+
+// handleLoginPoll blocks until the in-flight device flow is authorized (or fails), then
+// marks the node logged in. One in-flight login at a time (a single-operator console).
+func (s *Server) handleLoginPoll(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	s.loginMu.Lock()
+	dev := s.loginDevice
+	s.loginMu.Unlock()
+	if dev == nil {
+		http.Error(w, "no login in progress — begin first", http.StatusBadRequest)
+		return
+	}
+	login, err := client.LoginPoll(s.opts.Broker, s.opts.ClientID, *dev)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	s.loginMu.Lock()
+	s.loginDevice = nil
+	s.loginMu.Unlock()
+	s.ctrl.SetLoggedIn(true)
+	writeJSON(w, map[string]any{"ok": true, "login": login})
+}
+
+// handleLogout clears the local GitHub binding and the shared login state.
+func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
+	if err := client.LogoutReturn(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	s.ctrl.Logout()
+	writeJSON(w, map[string]any{"ok": true})
+}
+
+// handleTopup returns a Stripe Checkout URL for adding credit. Body: {"usd":10}.
+func (s *Server) handleTopup(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	var req struct {
+		USD float64 `json:"usd"`
+	}
+	if !decode(r, &req) || req.USD <= 0 {
+		http.Error(w, "usd must be > 0", http.StatusBadRequest)
+		return
+	}
+	url, err := client.TopupURL(s.opts.Broker, s.opts.User, req.USD)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, map[string]any{"url": url})
+}
+
+// handleLimit reads (GET) or sets (POST {cap}) the monthly spend cap.
+func (s *Server) handleLimit(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	if r.Method == http.MethodPost {
+		var req struct {
+			Cap float64 `json:"cap"`
+		}
+		if !decode(r, &req) {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		info, err := client.SetMonthlyLimit(s.opts.Broker, s.opts.User, req.Cap)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		writeJSON(w, info)
+		return
+	}
+	info, err := client.GetMonthlyLimit(s.opts.Broker, s.opts.User)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, info)
+}
+
+// handlePayout returns the Connect/KYC + payable snapshot (GET).
+func (s *Server) handlePayout(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	st, err := client.FetchPayoutStatus(s.opts.Broker)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, st)
+}
+
+// handlePayoutOnboard returns the Stripe Connect onboarding/KYC URL (POST).
+func (s *Server) handlePayoutOnboard(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	url, err := client.FetchOnboardURL(s.opts.Broker)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, map[string]any{"url": url})
+}
+
+// handlePayoutRequest requests a payout of the payable balance (POST).
+func (s *Server) handlePayoutRequest(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	rec, err := client.RequestPayout(s.opts.Broker)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, rec)
+}
+
+// handlePayoutHistory lists past payouts (GET).
+func (s *Server) handlePayoutHistory(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	recs, err := client.FetchPayoutHistory(s.opts.Broker)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, recs)
+}
+
+// handleGrants lists grants (GET) or creates one (POST {name,free}), returning the secret
+// once.
+func (s *Server) handleGrants(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	if r.Method == http.MethodPost {
+		var req struct {
+			Name string `json:"name"`
+			Free bool   `json:"free"`
+		}
+		if !decode(r, &req) || req.Name == "" {
+			http.Error(w, "name required", http.StatusBadRequest)
+			return
+		}
+		secret, err := client.GrantCreateSecret(s.opts.Broker, req.Name, req.Free)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		writeJSON(w, map[string]any{"ok": true, "secret": secret})
+		return
+	}
+	rows, err := client.GrantListRows(s.opts.Broker)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, rows)
+}
+
+// handleBrowse returns the broker's open-market discover feed (GET).
+func (s *Server) handleBrowse(w http.ResponseWriter, r *http.Request) {
+	if !s.brokerReady(w) {
+		return
+	}
+	offers, err := client.Discover(s.opts.Broker)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, offers)
+}

--- a/internal/webui/account_test.go
+++ b/internal/webui/account_test.go
@@ -1,0 +1,72 @@
+package webui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/client"
+	"github.com/rogerai-fyi/roger/internal/node"
+)
+
+func TestBrowseReturnsOffers(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/discover" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"offers": []map[string]any{
+				{"node_id": "amber-fox-m1", "model": "m1", "price_out": 2.0, "online": true},
+			}})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer broker.Close()
+
+	s := New(node.New(node.Config{}), Options{Broker: broker.URL})
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/browse?t=" + s.Token())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("browse = %d, want 200", resp.StatusCode)
+	}
+	var offers []client.Offer
+	if err := json.NewDecoder(resp.Body).Decode(&offers); err != nil {
+		t.Fatalf("decode offers: %v", err)
+	}
+	if len(offers) != 1 || offers[0].Model != "m1" {
+		t.Fatalf("offers = %+v, want one m1 offer", offers)
+	}
+}
+
+func TestAccountNotConfiguredWithoutBroker(t *testing.T) {
+	s := New(node.New(node.Config{}), Options{}) // no broker
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/api/account?t=" + s.Token())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("account without broker = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestBrowseRequiresToken(t *testing.T) {
+	s := New(node.New(node.Config{}), Options{Broker: "http://127.0.0.1:0"})
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/api/browse")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("browse without token = %d, want 403", resp.StatusCode)
+	}
+}

--- a/internal/webui/actions.go
+++ b/internal/webui/actions.go
@@ -1,0 +1,151 @@
+package webui
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rogerai-fyi/roger/internal/node"
+)
+
+// actionResp is the uniform reply to every write action: the resulting node snapshot
+// (so the browser re-renders immediately) plus a plain-text message and the same blocked
+// flags the TUI surfaces. Code carries the one-time private-band frequency code, returned
+// exactly once (on the private toggle that mints it) and never placed in a Snapshot.
+type actionResp struct {
+	OK          bool          `json:"ok"`
+	Message     string        `json:"message,omitempty"`
+	Code        string        `json:"code,omitempty"`
+	BandDisplay string        `json:"band_display,omitempty"`
+	LoginNeeded bool          `json:"login_needed,omitempty"`
+	AtLimit     bool          `json:"at_limit,omitempty"`
+	Snapshot    node.Snapshot `json:"snapshot"`
+}
+
+// action wraps a write handler with the token check AND a POST-only guard (a GET must
+// never mutate state — it would be CSRF-reachable via an <img>/<script> tag).
+func (s *Server) action(h http.HandlerFunc) http.HandlerFunc {
+	return s.auth(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h(w, r)
+	})
+}
+
+// decode reads a JSON body into v, treating an empty body as an empty object (so a
+// no-arg re-scan POST is valid). Returns false only on a malformed non-empty body.
+func decode(r *http.Request, v any) bool {
+	if r.Body == nil || r.ContentLength == 0 {
+		return true
+	}
+	return json.NewDecoder(r.Body).Decode(v) == nil
+}
+
+// handleOnAir toggles a model on/off air. Body: {"model":"..."}.
+func (s *Server) handleOnAir(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Model string `json:"model"`
+	}
+	if !decode(r, &req) || req.Model == "" {
+		http.Error(w, "model required", http.StatusBadRequest)
+		return
+	}
+	res := s.ctrl.ToggleOnAir(req.Model)
+	resp := actionResp{OK: res.Err == nil && !res.AtLimit && !res.LoginNeeded, Snapshot: s.ctrl.Snapshot(),
+		LoginNeeded: res.LoginNeeded, AtLimit: res.AtLimit}
+	switch {
+	case res.WentOff:
+		resp.Message = "off air — stopped sharing " + req.Model
+	case res.AtLimit:
+		resp.Message = "at the on-air limit — take one off air first, or raise share.max_on_air and restart"
+	case res.LoginNeeded:
+		resp.Message = "log in to earn (free sharing works without an account)"
+	case res.Err != nil:
+		resp.Message = "could not put " + req.Model + " on air: " + res.Err.Error()
+	case res.Priced:
+		resp.Message = "ON AIR — sharing " + req.Model + " priced"
+	default:
+		resp.Message = "ON AIR — sharing " + req.Model + " (FREE)"
+	}
+	writeJSON(w, resp)
+}
+
+// handlePrivate flips a model's private-band visibility. Body: {"model":"..."}.
+func (s *Server) handlePrivate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Model string `json:"model"`
+	}
+	if !decode(r, &req) || req.Model == "" {
+		http.Error(w, "model required", http.StatusBadRequest)
+		return
+	}
+	res := s.ctrl.TogglePrivate(req.Model)
+	resp := actionResp{OK: res.Err == nil && !res.AtLimit && !res.LoginNeeded, Snapshot: s.ctrl.Snapshot(),
+		LoginNeeded: res.LoginNeeded, AtLimit: res.AtLimit, Code: res.Code, BandDisplay: res.Display}
+	switch {
+	case res.LoginNeeded:
+		resp.Message = "log in to go private (a private band needs an account)"
+	case res.AtLimit:
+		resp.Message = "at the on-air limit — take one off air first"
+	case res.Err != nil:
+		resp.Message = "could not change " + req.Model + " visibility: " + res.Err.Error()
+	case !res.NowPrivate:
+		resp.Message = "back on the open market — " + req.Model + " is public again"
+	default:
+		resp.Message = "PRIVATE — " + req.Model + " is on a hidden band"
+	}
+	writeJSON(w, resp)
+}
+
+// handlePrice sets a model's price + schedule. Body:
+// {"model":"...","in":0,"out":2,"windows":[{"start":"HH:MM","end":"HH:MM","in":0,"out":0,"free":true}]}.
+func (s *Server) handlePrice(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Model   string             `json:"model"`
+		In      float64            `json:"in"`
+		Out     float64            `json:"out"`
+		Windows []node.SchedWindow `json:"windows"`
+	}
+	if !decode(r, &req) || req.Model == "" {
+		http.Error(w, "model required", http.StatusBadRequest)
+		return
+	}
+	s.ctrl.SetPricing(req.Model, node.Pricing{In: req.In, Out: req.Out, Windows: req.Windows})
+	writeJSON(w, actionResp{OK: true, Message: "price saved for " + req.Model, Snapshot: s.ctrl.Snapshot()})
+}
+
+// handleRename sets the station callsign. Body: {"station":"..."}.
+func (s *Server) handleRename(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Station string `json:"station"`
+	}
+	if !decode(r, &req) || req.Station == "" {
+		http.Error(w, "station required", http.StatusBadRequest)
+		return
+	}
+	s.ctrl.Rename(req.Station)
+	writeJSON(w, actionResp{OK: true, Message: "station set to " + s.ctrl.Station(), Snapshot: s.ctrl.Snapshot()})
+}
+
+// handleDetect re-scans for local models (optionally verifying a pasted URL + key) and
+// loads the result into the catalog. Body (all optional): {"url":"...","key":"..."}.
+func (s *Server) handleDetect(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		URL string `json:"url"`
+		Key string `json:"key"`
+	}
+	_ = decode(r, &req)
+	found, needKey := s.ctrl.Detect(req.URL, req.Key)
+	s.ctrl.LoadRows(found)
+	resp := actionResp{OK: true, Snapshot: s.ctrl.Snapshot()}
+	switch {
+	case len(found) > 0:
+		resp.Message = "detected local models"
+	case len(needKey) > 0:
+		resp.Message = needKey[0] + " needs an API key — paste it and re-scan"
+	default:
+		resp.Message = "nothing detected — start a local LLM or paste its URL"
+	}
+	writeJSON(w, resp)
+}

--- a/internal/webui/actions_test.go
+++ b/internal/webui/actions_test.go
@@ -45,7 +45,7 @@ func postAction(t *testing.T, srv *httptest.Server, token, path, body string) ac
 
 func TestOnAirActionTogglesNodeAndTUIWouldSee(t *testing.T) {
 	c := onairCtrl(t)
-	s := New(c)
+	s := New(c, Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 
@@ -78,7 +78,7 @@ func TestOnAirActionTogglesNodeAndTUIWouldSee(t *testing.T) {
 func TestPricedOnAirActionReportsLoginNeeded(t *testing.T) {
 	c := onairCtrl(t)
 	c.SetPricing("m1", node.Pricing{Out: 2})
-	s := New(c)
+	s := New(c, Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 	ar := postAction(t, srv, s.Token(), "/api/share/onair", `{"model":"m1"}`)
@@ -89,7 +89,7 @@ func TestPricedOnAirActionReportsLoginNeeded(t *testing.T) {
 
 func TestRenameAction(t *testing.T) {
 	c := onairCtrl(t)
-	s := New(c)
+	s := New(c, Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 	ar := postAction(t, srv, s.Token(), "/api/share/rename", `{"station":"violet-owl"}`)
@@ -100,7 +100,7 @@ func TestRenameAction(t *testing.T) {
 
 func TestPriceAction(t *testing.T) {
 	c := onairCtrl(t)
-	s := New(c)
+	s := New(c, Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 	ar := postAction(t, srv, s.Token(), "/api/share/price", `{"model":"m1","in":1,"out":3,"windows":[{"start":"03:00","end":"03:30","free":true}]}`)
@@ -114,7 +114,7 @@ func TestPriceAction(t *testing.T) {
 
 func TestWriteActionsRejectGET(t *testing.T) {
 	c := onairCtrl(t)
-	s := New(c)
+	s := New(c, Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 	// A GET (CSRF-reachable) to a write endpoint must be refused even WITH the token.
@@ -133,7 +133,7 @@ func TestWriteActionsRejectGET(t *testing.T) {
 
 func TestWriteActionRequiresToken(t *testing.T) {
 	c := onairCtrl(t)
-	s := New(c)
+	s := New(c, Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 	resp, err := http.Post(srv.URL+"/api/share/onair", "application/json", strings.NewReader(`{"model":"m1"}`))

--- a/internal/webui/actions_test.go
+++ b/internal/webui/actions_test.go
@@ -1,0 +1,147 @@
+package webui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/node"
+)
+
+// onairCtrl is a controller wired to a fake broker so a real session can start, with two
+// free models in the catalog.
+func onairCtrl(t *testing.T) *node.Controller {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}))
+	t.Cleanup(srv.Close)
+	c := node.New(node.Config{Broker: srv.URL, Station: "amber-fox"})
+	c.SetRows([]node.ShareRow{
+		{Model: "m1", Ctx: 8192, Upstream: "http://127.0.0.1:0/v1/chat/completions"},
+		{Model: "m2", Ctx: 8192, Upstream: "http://127.0.0.1:0/v1/chat/completions"},
+	})
+	return c
+}
+
+func postAction(t *testing.T, srv *httptest.Server, token, path, body string) actionResp {
+	t.Helper()
+	resp, err := http.Post(srv.URL+path+"?t="+token, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s = %d, want 200", path, resp.StatusCode)
+	}
+	var ar actionResp
+	if err := json.NewDecoder(resp.Body).Decode(&ar); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	return ar
+}
+
+func TestOnAirActionTogglesNodeAndTUIWouldSee(t *testing.T) {
+	c := onairCtrl(t)
+	s := New(c)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	ar := postAction(t, srv, s.Token(), "/api/share/onair", `{"model":"m1"}`)
+	if !ar.OK || ar.Snapshot.OnAir != 1 {
+		t.Fatalf("onair toggle: ok=%v on_air=%d, want ok + 1", ar.OK, ar.Snapshot.OnAir)
+	}
+	// The controller (which the TUI shares) really has the session now.
+	if c.OnAirCount() != 1 {
+		t.Fatalf("controller on-air = %d, want 1 (the TUI would render it too)", c.OnAirCount())
+	}
+	var m1 node.RowView
+	for _, rv := range ar.Snapshot.Rows {
+		if rv.Model == "m1" {
+			m1 = rv
+		}
+	}
+	if !m1.OnAir {
+		t.Fatal("snapshot row m1 should be on air")
+	}
+
+	// Toggle off.
+	ar = postAction(t, srv, s.Token(), "/api/share/onair", `{"model":"m1"}`)
+	if ar.Snapshot.OnAir != 0 || c.OnAirCount() != 0 {
+		t.Fatalf("off toggle: snapshot=%d controller=%d, want 0/0", ar.Snapshot.OnAir, c.OnAirCount())
+	}
+	c.StopAll()
+}
+
+func TestPricedOnAirActionReportsLoginNeeded(t *testing.T) {
+	c := onairCtrl(t)
+	c.SetPricing("m1", node.Pricing{Out: 2})
+	s := New(c)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	ar := postAction(t, srv, s.Token(), "/api/share/onair", `{"model":"m1"}`)
+	if !ar.LoginNeeded || ar.Snapshot.OnAir != 0 {
+		t.Fatalf("priced onair without login: login_needed=%v on_air=%d, want true/0", ar.LoginNeeded, ar.Snapshot.OnAir)
+	}
+}
+
+func TestRenameAction(t *testing.T) {
+	c := onairCtrl(t)
+	s := New(c)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	ar := postAction(t, srv, s.Token(), "/api/share/rename", `{"station":"violet-owl"}`)
+	if ar.Snapshot.Station != "violet-owl" || c.Station() != "violet-owl" {
+		t.Fatalf("rename: snapshot=%q controller=%q, want violet-owl", ar.Snapshot.Station, c.Station())
+	}
+}
+
+func TestPriceAction(t *testing.T) {
+	c := onairCtrl(t)
+	s := New(c)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	ar := postAction(t, srv, s.Token(), "/api/share/price", `{"model":"m1","in":1,"out":3,"windows":[{"start":"03:00","end":"03:30","free":true}]}`)
+	if !ar.OK {
+		t.Fatalf("price action not ok: %+v", ar)
+	}
+	if p := c.PricingFor("m1"); p.Out != 3 || len(p.Windows) != 1 {
+		t.Fatalf("PricingFor m1 = %+v, want out 3 + 1 window", p)
+	}
+}
+
+func TestWriteActionsRejectGET(t *testing.T) {
+	c := onairCtrl(t)
+	s := New(c)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	// A GET (CSRF-reachable) to a write endpoint must be refused even WITH the token.
+	resp, err := http.Get(srv.URL + "/api/share/onair?t=" + s.Token())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("GET on write action = %d, want 405", resp.StatusCode)
+	}
+	if c.OnAirCount() != 0 {
+		t.Fatal("a GET must never have mutated state")
+	}
+}
+
+func TestWriteActionRequiresToken(t *testing.T) {
+	c := onairCtrl(t)
+	s := New(c)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	resp, err := http.Post(srv.URL+"/api/share/onair", "application/json", strings.NewReader(`{"model":"m1"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("write without token = %d, want 403", resp.StatusCode)
+	}
+}

--- a/internal/webui/api.go
+++ b/internal/webui/api.go
@@ -1,0 +1,73 @@
+package webui
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// eventInterval is how often the SSE stream pushes a fresh snapshot. ~1 Hz is plenty for
+// a human-watched dashboard (the live counters change at human speed) and keeps the
+// stream cheap; it mirrors the cadence the TUI re-renders at.
+var eventInterval = time.Second
+
+// handleState returns a one-shot JSON snapshot of the node (the same Snapshot the SSE
+// stream pushes). Never includes the upstream key — see node.Snapshot.
+func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, s.ctrl.Snapshot())
+}
+
+// handleEvents streams the node snapshot as Server-Sent Events: one frame immediately,
+// then one every eventInterval, until the client disconnects. The browser console renders
+// each frame, so a change made in the terminal TUI shows up here within ~1s (and a change
+// made here shows up in the TUI on its next tick).
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+
+	send := func() bool {
+		blob, err := json.Marshal(s.ctrl.Snapshot())
+		if err != nil {
+			return false
+		}
+		if _, err := w.Write([]byte("data: ")); err != nil {
+			return false
+		}
+		if _, err := w.Write(blob); err != nil {
+			return false
+		}
+		if _, err := w.Write([]byte("\n\n")); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	if !send() {
+		return
+	}
+	ticker := time.NewTicker(eventInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			if !send() {
+				return
+			}
+		}
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/webui/assets/console.css
+++ b/internal/webui/assets/console.css
@@ -1,0 +1,297 @@
+/* ============================================================================
+   Roger node console — console.css
+   Restrained, mostly-white, one warm accent, monospace for data/callsigns.
+   No external fonts/assets. Sections:
+     1. Tokens / theme        5. Tables
+     2. Reset / base          6. Cards / account
+     3. Layout / topbar       7. Code card / login flow
+     4. Buttons / inputs      8. Modals / toasts
+     9. Dark mode  10. Reduced motion  11. Responsive
+   ========================================================================== */
+
+/* 1. TOKENS ---------------------------------------------------------------- */
+:root {
+  --accent: #d9531e;          /* warm radio orange — the one accent */
+  --accent-soft: #fbe6db;
+  --amber: #c4880a;           /* connecting / warn */
+  --gold: #b8860b;            /* verified lineage */
+  --green: #1f9d55;           /* online / good */
+  --red: #c5341f;
+
+  --bg: #ffffff;
+  --bg-soft: #faf9f7;
+  --panel: #ffffff;
+  --ink: #1b1b1a;
+  --ink-soft: #5c5a55;
+  --muted: #8b8880;
+  --line: #e7e4de;
+  --line-strong: #d6d2c9;
+
+  --shadow: 0 1px 3px rgba(0,0,0,.06), 0 6px 24px rgba(0,0,0,.05);
+  --radius: 10px;
+  --radius-sm: 6px;
+
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo,
+          Consolas, "Liberation Mono", monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+/* 2. RESET / BASE ---------------------------------------------------------- */
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--ink);
+  background: var(--bg-soft);
+  -webkit-font-smoothing: antialiased;
+}
+h1, h2, h3 { font-weight: 600; margin: 0; letter-spacing: .01em; }
+a { color: var(--accent); }
+.mono { font-family: var(--mono); }
+.muted { color: var(--muted); }
+.small { font-size: 12px; }
+code { font-family: var(--mono); }
+[hidden] { display: none !important; }
+
+/* 3. LAYOUT / TOPBAR ------------------------------------------------------- */
+.app { display: flex; flex-direction: column; min-height: 100%; }
+
+.topbar {
+  display: flex; align-items: center; gap: 16px;
+  padding: 10px 22px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--line);
+  position: sticky; top: 0; z-index: 20;
+}
+.topbar-left { display: flex; align-items: center; gap: 12px; }
+.topbar-right { margin-left: auto; }
+.brand-mark {
+  font-family: var(--mono);
+  font-weight: 700;
+  letter-spacing: .04em;
+  color: var(--accent);
+}
+.brand-mark::before { content: "◉ "; font-weight: 400; }
+.station-callsign { color: var(--ink-soft); font-size: 13px; }
+
+.slot-meter { font-size: 12px; color: var(--ink-soft); display: inline-flex; gap: 6px; align-items: center; }
+.slot-meter .dot-on { color: var(--accent); }
+.slot-meter.big { font-size: 13px; letter-spacing: .05em; }
+.slot-meter.big b { color: var(--accent); font-family: var(--mono); }
+
+.tabs { display: flex; gap: 4px; margin-left: 8px; }
+.tab {
+  font: inherit; font-size: 12px; letter-spacing: .08em;
+  padding: 7px 14px; border: 0; background: transparent;
+  color: var(--muted); cursor: pointer; border-radius: var(--radius-sm);
+}
+.tab:hover { color: var(--ink); background: var(--bg-soft); }
+.tab[aria-selected="true"] { color: var(--accent); background: var(--accent-soft); font-weight: 600; }
+
+.conn { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: var(--muted); }
+.conn-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--muted); }
+.conn.live .conn-dot { background: var(--green); }
+.conn.down .conn-dot { background: var(--red); }
+
+.content { width: 100%; max-width: 1180px; margin: 0 auto; padding: 24px 22px 64px; flex: 1; }
+
+.panel-head { margin-bottom: 18px; }
+.panel-head-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+.panel-head h2 { font-size: 13px; letter-spacing: .14em; color: var(--ink-soft); display: inline-flex; align-items: baseline; gap: 10px; }
+.panel-head-actions { display: flex; align-items: center; gap: 12px; }
+.callsign-edit { font-size: 16px; color: var(--ink); letter-spacing: 0; }
+.totals { margin-top: 8px; font-size: 12px; color: var(--ink-soft); }
+.login-warn {
+  margin-top: 10px; padding: 8px 12px; font-size: 12px;
+  background: #fff8ec; border: 1px solid #f0e2c4; border-radius: var(--radius-sm);
+  color: #7a5a12;
+}
+
+/* 4. BUTTONS / INPUTS ------------------------------------------------------ */
+.btn {
+  font: inherit; font-size: 12px; letter-spacing: .02em;
+  padding: 6px 12px; border-radius: var(--radius-sm);
+  border: 1px solid var(--line-strong); background: var(--bg); color: var(--ink);
+  cursor: pointer; white-space: nowrap; transition: background .12s, border-color .12s;
+}
+.btn:hover { background: var(--bg-soft); border-color: var(--muted); }
+.btn:active { transform: translateY(1px); }
+.btn[disabled] { opacity: .5; cursor: not-allowed; }
+.btn.small { padding: 4px 9px; font-size: 11px; }
+.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.btn.primary:hover { background: #c2491a; }
+.btn.ghost { background: transparent; border-color: var(--line); color: var(--ink-soft); }
+.btn.warn { color: var(--red); border-color: #e6c1ba; }
+
+.link-btn {
+  font: inherit; font-size: 12px; padding: 0; border: 0; background: none;
+  color: var(--accent); cursor: pointer; text-decoration: underline; text-underline-offset: 2px;
+}
+.link-btn:hover { color: #a93d14; }
+
+.inp {
+  font: inherit; font-size: 13px; padding: 6px 9px;
+  border: 1px solid var(--line-strong); border-radius: var(--radius-sm);
+  background: var(--bg); color: var(--ink); width: 100%;
+}
+.inp:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.inp.small { width: 110px; }
+.chk { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: var(--ink-soft); }
+
+/* 5. TABLES ---------------------------------------------------------------- */
+.table-wrap { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); overflow-x: auto; }
+.data-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.data-table th {
+  text-align: left; font-weight: 600; font-size: 10.5px; letter-spacing: .1em;
+  color: var(--muted); padding: 11px 14px; border-bottom: 1px solid var(--line);
+  white-space: nowrap; background: var(--bg-soft);
+}
+.data-table td { padding: 11px 14px; border-bottom: 1px solid var(--line); vertical-align: middle; }
+.data-table tr:last-child td { border-bottom: 0; }
+.data-table tbody tr:hover { background: #fcfbf9; }
+.data-table .num { text-align: right; font-variant-numeric: tabular-nums; font-family: var(--mono); }
+.empty-row td { color: var(--muted); text-align: center; padding: 26px; font-style: italic; }
+
+.cell-model { display: flex; align-items: center; gap: 9px; }
+.cell-model .model-name { font-family: var(--mono); font-weight: 500; }
+.cell-model .ctx { color: var(--muted); font-size: 11px; }
+
+.status-dot { font-size: 13px; line-height: 1; }
+.status-dot.on { color: var(--accent); }
+.status-dot.connecting { color: var(--amber); }
+.status-dot.off { color: var(--muted); }
+
+.status-label { font-size: 11px; letter-spacing: .08em; font-weight: 600; }
+.status-label.on { color: var(--accent); }
+.status-label.connecting { color: var(--amber); }
+.status-label.off { color: var(--muted); }
+.status-label.private { color: var(--gold); }
+
+.price-cell .sched { color: var(--muted); font-size: 11px; }
+.price-cell .free { color: var(--green); font-weight: 600; }
+
+.row-actions { display: flex; gap: 6px; justify-content: flex-end; flex-wrap: wrap; }
+
+/* signal meter — drawn from block glyphs */
+.signal { font-family: var(--mono); letter-spacing: -1px; }
+.signal.s-low { color: var(--muted); }
+.signal.s-mid { color: var(--ink-soft); }
+.signal.s-high { color: var(--green); }
+.verified { color: var(--gold); }
+.online-dot { font-size: 11px; }
+.online-dot.on { color: var(--green); }
+.online-dot.off { color: var(--muted); }
+
+/* 6. CARDS / ACCOUNT ------------------------------------------------------- */
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+.card {
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 18px; box-shadow: var(--shadow); display: flex; flex-direction: column; gap: 12px;
+}
+.card-title { font-size: 10.5px; letter-spacing: .12em; color: var(--muted); font-weight: 600; }
+.big-figure { font-size: 30px; font-weight: 600; letter-spacing: -.01em; }
+.meter-line { display: flex; flex-direction: column; gap: 5px; }
+.meter { height: 7px; background: var(--bg-soft); border: 1px solid var(--line); border-radius: 99px; overflow: hidden; }
+.meter-fill { height: 100%; width: 0; background: var(--accent); transition: width .3s ease; }
+.meter-fill.over { background: var(--red); }
+.card-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.kv { display: flex; justify-content: space-between; gap: 12px; font-size: 13px; }
+.kv span { color: var(--muted); }
+.grant-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; max-height: 160px; overflow-y: auto; }
+.grant-list li { padding: 4px 0; border-bottom: 1px dashed var(--line); }
+.history { white-space: pre-wrap; background: var(--bg-soft); border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 10px; max-height: 200px; overflow-y: auto; }
+.not-configured { margin-top: 18px; padding: 14px 16px; background: var(--bg-soft); border: 1px dashed var(--line-strong); border-radius: var(--radius); color: var(--ink-soft); font-size: 13px; }
+
+/* 7. CODE CARD / LOGIN FLOW ------------------------------------------------ */
+.code-card {
+  display: flex; align-items: flex-start; gap: 12px; margin-bottom: 18px;
+  padding: 14px 16px; background: linear-gradient(180deg, #fff8f2, #fff);
+  border: 1px solid var(--accent); border-radius: var(--radius); box-shadow: var(--shadow);
+}
+.code-card-body { flex: 1; }
+.code-card-title { font-size: 12px; color: var(--ink-soft); margin-bottom: 8px; }
+.code-card-title b { color: var(--accent); }
+.code-row { display: flex; align-items: center; gap: 10px; }
+.code-value { font-size: 16px; padding: 6px 10px; background: var(--bg-soft); border: 1px solid var(--line-strong); border-radius: var(--radius-sm); word-break: break-all; }
+.code-value.big { font-size: 22px; letter-spacing: .12em; }
+.x-btn { font: inherit; font-size: 20px; line-height: 1; border: 0; background: none; color: var(--muted); cursor: pointer; padding: 0 4px; }
+.x-btn:hover { color: var(--ink); }
+
+.login-flow { margin-top: 12px; padding: 12px; background: var(--bg-soft); border: 1px solid var(--line); border-radius: var(--radius-sm); }
+.spinner-line { display: flex; align-items: center; gap: 8px; margin-top: 10px; color: var(--ink-soft); font-size: 12px; }
+.spinner { width: 13px; height: 13px; border: 2px solid var(--line-strong); border-top-color: var(--accent); border-radius: 50%; animation: spin .8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* 8. MODALS / TOASTS ------------------------------------------------------- */
+.modal-backdrop {
+  position: fixed; inset: 0; background: rgba(20,18,16,.4);
+  display: flex; align-items: center; justify-content: center; z-index: 50; padding: 20px;
+}
+.modal {
+  background: var(--bg); border-radius: var(--radius); box-shadow: var(--shadow);
+  padding: 22px; width: 100%; max-width: 420px; display: flex; flex-direction: column; gap: 14px;
+}
+.modal.wide { max-width: 560px; }
+.modal h3 { font-size: 15px; }
+.field { display: flex; flex-direction: column; gap: 5px; font-size: 12px; color: var(--ink-soft); }
+.modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; }
+.price-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.windows-head { display: flex; justify-content: space-between; align-items: center; font-size: 11px; letter-spacing: .08em; color: var(--muted); border-top: 1px solid var(--line); padding-top: 12px; }
+.windows { display: flex; flex-direction: column; gap: 8px; }
+.window-row { display: grid; grid-template-columns: 1fr 1fr 1fr auto auto; gap: 6px; align-items: center; }
+.window-row .inp { font-size: 12px; padding: 5px 7px; }
+.window-row .chk { font-size: 11px; }
+
+.toasts { position: fixed; right: 18px; bottom: 18px; z-index: 60; display: flex; flex-direction: column; gap: 8px; max-width: 360px; }
+.toast {
+  padding: 11px 14px; border-radius: var(--radius-sm); font-size: 13px;
+  background: var(--ink); color: #fff; box-shadow: var(--shadow);
+  animation: toast-in .18s ease; border-left: 3px solid var(--accent);
+}
+.toast.err { border-left-color: var(--red); }
+.toast.ok { border-left-color: var(--green); }
+.toast.warn { border-left-color: var(--amber); }
+@keyframes toast-in { from { opacity: 0; transform: translateY(8px); } }
+
+/* AUTH GATE */
+.auth-gate { display: flex; align-items: center; justify-content: center; min-height: 100vh; padding: 24px; }
+.auth-card { max-width: 460px; text-align: center; background: var(--bg); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); padding: 40px 32px; }
+.auth-card h1 { font-size: 20px; margin: 14px 0 10px; }
+.auth-card p { color: var(--ink-soft); }
+.auth-card .brand-mark { font-size: 18px; }
+
+/* 9. DARK MODE ------------------------------------------------------------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #171614; --bg-soft: #1f1d1a; --panel: #1c1a18;
+    --ink: #ece9e3; --ink-soft: #b6b1a8; --muted: #837e74;
+    --line: #2e2b27; --line-strong: #403c36;
+    --accent-soft: #3a241a;
+    --shadow: 0 1px 3px rgba(0,0,0,.4), 0 8px 28px rgba(0,0,0,.35);
+  }
+  body { background: #121110; }
+  .data-table th { background: #211f1c; }
+  .data-table tbody tr:hover { background: #211f1c; }
+  .code-card { background: linear-gradient(180deg, #2a1d16, #1c1a18); }
+  .login-warn { background: #2a2316; border-color: #463a1f; color: #d8b86a; }
+  .toast { background: #2a2724; }
+}
+
+/* 10. REDUCED MOTION ------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; }
+}
+
+/* 11. RESPONSIVE ----------------------------------------------------------- */
+@media (max-width: 720px) {
+  .topbar { flex-wrap: wrap; gap: 10px; padding: 10px 14px; }
+  .topbar-right { margin-left: 0; }
+  .content { padding: 18px 14px 56px; }
+  .tabs { order: 3; width: 100%; }
+  .tab { flex: 1; }
+  .price-grid { grid-template-columns: 1fr; }
+  .window-row { grid-template-columns: 1fr 1fr; }
+}

--- a/internal/webui/assets/console.html
+++ b/internal/webui/assets/console.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Roger · Node Console</title>
+</head>
+<body>
+<noscript>The Roger node console needs JavaScript.</noscript>
+<main id="app">Tuning in…</main>
+<script src="/assets/console.js" defer></script>
+</body>
+</html>

--- a/internal/webui/assets/console.html
+++ b/internal/webui/assets/console.html
@@ -1,14 +1,268 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="robots" content="noindex">
-<title>Roger · Node Console</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <meta name="color-scheme" content="light dark">
+  <title>Roger · Node Console</title>
+  <link rel="stylesheet" href="/assets/console.css">
 </head>
 <body>
-<noscript>The Roger node console needs JavaScript.</noscript>
-<main id="app">Tuning in…</main>
-<script src="/assets/console.js" defer></script>
+  <noscript>The Roger node console needs JavaScript.</noscript>
+
+  <!-- ===================== AUTH GATE ===================== -->
+  <!-- Shown when ?t= is missing; hides the whole app. -->
+  <div id="auth-gate" class="auth-gate" hidden>
+    <div class="auth-card">
+      <div class="brand-mark">Roger</div>
+      <h1>Console locked</h1>
+      <p>Open the console from the link Roger printed in your terminal &mdash; it carries
+         the one-time access token this page needs.</p>
+      <p class="muted small">The address looks like
+         <code>http://127.0.0.1:&lt;port&gt;/?t=&hellip;</code></p>
+    </div>
+  </div>
+
+  <!-- ===================== APP SHELL ===================== -->
+  <div id="app" class="app" hidden>
+    <header class="topbar">
+      <div class="topbar-left">
+        <span class="brand-mark">Roger</span>
+        <span class="station-callsign mono" id="top-callsign">&mdash;</span>
+        <span class="slot-meter" id="top-slots" title="slots on air">
+          <span class="dot-on">&#9673;</span> <span id="top-slots-text">0/0</span>
+        </span>
+      </div>
+      <nav class="tabs" role="tablist" aria-label="Sections">
+        <button class="tab" data-tab="share" role="tab" aria-selected="true">SHARE</button>
+        <button class="tab" data-tab="account" role="tab" aria-selected="false">ACCOUNT</button>
+        <button class="tab" data-tab="browse" role="tab" aria-selected="false">BROWSE</button>
+      </nav>
+      <div class="topbar-right">
+        <span class="conn" id="conn-status" title="live link">
+          <span class="conn-dot" id="conn-dot"></span><span id="conn-text">connecting</span>
+        </span>
+      </div>
+    </header>
+
+    <main class="content">
+
+      <!-- ===================== SHARE ===================== -->
+      <section class="panel" id="panel-share" role="tabpanel">
+        <div class="panel-head">
+          <div class="panel-head-row">
+            <h2>SHARE
+              <span class="callsign-edit mono" id="share-callsign">&mdash;</span>
+              <button class="link-btn" id="btn-rename" title="rename station">rename</button>
+            </h2>
+            <div class="panel-head-actions">
+              <span class="slot-meter big" id="share-slots">ON AIR <b id="share-slots-text">0/0</b></span>
+              <button class="btn" id="btn-detect">re-detect</button>
+            </div>
+          </div>
+          <div class="totals mono" id="share-totals">
+            <span>0 requests</span> &middot; <span>0 out tok</span> &middot;
+            <span>$0.00</span> &middot; <span class="muted">settles on the broker</span>
+          </div>
+          <div class="login-warn" id="share-login-warn" hidden>
+            Not logged in &mdash; models can run but earnings need an account.
+            <button class="link-btn" data-goto="account">go to account</button>
+          </div>
+        </div>
+
+        <!-- one-time frequency code card (private toggle) -->
+        <div class="code-card" id="code-card" hidden>
+          <div class="code-card-body">
+            <div class="code-card-title">Frequency code &mdash; <b>save this, shown once</b></div>
+            <div class="code-row">
+              <code class="mono code-value" id="code-value"></code>
+              <button class="btn small" id="code-copy">copy</button>
+            </div>
+            <div class="muted small" id="code-band"></div>
+          </div>
+          <button class="x-btn" id="code-dismiss" title="dismiss">&times;</button>
+        </div>
+
+        <div class="table-wrap">
+          <table class="data-table share-table">
+            <thead>
+              <tr>
+                <th class="col-model">MODEL</th>
+                <th class="col-status">STATUS</th>
+                <th class="col-price">PRICE</th>
+                <th class="num">SERVED</th>
+                <th class="num">OUT TOK</th>
+                <th class="num">EARNINGS</th>
+                <th class="col-actions">ACTIONS</th>
+              </tr>
+            </thead>
+            <tbody id="share-rows">
+              <tr class="empty-row"><td colspan="7">No models detected yet. Try <b>re-detect</b>.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ===================== ACCOUNT ===================== -->
+      <section class="panel" id="panel-account" role="tabpanel" hidden>
+        <div class="panel-head"><h2>ACCOUNT</h2></div>
+
+        <div class="cards" id="account-body">
+          <!-- balance / spend -->
+          <div class="card" id="card-balance">
+            <div class="card-title">Balance</div>
+            <div class="big-figure mono" id="acct-balance">$0.00</div>
+            <div class="meter-line">
+              <div class="meter"><div class="meter-fill" id="acct-spend-fill"></div></div>
+              <div class="muted small" id="acct-spend-text">$0.00 of $0.00 this month</div>
+            </div>
+            <div class="card-actions">
+              <input class="inp small" id="topup-amount" type="number" min="1" step="1" placeholder="USD" inputmode="decimal">
+              <button class="btn" id="btn-topup">Top up</button>
+            </div>
+            <div class="card-actions">
+              <input class="inp small" id="limit-cap" type="number" min="0" step="1" placeholder="monthly cap">
+              <button class="btn ghost" id="btn-limit">Set limit</button>
+            </div>
+          </div>
+
+          <!-- login / session -->
+          <div class="card" id="card-session">
+            <div class="card-title">Session</div>
+            <div id="logged-out" hidden>
+              <p class="muted small">Sign in to earn and spend on the Roger market.</p>
+              <button class="btn primary" id="btn-login">Log in with GitHub</button>
+              <div class="login-flow" id="login-flow" hidden>
+                <p>Go to <a id="login-uri" target="_blank" rel="noopener">the GitHub device page</a>
+                   and enter this code:</p>
+                <div class="code-row">
+                  <code class="mono code-value big" id="login-code">&mdash;</code>
+                  <button class="btn small" id="login-code-copy">copy</button>
+                </div>
+                <div class="spinner-line"><span class="spinner"></span> waiting for GitHub&hellip;</div>
+              </div>
+            </div>
+            <div id="logged-in" hidden>
+              <p class="mono" id="acct-login-state">signed in</p>
+              <button class="btn ghost" id="btn-logout">Log out</button>
+            </div>
+          </div>
+
+          <!-- payouts -->
+          <div class="card" id="card-payout">
+            <div class="card-title">Payouts</div>
+            <div class="kv"><span>Status</span><b class="mono" id="payout-status">&mdash;</b></div>
+            <div class="kv"><span>Payable</span><b class="mono" id="payout-payable">$0.00</b></div>
+            <div class="card-actions">
+              <button class="btn" id="btn-payout-onboard">Set up payouts</button>
+              <button class="btn ghost" id="btn-payout-request">Request payout</button>
+              <button class="btn ghost" id="btn-payout-history">History</button>
+            </div>
+            <div class="history mono small" id="payout-history" hidden></div>
+          </div>
+
+          <!-- grants -->
+          <div class="card" id="card-grants">
+            <div class="card-title">Grants</div>
+            <ul class="grant-list mono small" id="grant-list"><li class="muted">none</li></ul>
+            <div class="card-actions">
+              <input class="inp small" id="grant-name" type="text" placeholder="grant name">
+              <label class="chk"><input type="checkbox" id="grant-free"> free</label>
+              <button class="btn" id="btn-grant-create">Create</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="not-configured" id="account-disabled" hidden>
+          The broker is not configured for this node, so account, payout and grant
+          features are unavailable.
+        </div>
+      </section>
+
+      <!-- ===================== BROWSE ===================== -->
+      <section class="panel" id="panel-browse" role="tabpanel" hidden>
+        <div class="panel-head">
+          <div class="panel-head-row">
+            <h2>BROWSE</h2>
+            <button class="btn" id="btn-browse-refresh">refresh</button>
+          </div>
+          <div class="muted small">Models on air across the open market &mdash; read-only.</div>
+        </div>
+        <div class="table-wrap">
+          <table class="data-table browse-table">
+            <thead>
+              <tr>
+                <th class="col-model">MODEL</th>
+                <th>NODE</th>
+                <th class="col-price">PRICE</th>
+                <th>SIGNAL</th>
+                <th class="num">TPS</th>
+                <th class="num">TTFT</th>
+                <th class="num">CTX</th>
+                <th>REGION</th>
+              </tr>
+            </thead>
+            <tbody id="browse-rows">
+              <tr class="empty-row"><td colspan="8">Loading the market&hellip;</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <!-- ===================== MODALS / TOASTS ===================== -->
+  <div class="modal-backdrop" id="modal-backdrop" hidden>
+    <!-- rename modal -->
+    <div class="modal" id="modal-rename" hidden>
+      <h3>Rename station</h3>
+      <label class="field"><span>Callsign</span>
+        <input class="inp" id="rename-input" type="text" maxlength="40" placeholder="amber-fox"></label>
+      <div class="modal-actions">
+        <button class="btn ghost" data-close>Cancel</button>
+        <button class="btn primary" id="rename-save">Save</button>
+      </div>
+    </div>
+
+    <!-- detect modal -->
+    <div class="modal" id="modal-detect" hidden>
+      <h3>Re-detect models</h3>
+      <p class="muted small">Scans your local LLM servers. Optionally point at a specific
+         OpenAI-compatible endpoint.</p>
+      <label class="field"><span>Endpoint URL (optional)</span>
+        <input class="inp" id="detect-url" type="text" placeholder="http://127.0.0.1:11434/v1/chat/completions"></label>
+      <label class="field"><span>API key (optional)</span>
+        <input class="inp" id="detect-key" type="password" placeholder="sk-&hellip;"></label>
+      <div class="modal-actions">
+        <button class="btn ghost" data-close>Cancel</button>
+        <button class="btn primary" id="detect-run">Detect</button>
+      </div>
+    </div>
+
+    <!-- price modal -->
+    <div class="modal wide" id="modal-price" hidden>
+      <h3>Price <span class="mono" id="price-model">&mdash;</span></h3>
+      <div class="price-grid">
+        <label class="field"><span>In ($/1M tok)</span>
+          <input class="inp" id="price-in" type="number" min="0" step="0.01" placeholder="0"></label>
+        <label class="field"><span>Out ($/1M tok)</span>
+          <input class="inp" id="price-out" type="number" min="0" step="0.01" placeholder="0"></label>
+      </div>
+      <div class="windows-head">
+        <span>Time-of-use windows</span>
+        <button class="link-btn" id="price-add-window">+ add window</button>
+      </div>
+      <div class="windows" id="price-windows"></div>
+      <div class="modal-actions">
+        <button class="btn ghost" data-close>Cancel</button>
+        <button class="btn primary" id="price-save">Save pricing</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="toasts" id="toasts" aria-live="polite"></div>
+
+  <script src="/assets/console.js" defer></script>
 </body>
 </html>

--- a/internal/webui/assets/console.js
+++ b/internal/webui/assets/console.js
@@ -1,14 +1,669 @@
-// Placeholder — the full node console UI lands in a later commit. For now it proves
-// the embedded static + token-guarded SSE path end to end.
+/* ============================================================================
+   Roger node console — console.js
+   Dependency-free vanilla JS. Module-pattern IIFE. Sections:
+     1. Auth / token        6. SHARE actions (onair/private/price/rename/detect)
+     2. tiny DOM + fmt      7. ACCOUNT
+     3. API + token plumbing 8. BROWSE
+     4. Toasts / modals     9. Boot
+     5. SSE + SHARE render
+   Every /api call carries the per-run token (header or query); the SSE stream
+   carries it in the query (EventSource cannot set headers).
+   ========================================================================== */
 (function () {
   "use strict";
-  var token = new URLSearchParams(location.search).get("t") || "";
-  var app = document.getElementById("app");
-  var es = new EventSource("/api/events?t=" + encodeURIComponent(token));
-  es.onmessage = function (e) {
-    try {
-      var s = JSON.parse(e.data);
-      app.textContent = "station " + s.station + " · " + s.on_air + "/" + s.max_on_air + " on air";
-    } catch (_) {}
-  };
+
+  /* 1. AUTH / TOKEN -------------------------------------------------------- */
+  var TOKEN = new URLSearchParams(location.search).get("t") || "";
+
+  /* 2. TINY DOM + FORMAT HELPERS ------------------------------------------ */
+  function $(id) { return document.getElementById(id); }
+  function el(tag, cls, txt) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (txt != null) e.textContent = txt;
+    return e;
+  }
+  function show(node, on) { if (node) node.hidden = !on; }
+  function fmtInt(n) { return (Number(n) || 0).toLocaleString("en-US"); }
+  function fmtUSD(n) { return "$" + (Number(n) || 0).toFixed(2); }
+  function clamp(n, lo, hi) { return Math.max(lo, Math.min(hi, n)); }
+
+  // Signal meter from block glyphs ▁▂▃▄▅▆▇█ — a small rising equalizer.
+  function signalBars(sig) {
+    var ramp = "▁▂▃▄▅▆▇█";
+    var n = clamp(Number(sig) || 0, 0, 100);
+    var out = "";
+    for (var seg = 0; seg < 5; seg++) {
+      var local = clamp((n - seg * 20) / 20, 0, 1); // 0..1 within this segment
+      out += ramp.charAt(Math.round(local * (ramp.length - 1)));
+    }
+    return out;
+  }
+  function signalClass(sig) {
+    var n = Number(sig) || 0;
+    return n >= 66 ? "s-high" : n >= 33 ? "s-mid" : "s-low";
+  }
+
+  /* 3. API + TOKEN PLUMBING ----------------------------------------------- */
+  // ApiError carries the HTTP status so callers can special-case 503 ("broker
+  // not configured") versus real failures.
+  function ApiError(status, message) { this.status = status; this.message = message; }
+  ApiError.prototype = Object.create(Error.prototype);
+
+  function withToken(path) {
+    return path + (path.indexOf("?") === -1 ? "?" : "&") + "t=" + encodeURIComponent(TOKEN);
+  }
+
+  // api(method, path, body) -> Promise<parsedJSON|null>. Always sends the token
+  // both as a header and in the query, so it works regardless of how the server
+  // reads it.
+  function api(method, path, body) {
+    var opts = {
+      method: method,
+      headers: { "X-Roger-Token": TOKEN }
+    };
+    if (body !== undefined) {
+      opts.headers["Content-Type"] = "application/json";
+      opts.body = JSON.stringify(body);
+    }
+    return fetch(withToken(path), opts).then(function (res) {
+      var ct = res.headers.get("content-type") || "";
+      var parse = ct.indexOf("application/json") !== -1
+        ? res.json().catch(function () { return null; })
+        : res.text().catch(function () { return ""; });
+      return parse.then(function (data) {
+        if (!res.ok) {
+          var msg = (data && data.message) || (typeof data === "string" && data) || res.statusText;
+          throw new ApiError(res.status, msg);
+        }
+        return data;
+      });
+    });
+  }
+  function apiGet(path) { return api("GET", path); }
+  function apiPost(path, body) { return api("POST", path, body || {}); }
+
+  /* 4. TOASTS / MODALS ----------------------------------------------------- */
+  function toast(msg, kind) {
+    if (!msg) return;
+    var t = el("div", "toast" + (kind ? " " + kind : ""), msg);
+    $("toasts").appendChild(t);
+    setTimeout(function () {
+      t.style.transition = "opacity .3s";
+      t.style.opacity = "0";
+      setTimeout(function () { t.remove(); }, 320);
+    }, kind === "err" ? 6000 : 4000);
+  }
+  function toastErr(e) {
+    var m = (e && e.message) || "something went wrong";
+    if (e && e.status === 503) m = "broker not configured: " + m;
+    toast(m, "err");
+  }
+
+  var openModal = null;
+  function modalOpen(id) {
+    closeModal();
+    openModal = $(id);
+    show($("modal-backdrop"), true);
+    show(openModal, true);
+    var first = openModal.querySelector("input, button");
+    if (first) try { first.focus(); } catch (_) {}
+  }
+  function closeModal() {
+    if (openModal) show(openModal, false);
+    show($("modal-backdrop"), false);
+    openModal = null;
+  }
+  function copyText(text, btn) {
+    var done = function () { if (btn) { var o = btn.textContent; btn.textContent = "copied"; setTimeout(function () { btn.textContent = o; }, 1200); } };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(done, function () { toast("copy failed", "warn"); });
+    } else {
+      try {
+        var ta = el("textarea"); ta.value = text; document.body.appendChild(ta);
+        ta.select(); document.execCommand("copy"); ta.remove(); done();
+      } catch (_) { toast("copy failed", "warn"); }
+    }
+  }
+
+  /* 5. SSE + SHARE RENDER -------------------------------------------------- */
+  var shareRowEls = {};       // model -> <tr>, reused across frames to avoid flicker
+  var lastSnapshot = null;
+
+  function connectSSE() {
+    var conn = $("conn-status");
+    var es = new EventSource(withToken("/api/events"));
+    es.onopen = function () { conn.className = "conn live"; $("conn-text").textContent = "live"; };
+    es.onmessage = function (e) {
+      try { renderSnapshot(JSON.parse(e.data)); } catch (_) {}
+    };
+    es.onerror = function () {
+      conn.className = "conn down";
+      $("conn-text").textContent = "reconnecting";
+      // EventSource auto-reconnects; nothing else to do.
+    };
+  }
+
+  function renderSnapshot(s) {
+    lastSnapshot = s;
+    // top bar + share header
+    $("top-callsign").textContent = s.station || "—";
+    $("share-callsign").textContent = s.station || "—";
+    var slots = (s.on_air || 0) + "/" + (s.max_on_air || 0);
+    $("top-slots-text").textContent = slots;
+    $("share-slots-text").textContent = slots;
+
+    var t = s.totals || {};
+    var totals = $("share-totals");
+    totals.innerHTML = "";
+    totals.appendChild(el("span", null, fmtInt(t.requests) + " requests"));
+    totals.appendChild(document.createTextNode(" · "));
+    totals.appendChild(el("span", null, fmtInt(t.out_tokens) + " out tok"));
+    totals.appendChild(document.createTextNode(" · "));
+    totals.appendChild(el("span", null, fmtUSD(t.earnings)));
+    totals.appendChild(document.createTextNode(" · "));
+    totals.appendChild(el("span", "muted", "settles on the broker"));
+
+    show($("share-login-warn"), !s.logged_in);
+    renderShareRows(s.rows || []);
+  }
+
+  function renderShareRows(rows) {
+    var tbody = $("share-rows");
+    // drop the placeholder empty row on first real data
+    var empty = tbody.querySelector(".empty-row");
+    if (rows.length && empty) empty.remove();
+
+    var seen = {};
+    rows.forEach(function (row) {
+      seen[row.model] = true;
+      var tr = shareRowEls[row.model];
+      if (!tr) { tr = buildShareRow(row.model); shareRowEls[row.model] = tr; tbody.appendChild(tr); }
+      updateShareRow(tr, row);
+    });
+    // remove rows for models that vanished
+    Object.keys(shareRowEls).forEach(function (m) {
+      if (!seen[m]) { shareRowEls[m].remove(); delete shareRowEls[m]; }
+    });
+    if (!tbody.children.length) {
+      var er = el("tr", "empty-row");
+      var td = el("td", null, "No models detected yet. Try re-detect.");
+      td.colSpan = 7; er.appendChild(td); tbody.appendChild(er);
+    }
+  }
+
+  // buildShareRow makes the stable skeleton once; updateShareRow fills it each
+  // frame. Button clicks go through tbody delegation (see wiring), so rebuilding
+  // text never drops handlers.
+  function buildShareRow(model) {
+    var tr = el("tr");
+    tr.setAttribute("data-model", model);
+    tr.appendChild(el("td", "cell-model"));               // 0 model
+    tr.appendChild(el("td", "status-cell"));              // 1 status
+    tr.appendChild(el("td", "price-cell"));               // 2 price
+    tr.appendChild(el("td", "num served"));               // 3 served
+    tr.appendChild(el("td", "num outtok"));               // 4 out tok
+    tr.appendChild(el("td", "num earnings"));             // 5 earnings
+    tr.appendChild(el("td", "col-actions"));              // 6 actions
+    return tr;
+  }
+
+  function updateShareRow(tr, row) {
+    var tds = tr.children;
+    var onAir = !!row.on_air, priv = !!row.private, link = row.link || "off";
+    var connecting = onAir && link !== "on-air"; // truthful link state
+
+    // --- model cell: dot + name + ctx ---
+    var dotCls = priv ? "off" : connecting ? "connecting" : onAir ? "on" : "off";
+    var dotCh = connecting ? "◌" : onAir ? "◉" : "○";
+    var ctx = (row.ctx ? (Math.round(row.ctx / 1024) + "k") + (row.ctx_estimated ? "≈" : "") : "");
+    tds[0].innerHTML = "";
+    tds[0].appendChild(el("span", "status-dot " + dotCls, dotCh));
+    tds[0].appendChild(el("span", "model-name", row.model));
+    if (ctx) tds[0].appendChild(el("span", "ctx", " " + ctx + " ctx"));
+
+    // --- status label ---
+    var lblCls, lblTxt;
+    if (priv) { lblCls = "private"; lblTxt = "PRIVATE"; }
+    else if (connecting) { lblCls = "connecting"; lblTxt = link === "reconnecting" ? "RECONNECTING" : "CONNECTING"; }
+    else if (onAir) { lblCls = "on"; lblTxt = "ON-AIR"; }
+    else { lblCls = "off"; lblTxt = "OFF-AIR"; }
+    tds[1].innerHTML = "";
+    tds[1].appendChild(el("span", "status-label " + lblCls, lblTxt));
+
+    // --- price ---
+    tds[2].innerHTML = "";
+    if ((Number(row.price_out) || 0) === 0) {
+      tds[2].appendChild(el("span", "free", "FREE"));
+    } else {
+      tds[2].appendChild(document.createTextNode("$" + row.price_out + "/1M out"));
+    }
+    if (row.scheduled) tds[2].appendChild(el("span", "sched", " · sched"));
+
+    // --- counters ---
+    tds[3].textContent = fmtInt(row.served);
+    tds[4].textContent = fmtInt(row.out_tokens);
+    tds[5].textContent = fmtUSD(row.earnings);
+
+    // --- actions ---
+    tds[6].innerHTML = "";
+    var actions = el("div", "row-actions");
+    var onairBtn = el("button", "btn small", onAir ? "Take off air" : "Put on air");
+    onairBtn.setAttribute("data-act", "onair");
+    onairBtn.setAttribute("data-model", row.model);
+    var privBtn = el("button", "btn small ghost", priv ? "Make public" : "Make private");
+    privBtn.setAttribute("data-act", "private");
+    privBtn.setAttribute("data-model", row.model);
+    var priceBtn = el("button", "btn small ghost", "Price");
+    priceBtn.setAttribute("data-act", "price");
+    priceBtn.setAttribute("data-model", row.model);
+    actions.appendChild(onairBtn);
+    actions.appendChild(privBtn);
+    actions.appendChild(priceBtn);
+    tds[6].appendChild(actions);
+  }
+
+  /* 6. SHARE ACTIONS ------------------------------------------------------- */
+  function findRow(model) {
+    if (!lastSnapshot || !lastSnapshot.rows) return null;
+    for (var i = 0; i < lastSnapshot.rows.length; i++) {
+      if (lastSnapshot.rows[i].model === model) return lastSnapshot.rows[i];
+    }
+    return null;
+  }
+
+  function actOnAir(model) {
+    apiPost("/api/share/onair", { model: model }).then(function (r) {
+      r = r || {};
+      if (r.login_needed) { toast(r.message || "Log in first to put a model on air.", "warn"); setTab("account"); }
+      else if (r.at_limit) { toast(r.message || "All on-air slots are full.", "warn"); }
+      else if (r.message) { toast(r.message, "ok"); }
+      // SSE reflects the real result either way.
+    }).catch(toastErr);
+  }
+
+  function actPrivate(model) {
+    apiPost("/api/share/private", { model: model }).then(function (r) {
+      r = r || {};
+      if (r.code) showFreqCode(r.code, r.band_display);
+      if (r.message) toast(r.message, "ok");
+    }).catch(toastErr);
+  }
+
+  function showFreqCode(code, band) {
+    $("code-value").textContent = code;
+    $("code-band").textContent = band ? ("band: " + band) : "";
+    show($("code-card"), true);
+    setTab("share");
+  }
+
+  // --- price modal ---
+  var priceModel = null;
+  function openPriceModal(model) {
+    priceModel = model;
+    var row = findRow(model) || {};
+    $("price-model").textContent = model;
+    $("price-in").value = row.price_in != null ? row.price_in : "";
+    $("price-out").value = row.price_out != null ? row.price_out : "";
+    $("price-windows").innerHTML = "";
+    modalOpen("modal-price");
+  }
+  function addWindowRow(w) {
+    w = w || {};
+    var wrap = el("div", "window-row");
+    function mk(ph, val, type) { var i = el("input", "inp"); i.type = type || "text"; i.placeholder = ph; if (val != null) i.value = val; return i; }
+    var start = mk("HH:MM", w.start); start.setAttribute("data-f", "start");
+    var end = mk("HH:MM", w.end); end.setAttribute("data-f", "end");
+    var inp = mk("in", w.in, "number"); inp.setAttribute("data-f", "in"); inp.min = "0"; inp.step = "0.01";
+    var outp = mk("out", w.out, "number"); outp.setAttribute("data-f", "out"); outp.min = "0"; outp.step = "0.01";
+    var freeLbl = el("label", "chk");
+    var free = el("input"); free.type = "checkbox"; free.setAttribute("data-f", "free"); free.checked = !!w.free;
+    freeLbl.appendChild(free); freeLbl.appendChild(document.createTextNode("free"));
+    var rm = el("button", "x-btn", "×"); rm.type = "button";
+    rm.onclick = function () { wrap.remove(); };
+    wrap.appendChild(start); wrap.appendChild(end); wrap.appendChild(inp); wrap.appendChild(outp); wrap.appendChild(freeLbl); wrap.appendChild(rm);
+    $("price-windows").appendChild(wrap);
+  }
+  function collectWindows() {
+    var rows = $("price-windows").querySelectorAll(".window-row");
+    var out = [];
+    Array.prototype.forEach.call(rows, function (r) {
+      function v(f) { return r.querySelector('[data-f="' + f + '"]'); }
+      var start = v("start").value.trim(), end = v("end").value.trim();
+      if (!start && !end) return;
+      out.push({
+        start: start, end: end,
+        in: parseFloat(v("in").value) || 0,
+        out: parseFloat(v("out").value) || 0,
+        free: v("free").checked
+      });
+    });
+    return out;
+  }
+  function savePrice() {
+    if (!priceModel) return;
+    var body = {
+      model: priceModel,
+      in: parseFloat($("price-in").value) || 0,
+      out: parseFloat($("price-out").value) || 0,
+      windows: collectWindows()
+    };
+    apiPost("/api/share/price", body).then(function (r) {
+      closeModal();
+      toast((r && r.message) || "Pricing saved.", "ok");
+    }).catch(toastErr);
+  }
+
+  // --- rename + detect ---
+  function saveRename() {
+    var name = $("rename-input").value.trim();
+    if (!name) { toast("Enter a callsign.", "warn"); return; }
+    apiPost("/api/share/rename", { station: name }).then(function (r) {
+      closeModal();
+      toast((r && r.message) || "Station renamed.", "ok");
+    }).catch(toastErr);
+  }
+  function runDetect() {
+    var url = $("detect-url").value.trim();
+    var key = $("detect-key").value.trim();
+    var body = {};
+    if (url) body.url = url;
+    if (key) body.key = key;
+    apiPost("/api/share/detect", body).then(function (r) {
+      closeModal();
+      toast((r && r.message) || "Detection complete.", "ok");
+    }).catch(toastErr);
+  }
+
+  /* 7. ACCOUNT ------------------------------------------------------------- */
+  var accountDisabled = false;
+
+  function disableAccount() {
+    accountDisabled = true;
+    show($("account-body"), false);
+    show($("account-disabled"), true);
+  }
+
+  function loadAccount() {
+    apiGet("/api/account").then(function (a) {
+      a = a || {};
+      accountDisabled = false;
+      show($("account-body"), true);
+      show($("account-disabled"), false);
+
+      $("acct-balance").textContent = fmtUSD(a.balance);
+      var cap = Number(a.monthly_cap) || 0, spend = Number(a.monthly_spend) || 0;
+      var pct = cap > 0 ? clamp(spend / cap * 100, 0, 100) : 0;
+      var fill = $("acct-spend-fill");
+      fill.style.width = pct + "%";
+      fill.className = "meter-fill" + (cap > 0 && spend >= cap ? " over" : "");
+      $("acct-spend-text").textContent = fmtUSD(spend) + " of " + (cap > 0 ? fmtUSD(cap) : "no cap") + " this month";
+      if ($("limit-cap").value === "") $("limit-cap").value = cap || "";
+
+      var inLogged = !!a.logged_in;
+      show($("logged-in"), inLogged);
+      show($("logged-out"), !inLogged);
+      if (inLogged) {
+        show($("login-flow"), false);
+        $("acct-login-state").textContent = "signed in" + (a.user_id ? " · " + a.user_id : "");
+      }
+    }).catch(function (e) {
+      if (e.status === 503) disableAccount();
+      else toastErr(e);
+    });
+
+    if (accountDisabled) return;
+    loadPayout();
+    loadGrants();
+  }
+
+  function loadPayout() {
+    apiGet("/api/payout").then(function (p) {
+      p = p || {};
+      $("payout-status").textContent = p.status || (p.kyc || "not set up");
+      $("payout-payable").textContent = fmtUSD(p.payable);
+    }).catch(function (e) { if (e.status !== 503) {/* keep quiet */} });
+  }
+  function payoutHistory() {
+    apiGet("/api/payout/history").then(function (h) {
+      var box = $("payout-history");
+      show(box, true);
+      if (!h || (h.length === 0)) { box.textContent = "no payouts yet"; return; }
+      var lines = (Array.isArray(h) ? h : (h.items || [])).map(function (x) {
+        return (x.date || x.created_at || "") + "  " + fmtUSD(x.amount) + "  " + (x.status || "");
+      });
+      box.textContent = lines.join("\n") || "no payouts yet";
+    }).catch(toastErr);
+  }
+
+  function loadGrants() {
+    apiGet("/api/grants").then(function (g) {
+      var list = $("grant-list");
+      list.innerHTML = "";
+      var items = Array.isArray(g) ? g : (g && g.items) || [];
+      if (!items.length) { list.appendChild(el("li", "muted", "none")); return; }
+      items.forEach(function (it) {
+        var name = it.name || it.id || "grant";
+        var meta = it.free ? " · free" : (it.balance != null ? " · " + fmtUSD(it.balance) : "");
+        list.appendChild(el("li", null, name + meta));
+      });
+    }).catch(function (e) { if (e.status !== 503) {/* quiet */} });
+  }
+  function createGrant() {
+    var name = $("grant-name").value.trim();
+    if (!name) { toast("Name the grant.", "warn"); return; }
+    apiPost("/api/grants", { name: name, free: $("grant-free").checked }).then(function (r) {
+      r = r || {};
+      $("grant-name").value = ""; $("grant-free").checked = false;
+      if (r.secret) revealGrantSecret(name, r.secret);
+      toast((r.message) || "Grant created.", "ok");
+      loadGrants();
+    }).catch(toastErr);
+  }
+  function revealGrantSecret(name, secret) {
+    var list = $("grant-list");
+    var li = el("li", null);
+    li.style.borderLeft = "3px solid var(--accent)";
+    li.style.paddingLeft = "8px";
+    li.appendChild(el("div", "small", name + " — save this secret, shown once:"));
+    var row = el("div", "code-row");
+    var code = el("code", "code-value", secret);
+    var copy = el("button", "btn small", "copy");
+    copy.onclick = function () { copyText(secret, copy); };
+    row.appendChild(code); row.appendChild(copy);
+    li.appendChild(row);
+    list.insertBefore(li, list.firstChild);
+  }
+
+  // login device flow
+  function loginBegin() {
+    var btn = $("btn-login"); btn.disabled = true;
+    apiPost("/api/account/login/begin", {}).then(function (r) {
+      r = r || {};
+      show($("login-flow"), true);
+      var a = $("login-uri");
+      a.href = r.verification_uri || "#";
+      a.textContent = r.verification_uri || "the GitHub device page";
+      $("login-code").textContent = r.user_code || "—";
+      // poll blocks server-side until authorized
+      return apiPost("/api/account/login/poll", {});
+    }).then(function () {
+      toast("Signed in.", "ok");
+      show($("login-flow"), false);
+      loadAccount();
+    }).catch(function (e) {
+      toastErr(e);
+      show($("login-flow"), false);
+    }).then(function () { btn.disabled = false; });
+  }
+  function logout() {
+    apiPost("/api/account/logout", {}).then(function () { toast("Signed out.", "ok"); loadAccount(); }).catch(toastErr);
+  }
+  function topup() {
+    var usd = parseFloat($("topup-amount").value);
+    if (!usd || usd <= 0) { toast("Enter an amount.", "warn"); return; }
+    apiPost("/api/account/topup", { usd: usd }).then(function (r) {
+      if (r && r.url) { window.open(r.url, "_blank", "noopener"); toast("Opening checkout…", "ok"); }
+      else toast((r && r.message) || "Top-up requested.", "ok");
+    }).catch(toastErr);
+  }
+  function setLimit() {
+    var cap = parseFloat($("limit-cap").value);
+    if (isNaN(cap) || cap < 0) { toast("Enter a cap (0 = no cap).", "warn"); return; }
+    apiPost("/api/account/limit", { cap: cap }).then(function (r) {
+      toast((r && r.message) || "Spend limit updated.", "ok"); loadAccount();
+    }).catch(toastErr);
+  }
+  function payoutOnboard() {
+    apiPost("/api/payout/onboard", {}).then(function (r) {
+      if (r && r.url) { window.open(r.url, "_blank", "noopener"); toast("Opening payout setup…", "ok"); }
+      else toast((r && r.message) || "Payout onboarding started.", "ok");
+    }).catch(toastErr);
+  }
+  function payoutRequest() {
+    apiPost("/api/payout/request", {}).then(function (r) {
+      toast((r && r.message) || "Payout requested.", "ok"); loadPayout();
+    }).catch(toastErr);
+  }
+
+  /* 8. BROWSE -------------------------------------------------------------- */
+  function loadBrowse() {
+    var tbody = $("browse-rows");
+    apiGet("/api/browse").then(function (offers) {
+      tbody.innerHTML = "";
+      offers = Array.isArray(offers) ? offers : [];
+      if (!offers.length) {
+        var er = el("tr", "empty-row");
+        var td = el("td", null, "No models on the market right now."); td.colSpan = 8;
+        er.appendChild(td); tbody.appendChild(er); return;
+      }
+      offers.forEach(function (o) { tbody.appendChild(buildBrowseRow(o)); });
+    }).catch(function (e) {
+      tbody.innerHTML = "";
+      var er = el("tr", "empty-row");
+      var td = el("td", null, e.status === 503 ? "Browse needs a configured broker." : "Could not load the market.");
+      td.colSpan = 8; er.appendChild(td); tbody.appendChild(er);
+    });
+  }
+  function buildBrowseRow(o) {
+    var tr = el("tr");
+    // model + verified
+    var m = el("td", "cell-model");
+    var dot = el("span", "online-dot " + (o.online ? "on" : "off"), o.online ? "◉" : "○");
+    m.appendChild(dot);
+    m.appendChild(el("span", "model-name", o.model || "—"));
+    if (o.verified) { var v = el("span", "verified", " ◆"); v.title = "verified lineage"; m.appendChild(v); }
+    if (o.confidential) m.appendChild(el("span", "ctx", " · conf"));
+    tr.appendChild(m);
+    // node
+    tr.appendChild(el("td", "mono", o.node_id || "—"));
+    // price
+    var price = el("td", "price-cell");
+    if (o.free_now || (Number(o.price_out) || 0) === 0) price.appendChild(el("span", "free", "FREE"));
+    else price.appendChild(document.createTextNode("$" + o.price_out + "/1M out"));
+    tr.appendChild(price);
+    // signal
+    var sig = el("td");
+    var bars = el("span", "signal " + signalClass(o.signal), signalBars(o.signal));
+    bars.title = "signal " + (Number(o.signal) || 0);
+    sig.appendChild(bars);
+    tr.appendChild(sig);
+    // tps / ttft / ctx / region
+    tr.appendChild(el("td", "num", o.tps != null ? Math.round(o.tps) : "—"));
+    tr.appendChild(el("td", "num", o.ttft_ms != null ? Math.round(o.ttft_ms) + "ms" : "—"));
+    tr.appendChild(el("td", "num", o.ctx ? Math.round(o.ctx / 1024) + "k" : "—"));
+    tr.appendChild(el("td", null, o.region || "—"));
+    return tr;
+  }
+
+  /* TABS ------------------------------------------------------------------- */
+  function setTab(name) {
+    ["share", "account", "browse"].forEach(function (n) {
+      show($("panel-" + n), n === name);
+    });
+    Array.prototype.forEach.call(document.querySelectorAll(".tab"), function (b) {
+      b.setAttribute("aria-selected", b.getAttribute("data-tab") === name ? "true" : "false");
+    });
+    if (name === "account") loadAccount();
+    if (name === "browse") loadBrowse();
+  }
+
+  /* 9. BOOT / WIRING ------------------------------------------------------- */
+  function wire() {
+    // tabs + any [data-goto] / [data-tab] click
+    document.addEventListener("click", function (e) {
+      var tabBtn = e.target.closest("[data-tab]");
+      if (tabBtn) { setTab(tabBtn.getAttribute("data-tab")); return; }
+      var gotoBtn = e.target.closest("[data-goto]");
+      if (gotoBtn) { setTab(gotoBtn.getAttribute("data-goto")); return; }
+      var closeBtn = e.target.closest("[data-close]");
+      if (closeBtn) { closeModal(); return; }
+    });
+
+    // share table action delegation
+    $("share-rows").addEventListener("click", function (e) {
+      var btn = e.target.closest("button[data-act]");
+      if (!btn) return;
+      var model = btn.getAttribute("data-model");
+      var act = btn.getAttribute("data-act");
+      if (act === "onair") actOnAir(model);
+      else if (act === "private") actPrivate(model);
+      else if (act === "price") openPriceModal(model);
+    });
+
+    // share header
+    $("btn-rename").onclick = function () {
+      $("rename-input").value = (lastSnapshot && lastSnapshot.station) || "";
+      modalOpen("modal-rename");
+    };
+    $("rename-save").onclick = saveRename;
+    $("btn-detect").onclick = function () {
+      $("detect-url").value = ""; $("detect-key").value = "";
+      modalOpen("modal-detect");
+    };
+    $("detect-run").onclick = runDetect;
+
+    // price modal
+    $("price-add-window").onclick = function () { addWindowRow(); };
+    $("price-save").onclick = savePrice;
+
+    // freq code card
+    $("code-copy").onclick = function () { copyText($("code-value").textContent, $("code-copy")); };
+    $("code-dismiss").onclick = function () { show($("code-card"), false); };
+
+    // backdrop click closes
+    $("modal-backdrop").addEventListener("click", function (e) {
+      if (e.target === $("modal-backdrop")) closeModal();
+    });
+    document.addEventListener("keydown", function (e) { if (e.key === "Escape") closeModal(); });
+
+    // account
+    $("btn-login").onclick = loginBegin;
+    $("login-code-copy").onclick = function () { copyText($("login-code").textContent, $("login-code-copy")); };
+    $("btn-logout").onclick = logout;
+    $("btn-topup").onclick = topup;
+    $("btn-limit").onclick = setLimit;
+    $("btn-payout-onboard").onclick = payoutOnboard;
+    $("btn-payout-request").onclick = payoutRequest;
+    $("btn-payout-history").onclick = payoutHistory;
+    $("btn-grant-create").onclick = createGrant;
+
+    // browse
+    $("btn-browse-refresh").onclick = loadBrowse;
+  }
+
+  function boot() {
+    if (!TOKEN) { show($("auth-gate"), true); return; }
+    show($("app"), true);
+    wire();
+    setTab("share");
+    // one-shot state for an instant paint, then live stream
+    apiGet("/api/state").then(renderSnapshot).catch(function (e) {
+      if (e.status === 403) { show($("app"), false); show($("auth-gate"), true); }
+    });
+    connectSSE();
+  }
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);
+  else boot();
 })();

--- a/internal/webui/assets/console.js
+++ b/internal/webui/assets/console.js
@@ -1,0 +1,14 @@
+// Placeholder — the full node console UI lands in a later commit. For now it proves
+// the embedded static + token-guarded SSE path end to end.
+(function () {
+  "use strict";
+  var token = new URLSearchParams(location.search).get("t") || "";
+  var app = document.getElementById("app");
+  var es = new EventSource("/api/events?t=" + encodeURIComponent(token));
+  es.onmessage = function (e) {
+    try {
+      var s = JSON.parse(e.data);
+      app.textContent = "station " + s.station + " · " + s.on_air + "/" + s.max_on_air + " on air";
+    } catch (_) {}
+  };
+})();

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -1,0 +1,152 @@
+// Package webui serves the browser-based node console: a localhost web app that is a
+// live twin of the terminal TUI. It drives the SAME *node.Controller the TUI holds, so a
+// model toggled on air in the browser flips the TUI row and vice-versa.
+//
+// It binds 127.0.0.1 ONLY and gates every /api request on a per-run random token (handed
+// to the browser in the opened URL's ?t=). Localhost + token is the Jupyter model: it
+// keeps other local processes (and cross-site requests) out of a console that can put a
+// GPU on air, spend/earn money, and holds the operator's upstream key.
+package webui
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"embed"
+	"encoding/hex"
+	"io/fs"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/rogerai-fyi/roger/internal/node"
+)
+
+//go:embed assets/*
+var assetsFS embed.FS
+
+// Server is the node console HTTP server. It is safe for concurrent requests: all live
+// state lives behind the controller's mutex.
+type Server struct {
+	ctrl  *node.Controller
+	token string
+	mux   *http.ServeMux
+}
+
+// New builds a console server over ctrl with a freshly-minted access token. Call
+// Handler() for the wrapped http.Handler, or Serve(ln) to run it.
+func New(ctrl *node.Controller) *Server {
+	s := &Server{ctrl: ctrl, token: newToken()}
+	s.mux = http.NewServeMux()
+	s.routes()
+	return s
+}
+
+// Token is the per-run access token required on every /api request (embedded in the URL
+// the operator opens).
+func (s *Server) Token() string { return s.token }
+
+// routes wires the static shell + the read API. Write actions and account/browse are
+// layered on in later commits.
+func (s *Server) routes() {
+	sub, _ := fs.Sub(assetsFS, "assets")
+	files := http.FileServer(http.FS(sub))
+	// The shell at / and its assets are static and carry no node data, so they load
+	// without a token; everything under /api does require it (see auth()).
+	s.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			r.URL.Path = "/console.html"
+		}
+		files.ServeHTTP(w, r)
+	})
+	s.mux.Handle("/assets/", http.StripPrefix("/assets/", files))
+	s.mux.HandleFunc("/api/state", s.auth(s.handleState))
+	s.mux.HandleFunc("/api/events", s.auth(s.handleEvents))
+}
+
+// Handler returns the fully-wrapped handler (localhost guard in front of the mux).
+func (s *Server) Handler() http.Handler { return s.localhostOnly(s.mux) }
+
+// Serve runs the console on ln until the listener closes.
+func (s *Server) Serve(ln net.Listener) error {
+	return (&http.Server{Handler: s.Handler()}).Serve(ln)
+}
+
+// auth wraps an /api handler with the constant-time token check. The token may arrive as
+// ?t= (the opened URL) or an X-Roger-Token header (the page's fetch/EventSource calls).
+func (s *Server) auth(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		got := r.URL.Query().Get("t")
+		if got == "" {
+			got = r.Header.Get("X-Roger-Token")
+		}
+		if subtle.ConstantTimeCompare([]byte(got), []byte(s.token)) != 1 {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		h(w, r)
+	}
+}
+
+// localhostOnly rejects any request whose peer is not a loopback address — defense in
+// depth on top of the 127.0.0.1 bind (e.g. a misconfigured reverse proxy).
+func (s *Server) localhostOnly(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			host = r.RemoteAddr
+		}
+		if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+			http.Error(w, "console is localhost-only", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Listen binds a free localhost port at/after addr and returns the listener plus the URL
+// (with the access token) to open. addr like "127.0.0.1:4180"; if that port is taken it
+// scans upward, mirroring the TUI's listenFreePort so a busy port never dead-ends.
+func (s *Server) Listen(addr string) (net.Listener, string, error) {
+	ln, err := listenFreePort(addr)
+	if err != nil {
+		return nil, "", err
+	}
+	return ln, "http://" + ln.Addr().String() + "/?t=" + s.token, nil
+}
+
+// listenFreePort binds addr, or — if its port is taken — scans upward to the first free
+// port on the same host (bounded). Mirrors internal/tui.listenFreePort.
+func listenFreePort(addr string) (net.Listener, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		host, port = "127.0.0.1", "0"
+	}
+	if port == "0" {
+		return net.Listen("tcp", net.JoinHostPort(host, "0"))
+	}
+	start, _ := strconv.Atoi(port)
+	var lastErr error
+	for p := start; p < start+64; p++ {
+		ln, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(p)))
+		if err == nil {
+			return ln, nil
+		}
+		lastErr = err
+	}
+	// Last resort: let the OS pick any free port rather than dead-end.
+	if ln, err := net.Listen("tcp", net.JoinHostPort(host, "0")); err == nil {
+		return ln, nil
+	}
+	return nil, lastErr
+}
+
+func newToken() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// rand.Read failing is catastrophic; fall back to a fixed-length zero token rather
+		// than panic — the localhost bind still gates access.
+		return strings.Repeat("0", 32)
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -62,6 +62,12 @@ func (s *Server) routes() {
 	s.mux.Handle("/assets/", http.StripPrefix("/assets/", files))
 	s.mux.HandleFunc("/api/state", s.auth(s.handleState))
 	s.mux.HandleFunc("/api/events", s.auth(s.handleEvents))
+	// Operator write actions (POST-only, token-gated). Each returns the new snapshot.
+	s.mux.HandleFunc("/api/share/onair", s.action(s.handleOnAir))
+	s.mux.HandleFunc("/api/share/private", s.action(s.handlePrivate))
+	s.mux.HandleFunc("/api/share/price", s.action(s.handlePrice))
+	s.mux.HandleFunc("/api/share/rename", s.action(s.handleRename))
+	s.mux.HandleFunc("/api/share/detect", s.action(s.handleDetect))
 }
 
 // Handler returns the fully-wrapped handler (localhost guard in front of the mux).

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -18,25 +18,40 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 
+	"github.com/rogerai-fyi/roger/internal/client"
 	"github.com/rogerai-fyi/roger/internal/node"
 )
 
 //go:embed assets/*
 var assetsFS embed.FS
 
+// Options carry the broker identity the account + browse surfaces need. They are
+// optional: with an empty Broker the share/monitor surfaces still work and the account/
+// browse endpoints report "not configured" rather than erroring.
+type Options struct {
+	Broker   string
+	User     string // signed user id (X-Roger-User)
+	ClientID string // GitHub OAuth client id for the device-flow login
+}
+
 // Server is the node console HTTP server. It is safe for concurrent requests: all live
-// state lives behind the controller's mutex.
+// state lives behind the controller's mutex; the in-flight login device has its own lock.
 type Server struct {
 	ctrl  *node.Controller
 	token string
 	mux   *http.ServeMux
+	opts  Options
+
+	loginMu     sync.Mutex
+	loginDevice *client.Device // the in-flight device-flow login between begin and poll
 }
 
 // New builds a console server over ctrl with a freshly-minted access token. Call
 // Handler() for the wrapped http.Handler, or Serve(ln) to run it.
-func New(ctrl *node.Controller) *Server {
-	s := &Server{ctrl: ctrl, token: newToken()}
+func New(ctrl *node.Controller, opts Options) *Server {
+	s := &Server{ctrl: ctrl, token: newToken(), opts: opts}
 	s.mux = http.NewServeMux()
 	s.routes()
 	return s
@@ -68,6 +83,20 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/api/share/price", s.action(s.handlePrice))
 	s.mux.HandleFunc("/api/share/rename", s.action(s.handleRename))
 	s.mux.HandleFunc("/api/share/detect", s.action(s.handleDetect))
+	// Account (reads token-gated; writes POST-only).
+	s.mux.HandleFunc("/api/account", s.auth(s.handleAccount))
+	s.mux.HandleFunc("/api/account/login/begin", s.action(s.handleLoginBegin))
+	s.mux.HandleFunc("/api/account/login/poll", s.action(s.handleLoginPoll))
+	s.mux.HandleFunc("/api/account/logout", s.action(s.handleLogout))
+	s.mux.HandleFunc("/api/account/topup", s.action(s.handleTopup))
+	s.mux.HandleFunc("/api/account/limit", s.auth(s.handleLimit)) // GET reads, POST sets
+	s.mux.HandleFunc("/api/payout", s.auth(s.handlePayout))
+	s.mux.HandleFunc("/api/payout/onboard", s.action(s.handlePayoutOnboard))
+	s.mux.HandleFunc("/api/payout/request", s.action(s.handlePayoutRequest))
+	s.mux.HandleFunc("/api/payout/history", s.auth(s.handlePayoutHistory))
+	s.mux.HandleFunc("/api/grants", s.auth(s.handleGrants)) // GET lists, POST creates
+	// Browse (the open-market discover feed).
+	s.mux.HandleFunc("/api/browse", s.auth(s.handleBrowse))
 }
 
 // Handler returns the fully-wrapped handler (localhost guard in front of the mux).

--- a/internal/webui/server_test.go
+++ b/internal/webui/server_test.go
@@ -19,7 +19,7 @@ func testCtrl() *node.Controller {
 }
 
 func TestStateRequiresToken(t *testing.T) {
-	s := New(testCtrl())
+	s := New(testCtrl(), Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 
@@ -59,7 +59,7 @@ func TestStateRequiresToken(t *testing.T) {
 }
 
 func TestTokenViaHeader(t *testing.T) {
-	s := New(testCtrl())
+	s := New(testCtrl(), Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 	req, _ := http.NewRequest("GET", srv.URL+"/api/state", nil)
@@ -75,7 +75,7 @@ func TestTokenViaHeader(t *testing.T) {
 }
 
 func TestStateNeverLeaksUpstreamKey(t *testing.T) {
-	s := New(testCtrl())
+	s := New(testCtrl(), Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 	resp, err := http.Get(srv.URL + "/api/state?t=" + s.Token())
@@ -91,7 +91,7 @@ func TestStateNeverLeaksUpstreamKey(t *testing.T) {
 }
 
 func TestStaticShellNoTokenNeeded(t *testing.T) {
-	s := New(testCtrl())
+	s := New(testCtrl(), Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 	resp, err := http.Get(srv.URL + "/")
@@ -109,7 +109,7 @@ func TestEventsStream(t *testing.T) {
 	eventInterval = 20 * time.Millisecond
 	defer func() { eventInterval = old }()
 
-	s := New(testCtrl())
+	s := New(testCtrl(), Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 
@@ -141,7 +141,7 @@ func TestEventsStream(t *testing.T) {
 }
 
 func TestEventsRequiresToken(t *testing.T) {
-	s := New(testCtrl())
+	s := New(testCtrl(), Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
 	resp, err := http.Get(srv.URL + "/api/events")
@@ -155,7 +155,7 @@ func TestEventsRequiresToken(t *testing.T) {
 }
 
 func TestListenReturnsLocalhostURLWithToken(t *testing.T) {
-	s := New(testCtrl())
+	s := New(testCtrl(), Options{})
 	ln, url, err := s.Listen("127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/webui/server_test.go
+++ b/internal/webui/server_test.go
@@ -3,6 +3,7 @@ package webui
 import (
 	"bufio"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -151,6 +152,37 @@ func TestEventsRequiresToken(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("events without token = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestAssetsServe(t *testing.T) {
+	s := New(testCtrl(), Options{})
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	// The shell HTML references these; both must serve without a token (static, no data).
+	for _, path := range []string{"/", "/assets/console.css", "/assets/console.js"} {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		body := make([]byte, 64)
+		n, _ := resp.Body.Read(body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s = %d, want 200", path, resp.StatusCode)
+		}
+		if n == 0 {
+			t.Fatalf("GET %s served an empty body", path)
+		}
+	}
+	// The shell references the css + js by the paths above.
+	resp, _ := http.Get(srv.URL + "/")
+	html, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	for _, ref := range []string{"/assets/console.css", "/assets/console.js"} {
+		if !strings.Contains(string(html), ref) {
+			t.Errorf("shell HTML does not reference %s", ref)
+		}
 	}
 }
 

--- a/internal/webui/server_test.go
+++ b/internal/webui/server_test.go
@@ -1,0 +1,167 @@
+package webui
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/node"
+)
+
+func testCtrl() *node.Controller {
+	c := node.New(node.Config{Station: "amber-fox", Upstream: "http://127.0.0.1:1234/v1", UpstreamKey: "sk-secret-leak-canary"})
+	c.SetRows([]node.ShareRow{{Model: "m1", Ctx: 8192}, {Model: "m2", Ctx: 8192}})
+	return c
+}
+
+func TestStateRequiresToken(t *testing.T) {
+	s := New(testCtrl())
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	// No token -> forbidden.
+	resp, err := http.Get(srv.URL + "/api/state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("state without token = %d, want 403", resp.StatusCode)
+	}
+
+	// Wrong token -> forbidden.
+	resp, _ = http.Get(srv.URL + "/api/state?t=nope")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("state with wrong token = %d, want 403", resp.StatusCode)
+	}
+
+	// Right token -> ok.
+	resp, err = http.Get(srv.URL + "/api/state?t=" + s.Token())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("state with token = %d, want 200", resp.StatusCode)
+	}
+	var snap node.Snapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	if snap.Station != "amber-fox" || len(snap.Rows) != 2 {
+		t.Fatalf("snapshot = %+v, want station amber-fox + 2 rows", snap)
+	}
+}
+
+func TestTokenViaHeader(t *testing.T) {
+	s := New(testCtrl())
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	req, _ := http.NewRequest("GET", srv.URL+"/api/state", nil)
+	req.Header.Set("X-Roger-Token", s.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("state with header token = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestStateNeverLeaksUpstreamKey(t *testing.T) {
+	s := New(testCtrl())
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/api/state?t=" + s.Token())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	buf := make([]byte, 1<<16)
+	n, _ := resp.Body.Read(buf)
+	if strings.Contains(string(buf[:n]), "sk-secret-leak-canary") {
+		t.Fatalf("state response leaked the upstream key:\n%s", buf[:n])
+	}
+}
+
+func TestStaticShellNoTokenNeeded(t *testing.T) {
+	s := New(testCtrl())
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET / = %d, want 200 (static shell loads without a token)", resp.StatusCode)
+	}
+}
+
+func TestEventsStream(t *testing.T) {
+	old := eventInterval
+	eventInterval = 20 * time.Millisecond
+	defer func() { eventInterval = old }()
+
+	s := New(testCtrl())
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api/events?t="+s.Token(), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("events content-type = %q, want text/event-stream", ct)
+	}
+	// Read the first SSE frame and assert it's a JSON snapshot.
+	sc := bufio.NewScanner(resp.Body)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "data: ") {
+			var snap node.Snapshot
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &snap); err != nil {
+				t.Fatalf("SSE frame not a snapshot: %v (%q)", err, line)
+			}
+			if snap.Station != "amber-fox" {
+				t.Fatalf("SSE snapshot station = %q, want amber-fox", snap.Station)
+			}
+			return
+		}
+	}
+	t.Fatal("no SSE data frame received")
+}
+
+func TestEventsRequiresToken(t *testing.T) {
+	s := New(testCtrl())
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/api/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("events without token = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestListenReturnsLocalhostURLWithToken(t *testing.T) {
+	s := New(testCtrl())
+	ln, url, err := s.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	if !strings.HasPrefix(url, "http://127.0.0.1:") || !strings.Contains(url, "?t="+s.Token()) {
+		t.Fatalf("Listen url = %q, want a 127.0.0.1 URL carrying the token", url)
+	}
+}

--- a/test/smoke/web_links_test.go
+++ b/test/smoke/web_links_test.go
@@ -49,8 +49,9 @@ func distDir(t *testing.T) string {
 	return filepath.Join(repoRoot(t), "web", "dist")
 }
 
-// versionRe pulls the value out of `const Version = "X.Y.Z"` in main.go.
-var versionRe = regexp.MustCompile(`(?m)^const Version = "([0-9][^"]*)"`)
+// versionRe pulls the value out of `const Version = "X.Y.Z"` (or `var Version = ...`,
+// since the version is now linker-stampable) in main.go.
+var versionRe = regexp.MustCompile(`(?m)^(?:const|var) Version = "([0-9][^"]*)"`)
 
 // TestManualMentionsCLIVersion is the sync guard: the built operating manual
 // (web/dist/manual.html) MUST mention the current CLI version from
@@ -65,7 +66,7 @@ func TestManualMentionsCLIVersion(t *testing.T) {
 	}
 	m := versionRe.FindSubmatch(mainGo)
 	if m == nil {
-		t.Fatal("could not find `const Version = \"...\"` in cmd/rogerai/main.go")
+		t.Fatal("could not find `const/var Version = \"...\"` in cmd/rogerai/main.go")
 	}
 	version := string(m[1])
 


### PR DESCRIPTION
## Stacked PR

Targets **`feat/keyed-local-upstreams`** (PR #1), not `main`. Review/merge that one first.

## What

A localhost **browser console** that complements the terminal TUI — both run at once and drive **one shared node**, so a model toggled on air in the browser flips the TUI row and vice-versa. **On by default**, `--no-webui` to opt out. Covers everything the TUI does on the operator/account/browse side **except the chat/channel**.

## How it's built (6 + 1 commits)

- **`feat(node)`** — `internal/node.Controller`: one mutex-guarded owner of the live share state (sessions, catalog, prices, private flags, station, upstream). The TUI was refactored to delegate to it (its share fields became a render cache synced each tick); behaviour-preserving — the TUI suite stays green.
- **`feat(webui)` server** — `go:embed` assets, **127.0.0.1-only**, per-run **token** on every `/api` (Jupyter model), `GET /api/state` + SSE `/api/events`. The snapshot never carries the upstream key.
- **write actions** — `POST /api/share/{onair,private,price,rename,detect}` → controller; **POST-only + token** (a GET can't mutate via `<img>`/`<script>`).
- **account + browse** — `/api/account`, login device-flow, logout, topup, limits, payouts, grants, `/api/browse` — reusing `internal/client` (two readers, `Discover` + `FetchBalance`, exported once). Login state is raise-only + an explicit `Logout` so the two front-ends don't clobber each other.
- **frontend** — vanilla embedded HTML/CSS/JS in the project's radio aesthetic (◉◌○, ◆, `▁▂▃▄▅▆▇█`); SHARE / ACCOUNT / BROWSE, live SSE with in-place reconcile, one-time frequency-code card. No chat.
- **`feat(cli)`** — bare `roger` builds one controller, starts the console over it (opens the browser, TTY-gated), then runs the TUI via `RunWithController`. `--no-webui` / `--webui` / `--webui-port=N` + `config.Webui`.
- **`build:`** — `main.Version` is now a var so betas stamp a semver via `-ldflags` (`make beta VERSION=4.8.0-beta.1`).

## Security

Localhost bind + per-run token gate every `/api` request and the SSE stream; writes are POST-only (no cross-site GET mutation); the upstream key is never serialized into a snapshot or relayed. Tests cover the token/CSRF/localhost guards and a key-leak canary.

## Tests

`internal/node` (incl. `-race` on concurrent toggles), `internal/webui` (token/method guards, key-leak canary, SSE, action round-trips asserting the shared controller changed, asset serving), and `internal/client` all pass. A live TCP smoke confirmed the embedded console serves and `/api/state` is 403 without the token / 200 with it.

Pre-existing, unrelated failures (`TestOnAirLock_*`, the history/input tests) reproduce identically on the parent commit.

## Known gap

Headless `roger share` doesn't auto-launch the console yet (the default lands on the interactive `roger` path) — a clean follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)