### PR TITLE
feat: web console polish — rogerai.fyi theme + detection fixes

### DIFF
--- a/cmd/rogerai/webconsole.go
+++ b/cmd/rogerai/webconsole.go
@@ -61,7 +61,9 @@ func startWebConsole(cfg config, ctrl *node.Controller, port string) {
 	// snapshot/SSE picks up whatever it finds, and re-detect can refine it.
 	go func() {
 		found, _ := ctrl.Detect("", "")
-		ctrl.LoadRows(found)
+		// No-persist: a passive launch scan populates the table for display but must NOT
+		// rewrite saved share config — that's reserved for an explicit re-detect.
+		ctrl.LoadRowsNoPersist(found)
 	}()
 	// Open the browser only on a real interactive terminal (the helper self-gates), so a
 	// headless `roger share` daemon prints the URL but never hijacks a browser.

--- a/cmd/rogerai/webconsole.go
+++ b/cmd/rogerai/webconsole.go
@@ -55,6 +55,14 @@ func startWebConsole(cfg config, ctrl *node.Controller, port string) {
 	}
 	fmt.Printf("web console → %s\n", url)
 	go func() { _ = s.Serve(ln) }()
+	// Kick an initial detection in the background so the browser SHARE tab is populated on
+	// first paint. The TUI only detects lazily (on entering SHARE), so without this a fresh
+	// launch would show an empty table until the user clicked re-detect. Best-effort; the
+	// snapshot/SSE picks up whatever it finds, and re-detect can refine it.
+	go func() {
+		found, _ := ctrl.Detect("", "")
+		ctrl.LoadRows(found)
+	}()
 	// Open the browser only on a real interactive terminal (the helper self-gates), so a
 	// headless `roger share` daemon prints the URL but never hijacks a browser.
 	tui.OpenURL(url)

--- a/internal/node/controller.go
+++ b/internal/node/controller.go
@@ -396,12 +396,25 @@ func (c *Controller) Rename(station string) {
 // Detect runs an async-safe local-LLM scan (used by the re-detect action). It does not
 // mutate the catalog; the caller passes the result to LoadRows.
 func (c *Controller) Detect(extra, key string) (found []detect.Found, needKey []string) {
-	if extra != "" {
-		if f, st := detect.ProbeKey(extra, key); st == detect.Reachable {
+	// A pasted URL+key takes priority; otherwise fall back to the saved/verified upstream
+	// (and its key). A bare DetectFull only scans the default ports + listening sockets, so
+	// without this a saved CUSTOM/keyed endpoint — the one the CLI finds because it seeds it
+	// — would be missed by re-detect, leaving the SHARE tab empty.
+	c.mu.Lock()
+	savedUp, savedKey := c.upstream, c.upstreamKey
+	c.mu.Unlock()
+	url, k := extra, key
+	if url == "" {
+		url, k = savedUp, savedKey
+	}
+	if url != "" {
+		if f, st := detect.ProbeKey(url, k); st == detect.Reachable {
 			return []detect.Found{f}, nil
 		}
 	}
-	return detect.DetectFull(extra)
+	// Seed the (saved or pasted) endpoint as a priority candidate so it wins de-dup, then
+	// scan the defaults — exactly the CLI's DetectFull path.
+	return detect.DetectFull(url)
 }
 
 // StopAll takes every model off air (clean exit / `/share off`).

--- a/internal/node/controller.go
+++ b/internal/node/controller.go
@@ -171,17 +171,24 @@ func (c *Controller) SetPrices(p map[string]Pricing) {
 	}
 }
 
-// LoadRows replaces the detected-model catalog from a detection scan. It also adopts
-// the headline upstream + key from the first server and persists a newly-verified
-// endpoint (mirrors the CLI's save in `roger share`), only on a real change so a
-// re-scan of the already-saved endpoint never rewrites config.
-func (c *Controller) LoadRows(found []detect.Found) {
+// LoadRows replaces the detected-model catalog from a detection scan. It adopts the
+// headline upstream + key from the first server and PERSISTS a newly-verified endpoint
+// (mirrors the CLI's save in `roger share`), only on a real change so a re-scan of the
+// already-saved endpoint never rewrites config. Use for an EXPLICIT user re-detect.
+func (c *Controller) LoadRows(found []detect.Found) { c.loadRows(found, true) }
+
+// LoadRowsNoPersist is LoadRows that NEVER writes the upstream to disk. Used for the
+// passive initial detection on web-console launch, so merely opening the console can't
+// silently rewrite share config — persistence is reserved for an explicit re-detect.
+func (c *Controller) LoadRowsNoPersist(found []detect.Found) { c.loadRows(found, false) }
+
+func (c *Controller) loadRows(found []detect.Found, persist bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(found) > 0 {
 		c.upstream = NormalizeUpstream(found[0].Chat)
 		c.upstreamKey = found[0].Key
-		if c.hooks.SaveUpstream != nil && found[0].BaseURL != "" &&
+		if persist && c.hooks.SaveUpstream != nil && found[0].BaseURL != "" &&
 			(found[0].BaseURL != c.savedUp || found[0].Key != c.savedKey) {
 			c.savedUp, c.savedKey = found[0].BaseURL, found[0].Key
 			c.hooks.SaveUpstream(found[0].BaseURL, found[0].Key)

--- a/internal/node/controller_test.go
+++ b/internal/node/controller_test.go
@@ -178,6 +178,29 @@ func TestLoadRowsFlattensAndPersistsUpstream(t *testing.T) {
 	}
 }
 
+// TestLoadRowsNoPersistDoesNotWrite: the passive launch scan populates rows but must NOT
+// rewrite saved config; an explicit LoadRows still persists a newly-verified endpoint.
+func TestLoadRowsNoPersistDoesNotWrite(t *testing.T) {
+	saved := 0
+	c := New(Config{Station: "amber-fox", Hooks: Hooks{SaveUpstream: func(u, k string) { saved++ }}})
+	found := []detect.Found{{
+		BaseURL: "http://127.0.0.1:9001/v1", Chat: "http://127.0.0.1:9001/v1/chat/completions",
+		Models: []string{"m"},
+	}}
+	c.LoadRowsNoPersist(found)
+	if saved != 0 {
+		t.Fatalf("LoadRowsNoPersist must not persist; SaveUpstream called %d times", saved)
+	}
+	if len(c.Rows()) != 1 {
+		t.Fatalf("LoadRowsNoPersist should still populate rows; got %d", len(c.Rows()))
+	}
+	// An explicit re-detect DOES persist the (still-unsaved) endpoint, exactly once.
+	c.LoadRows(found)
+	if saved != 1 {
+		t.Fatalf("LoadRows should persist a new endpoint once; got %d", saved)
+	}
+}
+
 // TestDetectFallsBackToSavedUpstream: with no pasted URL, Detect probes the saved/verified
 // upstream first — so a custom/non-default endpoint (the one the CLI seeds) is found instead
 // of the SHARE tab staying empty after a bare port scan.

--- a/internal/node/controller_test.go
+++ b/internal/node/controller_test.go
@@ -178,6 +178,34 @@ func TestLoadRowsFlattensAndPersistsUpstream(t *testing.T) {
 	}
 }
 
+// TestDetectFallsBackToSavedUpstream: with no pasted URL, Detect probes the saved/verified
+// upstream first — so a custom/non-default endpoint (the one the CLI seeds) is found instead
+// of the SHARE tab staying empty after a bare port scan.
+func TestDetectFallsBackToSavedUpstream(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/models") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{"id": "saved-model"}}})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := New(Config{Station: "amber-fox", Upstream: srv.URL}) // the saved upstream
+	found, _ := c.Detect("", "")                              // re-detect with no pasted URL
+	got := false
+	for _, f := range found {
+		for _, m := range f.Models {
+			if m == "saved-model" {
+				got = true
+			}
+		}
+	}
+	if !got {
+		t.Fatalf("Detect() should probe the saved upstream and find its model; got %+v", found)
+	}
+}
+
 // TestConcurrentToggle exercises the lock: two front-ends (the TUI goroutine and the
 // web server) toggling the same node concurrently must never race. Run with -race.
 func TestConcurrentToggle(t *testing.T) {

--- a/internal/webui/assets/console.css
+++ b/internal/webui/assets/console.css
@@ -1,297 +1,997 @@
-/* ============================================================================
-   Roger node console — console.css
-   Restrained, mostly-white, one warm accent, monospace for data/callsigns.
-   No external fonts/assets. Sections:
-     1. Tokens / theme        5. Tables
-     2. Reset / base          6. Cards / account
-     3. Layout / topbar       7. Code card / login flow
-     4. Buttons / inputs      8. Modals / toasts
-     9. Dark mode  10. Reduced motion  11. Responsive
-   ========================================================================== */
+/* =====================================================================
+   Roger - console.css : the embedded "node console", restyled to the
+   rogerai.fyi design system ("The Live Operating Manual").
 
-/* 1. TOKENS ---------------------------------------------------------------- */
-:root {
-  --accent: #d9531e;          /* warm radio orange — the one accent */
-  --accent-soft: #fbe6db;
-  --amber: #c4880a;           /* connecting / warn */
-  --gold: #b8860b;            /* verified lineage */
-  --green: #1f9d55;           /* online / good */
-  --red: #c5341f;
+   ~95% warm monochrome + EXACTLY ONE accent: the red on-air beacon
+   (var(--live), #E0231C). Color is a SIGNAL, never a surface - red shows
+   up only as small glints: the on-air dot, the live-link dot, focus rings,
+   the active-tab underline, the primary action, an over-cap warning.
 
-  --bg: #ffffff;
-  --bg-soft: #faf9f7;
-  --panel: #ffffff;
-  --ink: #1b1b1a;
-  --ink-soft: #5c5a55;
-  --muted: #8b8880;
-  --line: #e7e4de;
-  --line-strong: #d6d2c9;
+   This view is SELF-CONTAINED / OFFLINE: only tokens.css is loaded before
+   it (no base.css / account-base.css, no webfont CDN). So the handful of
+   shared primitives the site keeps in those modules - the reset, the flat
+   hairline plate, the §-marker headings, the stat/receipt rows, the ghost
+   + one-solid button voice, the mono table - are re-expressed here in the
+   same token vocabulary. Type relies on the --font-ui / --font-mono family
+   stacks' system fallbacks (Space Grotesk / JetBrains Mono if installed).
 
-  --shadow: 0 1px 3px rgba(0,0,0,.06), 0 6px 24px rgba(0,0,0,.05);
-  --radius: 10px;
-  --radius-sm: 6px;
+   Sections:
+     0. Local alias + dark-mode token re-apply
+     1. Reset / base / utilities
+     2. Auth gate (locked plate)
+     3. Topbar : brand, callsign, slot meter, live-link, tabs
+     4. Content + panels + §-marker headings
+     5. SHARE : totals, login warn, frequency-code card
+     6. Tables : the lineage / market log (share + browse)
+     7. Status beacons : dots, labels, signal bars, verified lineage
+     8. ACCOUNT : plates, balance meter, session, payouts, grants
+     9. Controls : buttons, inputs, link/x buttons, checkboxes
+    10. Modals + fields
+    11. Toasts
+    12. Responsive + reduced motion
+   ===================================================================== */
 
-  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo,
-          Consolas, "Liberation Mono", monospace;
-  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-}
+/* =====================================================================
+   0. LOCAL ALIAS + DARK MODE
+   ===================================================================== */
 
-/* 2. RESET / BASE ---------------------------------------------------------- */
-* { box-sizing: border-box; }
-html, body { height: 100%; }
-body {
-  margin: 0;
-  font-family: var(--sans);
-  font-size: 14px;
-  line-height: 1.45;
-  color: var(--ink);
-  background: var(--bg-soft);
-  -webkit-font-smoothing: antialiased;
-}
-h1, h2, h3 { font-weight: 600; margin: 0; letter-spacing: .01em; }
-a { color: var(--accent); }
-.mono { font-family: var(--mono); }
-.muted { color: var(--muted); }
-.small { font-size: 12px; }
-code { font-family: var(--mono); }
-[hidden] { display: none !important; }
+/* console.js writes an inline `border-left: 3px solid var(--accent)` on a
+   freshly-revealed grant secret. Map that legacy name onto the one red so
+   the glint stays on-system without touching the JS. */
+:root { --accent: var(--live); }
 
-/* 3. LAYOUT / TOPBAR ------------------------------------------------------- */
-.app { display: flex; flex-direction: column; min-height: 100%; }
-
-.topbar {
-  display: flex; align-items: center; gap: 16px;
-  padding: 10px 22px;
-  background: var(--bg);
-  border-bottom: 1px solid var(--line);
-  position: sticky; top: 0; z-index: 20;
-}
-.topbar-left { display: flex; align-items: center; gap: 12px; }
-.topbar-right { margin-left: auto; }
-.brand-mark {
-  font-family: var(--mono);
-  font-weight: 700;
-  letter-spacing: .04em;
-  color: var(--accent);
-}
-.brand-mark::before { content: "◉ "; font-weight: 400; }
-.station-callsign { color: var(--ink-soft); font-size: 13px; }
-
-.slot-meter { font-size: 12px; color: var(--ink-soft); display: inline-flex; gap: 6px; align-items: center; }
-.slot-meter .dot-on { color: var(--accent); }
-.slot-meter.big { font-size: 13px; letter-spacing: .05em; }
-.slot-meter.big b { color: var(--accent); font-family: var(--mono); }
-
-.tabs { display: flex; gap: 4px; margin-left: 8px; }
-.tab {
-  font: inherit; font-size: 12px; letter-spacing: .08em;
-  padding: 7px 14px; border: 0; background: transparent;
-  color: var(--muted); cursor: pointer; border-radius: var(--radius-sm);
-}
-.tab:hover { color: var(--ink); background: var(--bg-soft); }
-.tab[aria-selected="true"] { color: var(--accent); background: var(--accent-soft); font-weight: 600; }
-
-.conn { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: var(--muted); }
-.conn-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--muted); }
-.conn.live .conn-dot { background: var(--green); }
-.conn.down .conn-dot { background: var(--red); }
-
-.content { width: 100%; max-width: 1180px; margin: 0 auto; padding: 24px 22px 64px; flex: 1; }
-
-.panel-head { margin-bottom: 18px; }
-.panel-head-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
-.panel-head h2 { font-size: 13px; letter-spacing: .14em; color: var(--ink-soft); display: inline-flex; align-items: baseline; gap: 10px; }
-.panel-head-actions { display: flex; align-items: center; gap: 12px; }
-.callsign-edit { font-size: 16px; color: var(--ink); letter-spacing: 0; }
-.totals { margin-top: 8px; font-size: 12px; color: var(--ink-soft); }
-.login-warn {
-  margin-top: 10px; padding: 8px 12px; font-size: 12px;
-  background: #fff8ec; border: 1px solid #f0e2c4; border-radius: var(--radius-sm);
-  color: #7a5a12;
-}
-
-/* 4. BUTTONS / INPUTS ------------------------------------------------------ */
-.btn {
-  font: inherit; font-size: 12px; letter-spacing: .02em;
-  padding: 6px 12px; border-radius: var(--radius-sm);
-  border: 1px solid var(--line-strong); background: var(--bg); color: var(--ink);
-  cursor: pointer; white-space: nowrap; transition: background .12s, border-color .12s;
-}
-.btn:hover { background: var(--bg-soft); border-color: var(--muted); }
-.btn:active { transform: translateY(1px); }
-.btn[disabled] { opacity: .5; cursor: not-allowed; }
-.btn.small { padding: 4px 9px; font-size: 11px; }
-.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
-.btn.primary:hover { background: #c2491a; }
-.btn.ghost { background: transparent; border-color: var(--line); color: var(--ink-soft); }
-.btn.warn { color: var(--red); border-color: #e6c1ba; }
-
-.link-btn {
-  font: inherit; font-size: 12px; padding: 0; border: 0; background: none;
-  color: var(--accent); cursor: pointer; text-decoration: underline; text-underline-offset: 2px;
-}
-.link-btn:hover { color: #a93d14; }
-
-.inp {
-  font: inherit; font-size: 13px; padding: 6px 9px;
-  border: 1px solid var(--line-strong); border-radius: var(--radius-sm);
-  background: var(--bg); color: var(--ink); width: 100%;
-}
-.inp:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
-.inp.small { width: 110px; }
-.chk { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: var(--ink-soft); }
-
-/* 5. TABLES ---------------------------------------------------------------- */
-.table-wrap { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); overflow-x: auto; }
-.data-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-.data-table th {
-  text-align: left; font-weight: 600; font-size: 10.5px; letter-spacing: .1em;
-  color: var(--muted); padding: 11px 14px; border-bottom: 1px solid var(--line);
-  white-space: nowrap; background: var(--bg-soft);
-}
-.data-table td { padding: 11px 14px; border-bottom: 1px solid var(--line); vertical-align: middle; }
-.data-table tr:last-child td { border-bottom: 0; }
-.data-table tbody tr:hover { background: #fcfbf9; }
-.data-table .num { text-align: right; font-variant-numeric: tabular-nums; font-family: var(--mono); }
-.empty-row td { color: var(--muted); text-align: center; padding: 26px; font-style: italic; }
-
-.cell-model { display: flex; align-items: center; gap: 9px; }
-.cell-model .model-name { font-family: var(--mono); font-weight: 500; }
-.cell-model .ctx { color: var(--muted); font-size: 11px; }
-
-.status-dot { font-size: 13px; line-height: 1; }
-.status-dot.on { color: var(--accent); }
-.status-dot.connecting { color: var(--amber); }
-.status-dot.off { color: var(--muted); }
-
-.status-label { font-size: 11px; letter-spacing: .08em; font-weight: 600; }
-.status-label.on { color: var(--accent); }
-.status-label.connecting { color: var(--amber); }
-.status-label.off { color: var(--muted); }
-.status-label.private { color: var(--gold); }
-
-.price-cell .sched { color: var(--muted); font-size: 11px; }
-.price-cell .free { color: var(--green); font-weight: 600; }
-
-.row-actions { display: flex; gap: 6px; justify-content: flex-end; flex-wrap: wrap; }
-
-/* signal meter — drawn from block glyphs */
-.signal { font-family: var(--mono); letter-spacing: -1px; }
-.signal.s-low { color: var(--muted); }
-.signal.s-mid { color: var(--ink-soft); }
-.signal.s-high { color: var(--green); }
-.verified { color: var(--gold); }
-.online-dot { font-size: 11px; }
-.online-dot.on { color: var(--green); }
-.online-dot.off { color: var(--muted); }
-
-/* 6. CARDS / ACCOUNT ------------------------------------------------------- */
-.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
-.card {
-  background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
-  padding: 18px; box-shadow: var(--shadow); display: flex; flex-direction: column; gap: 12px;
-}
-.card-title { font-size: 10.5px; letter-spacing: .12em; color: var(--muted); font-weight: 600; }
-.big-figure { font-size: 30px; font-weight: 600; letter-spacing: -.01em; }
-.meter-line { display: flex; flex-direction: column; gap: 5px; }
-.meter { height: 7px; background: var(--bg-soft); border: 1px solid var(--line); border-radius: 99px; overflow: hidden; }
-.meter-fill { height: 100%; width: 0; background: var(--accent); transition: width .3s ease; }
-.meter-fill.over { background: var(--red); }
-.card-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-.kv { display: flex; justify-content: space-between; gap: 12px; font-size: 13px; }
-.kv span { color: var(--muted); }
-.grant-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; max-height: 160px; overflow-y: auto; }
-.grant-list li { padding: 4px 0; border-bottom: 1px dashed var(--line); }
-.history { white-space: pre-wrap; background: var(--bg-soft); border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 10px; max-height: 200px; overflow-y: auto; }
-.not-configured { margin-top: 18px; padding: 14px 16px; background: var(--bg-soft); border: 1px dashed var(--line-strong); border-radius: var(--radius); color: var(--ink-soft); font-size: 13px; }
-
-/* 7. CODE CARD / LOGIN FLOW ------------------------------------------------ */
-.code-card {
-  display: flex; align-items: flex-start; gap: 12px; margin-bottom: 18px;
-  padding: 14px 16px; background: linear-gradient(180deg, #fff8f2, #fff);
-  border: 1px solid var(--accent); border-radius: var(--radius); box-shadow: var(--shadow);
-}
-.code-card-body { flex: 1; }
-.code-card-title { font-size: 12px; color: var(--ink-soft); margin-bottom: 8px; }
-.code-card-title b { color: var(--accent); }
-.code-row { display: flex; align-items: center; gap: 10px; }
-.code-value { font-size: 16px; padding: 6px 10px; background: var(--bg-soft); border: 1px solid var(--line-strong); border-radius: var(--radius-sm); word-break: break-all; }
-.code-value.big { font-size: 22px; letter-spacing: .12em; }
-.x-btn { font: inherit; font-size: 20px; line-height: 1; border: 0; background: none; color: var(--muted); cursor: pointer; padding: 0 4px; }
-.x-btn:hover { color: var(--ink); }
-
-.login-flow { margin-top: 12px; padding: 12px; background: var(--bg-soft); border: 1px solid var(--line); border-radius: var(--radius-sm); }
-.spinner-line { display: flex; align-items: center; gap: 8px; margin-top: 10px; color: var(--ink-soft); font-size: 12px; }
-.spinner { width: 13px; height: 13px; border: 2px solid var(--line-strong); border-top-color: var(--accent); border-radius: 50%; animation: spin .8s linear infinite; }
-@keyframes spin { to { transform: rotate(360deg); } }
-
-/* 8. MODALS / TOASTS ------------------------------------------------------- */
-.modal-backdrop {
-  position: fixed; inset: 0; background: rgba(20,18,16,.4);
-  display: flex; align-items: center; justify-content: center; z-index: 50; padding: 20px;
-}
-.modal {
-  background: var(--bg); border-radius: var(--radius); box-shadow: var(--shadow);
-  padding: 22px; width: 100%; max-width: 420px; display: flex; flex-direction: column; gap: 14px;
-}
-.modal.wide { max-width: 560px; }
-.modal h3 { font-size: 15px; }
-.field { display: flex; flex-direction: column; gap: 5px; font-size: 12px; color: var(--ink-soft); }
-.modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; }
-.price-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-.windows-head { display: flex; justify-content: space-between; align-items: center; font-size: 11px; letter-spacing: .08em; color: var(--muted); border-top: 1px solid var(--line); padding-top: 12px; }
-.windows { display: flex; flex-direction: column; gap: 8px; }
-.window-row { display: grid; grid-template-columns: 1fr 1fr 1fr auto auto; gap: 6px; align-items: center; }
-.window-row .inp { font-size: 12px; padding: 5px 7px; }
-.window-row .chk { font-size: 11px; }
-
-.toasts { position: fixed; right: 18px; bottom: 18px; z-index: 60; display: flex; flex-direction: column; gap: 8px; max-width: 360px; }
-.toast {
-  padding: 11px 14px; border-radius: var(--radius-sm); font-size: 13px;
-  background: var(--ink); color: #fff; box-shadow: var(--shadow);
-  animation: toast-in .18s ease; border-left: 3px solid var(--accent);
-}
-.toast.err { border-left-color: var(--red); }
-.toast.ok { border-left-color: var(--green); }
-.toast.warn { border-left-color: var(--amber); }
-@keyframes toast-in { from { opacity: 0; transform: translateY(8px); } }
-
-/* AUTH GATE */
-.auth-gate { display: flex; align-items: center; justify-content: center; min-height: 100vh; padding: 24px; }
-.auth-card { max-width: 460px; text-align: center; background: var(--bg); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); padding: 40px 32px; }
-.auth-card h1 { font-size: 20px; margin: 14px 0 10px; }
-.auth-card p { color: var(--ink-soft); }
-.auth-card .brand-mark { font-size: 18px; }
-
-/* 9. DARK MODE ------------------------------------------------------------- */
+/* The console has no theme toggle / JS to set data-theme, so honor the OS
+   preference directly: re-apply tokens.css's [data-theme="dark"] values to
+   :root. Values mirror the dark block in tokens.css verbatim; same
+   single-accent discipline. */
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #171614; --bg-soft: #1f1d1a; --panel: #1c1a18;
-    --ink: #ece9e3; --ink-soft: #b6b1a8; --muted: #837e74;
-    --line: #2e2b27; --line-strong: #403c36;
-    --accent-soft: #3a241a;
-    --shadow: 0 1px 3px rgba(0,0,0,.4), 0 8px 28px rgba(0,0,0,.35);
+    --white:      #1C1A14;
+    --paper:      #0E0D0B;
+    --paper-2:    #16140F;
+    --paper-3:    #1F1C16;
+    --hairline:   #2A2720;
+    --hairline-2: #38342B;
+
+    --ink-900:    #F3F1EA;
+    --ink-700:    #D7D3C8;
+    --ink-500:    #9A968B;
+    --ink-400:    #7A766B;
+    --ink-300:    #555148;
+
+    --live:       #FF4438;
+    --live-tint:  rgba(255, 68, 56, 0.16);
+    --live-glow:  rgba(255, 68, 56, 0.32);
+    --live-wash:  rgba(255, 68, 56, 0.14);
+
+    --glass:      rgba(14, 13, 11, 0.82);
+    --glass-soft: rgba(14, 13, 11, 0.55);
+
+    color-scheme: dark;
   }
-  body { background: #121110; }
-  .data-table th { background: #211f1c; }
-  .data-table tbody tr:hover { background: #211f1c; }
-  .code-card { background: linear-gradient(180deg, #2a1d16, #1c1a18); }
-  .login-warn { background: #2a2316; border-color: #463a1f; color: #d8b86a; }
-  .toast { background: #2a2724; }
 }
 
-/* 10. REDUCED MOTION ------------------------------------------------------- */
-@media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after { animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; }
+/* =====================================================================
+   1. RESET / BASE / UTILITIES
+   ===================================================================== */
+*, *::before, *::after { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: var(--t-body);
+  line-height: var(--lh-body);
+  color: var(--ink-700);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-/* 11. RESPONSIVE ----------------------------------------------------------- */
-@media (max-width: 720px) {
-  .topbar { flex-wrap: wrap; gap: 10px; padding: 10px 14px; }
-  .topbar-right { margin-left: 0; }
-  .content { padding: 18px 14px 56px; }
-  .tabs { order: 3; width: 100%; }
-  .tab { flex: 1; }
+h1, h2, h3, p { margin: 0; }
+button { font: inherit; cursor: pointer; border: 0; background: none; color: inherit; }
+code { font-family: var(--font-mono); }
+[hidden] { display: none !important; }
+::selection { background: var(--live); color: var(--paper); }
+
+noscript {
+  display: block;
+  padding: var(--s-4) var(--gutter);
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  color: var(--ink-500);
+}
+
+/* machine truth: tabular mono numerals everywhere a figure is set. */
+.mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums slashed-zero;
+  font-feature-settings: "tnum" 1, "zero" 1;
+  letter-spacing: -0.01em;
+}
+.muted { color: var(--ink-400); }
+.small { font-size: var(--t-xs); }
+
+/* focus discipline: the one red ring, shared by every interactive node. */
+:focus-visible { outline: 2px solid var(--live); outline-offset: 2px; }
+
+/* =====================================================================
+   2. AUTH GATE - the "console locked" plate (one flat hairline frame).
+   ===================================================================== */
+.auth-gate {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: var(--s-12) var(--gutter);
+}
+.auth-card {
+  width: 100%;
+  max-width: 460px;
+  border: 1px solid var(--hairline-2);
+  border-radius: var(--r-sm);
+  background: var(--paper);
+  padding: var(--s-10) clamp(var(--s-6), 5vw, var(--s-10));
+}
+.auth-card .brand-mark { margin-bottom: var(--s-5); }
+.auth-card h1 {
+  font-size: var(--t-h2);
+  font-weight: var(--weight-semi);
+  letter-spacing: var(--tracking-h2);
+  color: var(--ink-900);
+  line-height: var(--lh-snug);
+  margin-bottom: var(--s-4);
+}
+.auth-card p { color: var(--ink-500); font-size: var(--t-sm); margin-bottom: var(--s-3); }
+.auth-card code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  background: var(--paper-2);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-sm);
+  padding: 1px 6px;
+  color: var(--ink-900);
+}
+
+/* the wordmark: grotesk, ink, with one live-red beacon dot for "on air". */
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-ui);
+  font-weight: var(--weight-bold);
+  font-size: var(--t-h3);
+  letter-spacing: -0.01em;
+  color: var(--ink-900);
+}
+.brand-mark::after {
+  content: "";
+  width: 6px; height: 6px;
+  margin-left: 4px;
+  border-radius: 50%;
+  background: var(--live);
+  box-shadow: 0 0 0 3px var(--live-wash);
+  animation: beat var(--carrier) var(--ease-in-out) infinite;
+}
+
+/* =====================================================================
+   3. TOPBAR - the restrained nav voice: mono labels, hairline rule, a
+   frosted glass backing, the live-link + slot beacons.
+   ===================================================================== */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-nav);
+  display: flex;
+  align-items: center;
+  gap: var(--s-5);
+  flex-wrap: wrap;
+  padding: var(--s-3) var(--gutter);
+  background: var(--glass);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--hairline);
+}
+.topbar-left {
+  display: flex;
+  align-items: baseline;
+  gap: var(--s-3);
+  min-width: 0;
+}
+.topbar-left .brand-mark { font-size: var(--t-lead); }
+
+/* station callsign: machine truth, mono, primary ink. */
+.station-callsign {
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  color: var(--ink-700);
+  letter-spacing: -0.01em;
+}
+
+/* topbar slot meter: ◉ red on-air glyph + n/n mono reading. */
+.slot-meter {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-1);
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  color: var(--ink-500);
+  font-variant-numeric: tabular-nums;
+}
+.slot-meter .dot-on { color: var(--live); font-size: 0.7em; line-height: 1; }
+
+/* the big share-header slot reading. */
+.slot-meter.big {
+  font-size: var(--t-micro);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-400);
+  font-weight: var(--weight-medium);
+}
+.slot-meter.big b {
+  font-size: var(--t-sm);
+  letter-spacing: -0.01em;
+  color: var(--ink-900);
+  font-weight: var(--weight-semi);
+}
+
+/* ---- tabs : SHARE / ACCOUNT / BROWSE - mono, the active one underlined
+   in the one red. ---- */
+.tabs {
+  display: flex;
+  align-items: stretch;
+  gap: var(--s-5);
+  margin-left: auto;
+}
+.tab {
+  position: relative;
+  padding: var(--s-2) 2px;
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-500);
+  transition: color var(--d-2) var(--ease-standard);
+}
+.tab:hover { color: var(--ink-900); }
+.tab[aria-selected="true"] { color: var(--ink-900); }
+.tab::after {
+  content: "";
+  position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 2px;
+  background: var(--live);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--d-2) var(--ease-out-quint);
+}
+.tab[aria-selected="true"]::after { transform: scaleX(1); }
+
+/* ---- the live-link beacon : on air = red, connecting/reconnecting =
+   a MONOCHROME pulsing ink dot (per the one-red rule, never amber). ---- */
+.topbar-right { display: inline-flex; align-items: center; }
+.conn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  font-family: var(--font-mono);
+  font-size: var(--t-micro);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-400);
+}
+.conn-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--ink-300);
+  /* default state = connecting : a muted ink pulse. */
+  animation: pulse var(--carrier) var(--ease-in-out) infinite;
+}
+.conn.live { color: var(--ink-700); }
+.conn.live .conn-dot {
+  background: var(--live);
+  box-shadow: 0 0 0 3px var(--live-wash);
+  animation: beat var(--carrier) var(--ease-in-out) infinite;
+}
+.conn.down .conn-dot { background: var(--ink-400); }
+
+/* =====================================================================
+   4. CONTENT + PANELS + §-MARKER HEADINGS
+   ===================================================================== */
+.content {
+  width: 100%;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: var(--s-8) var(--gutter) var(--s-16);
+}
+.panel { margin: 0; }
+
+.panel-head { margin-bottom: var(--s-5); }
+.panel-head-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--s-4);
+  flex-wrap: wrap;
+}
+.panel-head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-4);
+  flex-wrap: wrap;
+}
+
+/* §-marker register: a mono, tracked, uppercase title preceded by the one
+   short red rule (mirrors account-base.css .card h2 / .sectionno). */
+.panel-head h2 {
+  display: flex;
+  align-items: baseline;
+  gap: var(--s-3);
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: var(--t-micro);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-400);
+  line-height: 1.4;
+}
+.panel-head h2::before {
+  content: "";
+  align-self: center;
+  width: 18px; height: 2px;
+  background: var(--live);
+  flex: none;
+}
+/* the station callsign sitting in the SHARE heading: mono, primary ink. */
+.callsign-edit {
+  font-family: var(--font-mono);
+  font-size: var(--t-body);
+  font-weight: var(--weight-medium);
+  letter-spacing: -0.01em;
+  color: var(--ink-900);
+  text-transform: none;
+}
+
+/* =====================================================================
+   5. SHARE : totals line, login warning, frequency-code card
+   ===================================================================== */
+
+/* totals: a printed spec line - mono, dotted with middots, tertiary ink. */
+.totals {
+  margin-top: var(--s-4);
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  font-variant-numeric: tabular-nums slashed-zero;
+  color: var(--ink-700);
+  line-height: 1.6;
+}
+.totals .muted { color: var(--ink-400); }
+
+/* login warning : a flat hairline plate with a single red left rule
+   (the manual's caution call-out, not a yellow SaaS banner). */
+.login-warn {
+  margin-top: var(--s-4);
+  padding: var(--s-3) var(--s-4);
+  border: 1px solid var(--hairline-2);
+  border-left: 2px solid var(--live);
+  border-radius: var(--r-sm);
+  background: var(--paper-2);
+  font-size: var(--t-sm);
+  color: var(--ink-700);
+}
+
+/* frequency-code card : the "shown once" secret - paper-3 fill, hairline
+   frame, square, the copy-line register. */
+.code-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--s-3);
+  margin-top: var(--s-5);
+  padding: var(--s-4);
+  background: var(--paper-3);
+  border: 1px solid var(--hairline-2);
+  border-left: 2px solid var(--live);
+  border-radius: var(--r-md);
+}
+.code-card-body { flex: 1 1 auto; min-width: 0; }
+.code-card-title {
+  font-family: var(--font-mono);
+  font-size: var(--t-micro);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-500);
+  margin-bottom: var(--s-2);
+}
+.code-card-title b { color: var(--ink-900); font-weight: var(--weight-semi); }
+.code-row {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  flex-wrap: wrap;
+}
+.code-value {
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  color: var(--ink-900);
+  word-break: break-all;
+  background: var(--paper);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-sm);
+  padding: 4px 8px;
+}
+.code-value.big { font-size: var(--t-h3); letter-spacing: 0.04em; }
+.code-band {
+  margin-top: var(--s-2);
+  font-family: var(--font-mono);
+  color: var(--ink-400);
+}
+
+/* =====================================================================
+   6. TABLES : the lineage / market log (share + browse). Mono,
+   tabular-nums, hairline row rules, right-aligned numeric columns -
+   the account console's receipt/log register.
+   ===================================================================== */
+.table-wrap {
+  margin-top: var(--s-5);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  font-variant-numeric: tabular-nums slashed-zero;
+}
+.data-table th,
+.data-table td {
+  padding: var(--s-2) var(--s-3);
+  border-top: 1px solid var(--hairline);
+  text-align: left;
+  white-space: nowrap;
+  vertical-align: baseline;
+}
+.data-table thead th {
+  border-top: 0;
+  border-bottom: 1px solid var(--hairline-2);
+  font-size: var(--t-micro);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-400);
+}
+.data-table td.num,
+.data-table th.num { text-align: right; }
+
+/* numeric body cells: tabular mono, money in primary ink + weight. */
+.data-table td.served,
+.data-table td.outtok { color: var(--ink-700); }
+.data-table td.earnings { color: var(--ink-900); font-weight: var(--weight-medium); }
+
+/* model cell: dot + name (+ ctx caption). */
+.cell-model { color: var(--ink-900); }
+.model-name {
+  font-family: var(--font-mono);
+  color: var(--ink-900);
+  letter-spacing: -0.01em;
+}
+.ctx { color: var(--ink-400); font-size: var(--t-xs); }
+
+/* price cell. */
+.price-cell { color: var(--ink-700); }
+.price-cell .free,
+.free {
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-500);
+}
+.sched { color: var(--ink-400); font-size: var(--t-xs); }
+
+/* empty / loading row: quiet, centered, in the UI face (not mono). */
+.empty-row td {
+  color: var(--ink-400);
+  text-align: center;
+  font-family: var(--font-ui);
+  padding: var(--s-8) var(--s-3);
+  white-space: normal;
+}
+.empty-row b { color: var(--ink-700); font-weight: var(--weight-medium); }
+
+/* per-row actions live in the last column. */
+.row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  flex-wrap: wrap;
+}
+
+/* =====================================================================
+   7. STATUS BEACONS : dots, labels, signal bars, verified lineage.
+   The whole accent budget lives here - red ONLY for on-air; every other
+   state is warm ink, monochrome.
+   ===================================================================== */
+
+/* share-table status dot: ◉ on-air (red) / ◌ connecting (ink pulse) /
+   ○ off (ink-300). */
+.status-dot {
+  font-size: 0.78em;
+  line-height: 1;
+  margin-right: 4px;
+}
+.status-dot.on { color: var(--live); }
+.status-dot.connecting {
+  color: var(--ink-500);
+  animation: pulse var(--carrier) var(--ease-in-out) infinite;
+}
+.status-dot.off { color: var(--ink-300); }
+
+/* status label: mono, tracked, uppercase. On-air wears the one red. */
+.status-label {
+  font-family: var(--font-mono);
+  font-size: var(--t-micro);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  font-weight: var(--weight-medium);
+}
+.status-label.on { color: var(--live); }
+.status-label.connecting { color: var(--ink-500); }
+.status-label.private { color: var(--ink-500); }
+.status-label.off { color: var(--ink-400); }
+
+/* browse online dot: ◉ live on the market (red) / ○ off (ink-300). */
+.online-dot { font-size: 0.78em; line-height: 1; margin-right: 4px; }
+.online-dot.on { color: var(--live); }
+.online-dot.off { color: var(--ink-300); }
+
+/* verified lineage ◆ : sober ink (the --gold lineage collapses to ink). */
+.verified { color: var(--ink-700); }
+
+/* signal bars ▁▂▃▄▅▆▇█ : kept monochrome, weighted by strength in ink. */
+.signal {
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+}
+.signal.s-low  { color: var(--ink-400); }
+.signal.s-mid  { color: var(--ink-500); }
+.signal.s-high { color: var(--ink-900); }
+
+/* =====================================================================
+   8. ACCOUNT : flat hairline plates, balance meter, session, payouts,
+   grants. Mirrors account-base.css (.card, .stats, .kv rows).
+   ===================================================================== */
+.cards {
+  margin-top: var(--s-5);
+  display: grid;
+  gap: var(--s-5);
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+/* each plate: a single hairline frame, square corners, no shadow. */
+.card {
+  border: 1px solid var(--hairline-2);
+  border-radius: var(--r-sm);
+  background: var(--paper);
+  padding: var(--s-6);
+}
+
+/* plate title: the §-marker register (mono, tracked, one red rule). */
+.card-title {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  font-family: var(--font-mono);
+  font-size: var(--t-micro);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-400);
+  margin-bottom: var(--s-4);
+}
+.card-title::before {
+  content: "";
+  width: 14px; height: 2px;
+  background: var(--live);
+  flex: none;
+}
+
+/* the big balance figure: mono, tabular, primary ink (a stat reading). */
+.big-figure {
+  font-family: var(--font-mono);
+  font-size: 1.9rem;
+  font-weight: var(--weight-medium);
+  font-variant-numeric: tabular-nums slashed-zero;
+  letter-spacing: -0.01em;
+  color: var(--ink-900);
+  line-height: 1.1;
+}
+
+/* spend meter: ink fill on a paper-3 track; red only when over the cap. */
+.meter-line { margin-top: var(--s-3); }
+.meter {
+  height: 6px;
+  border-radius: var(--r-pill);
+  background: var(--paper-3);
+  border: 1px solid var(--hairline);
+  overflow: hidden;
+}
+.meter-fill {
+  height: 100%;
+  width: 0;
+  background: var(--ink-700);
+  border-radius: inherit;
+  transition: width var(--d-3) var(--ease-out-quint);
+}
+.meter-fill.over { background: var(--live); }
+.meter-line .small { margin-top: var(--s-2); color: var(--ink-400); }
+
+/* key/value rows: mono uppercase key + mono reading, on hairlines. */
+.kv {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--s-3);
+  padding: var(--s-2) 0;
+  border-top: 1px solid var(--hairline);
+  font-size: var(--t-sm);
+}
+.kv:first-of-type { border-top: 0; }
+.kv > span {
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-400);
+}
+.kv > b {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums slashed-zero;
+  color: var(--ink-900);
+  font-weight: var(--weight-medium);
+}
+
+/* a horizontal control cluster inside a plate. */
+.card-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  flex-wrap: wrap;
+  margin-top: var(--s-4);
+}
+
+/* session: lead copy + the device-flow block. */
+#card-session p { font-size: var(--t-sm); color: var(--ink-500); margin-bottom: var(--s-3); }
+#card-session p a { color: var(--live); border-bottom: 1px solid var(--live); }
+#acct-login-state {
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  color: var(--ink-700);
+  margin-bottom: var(--s-3);
+}
+.login-flow { margin-top: var(--s-3); }
+.spinner-line {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  margin-top: var(--s-3);
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  color: var(--ink-400);
+}
+.spinner {
+  width: 12px; height: 12px;
+  border: 2px solid var(--hairline-2);
+  border-top-color: var(--live);
+  border-radius: 50%;
+  flex: none;
+  animation: spin 0.8s linear infinite;
+}
+
+/* payout history + grant list: mono printouts on the plate. */
+.history {
+  margin-top: var(--s-3);
+  padding-top: var(--s-3);
+  border-top: 1px solid var(--hairline);
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  color: var(--ink-700);
+  white-space: pre-wrap;
+  line-height: 1.7;
+}
+.grant-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+}
+.grant-list li {
+  padding: var(--s-2) 0;
+  border-top: 1px solid var(--hairline);
+  color: var(--ink-700);
+  word-break: break-word;
+}
+.grant-list li:first-child { border-top: 0; }
+.grant-list .muted { color: var(--ink-400); }
+
+/* the "broker not configured" notice. */
+.not-configured {
+  margin-top: var(--s-5);
+  padding: var(--s-4);
+  border: 1px solid var(--hairline-2);
+  border-left: 2px solid var(--live);
+  border-radius: var(--r-sm);
+  background: var(--paper-2);
+  font-size: var(--t-sm);
+  color: var(--ink-700);
+}
+
+/* =====================================================================
+   9. CONTROLS : buttons, inputs, link/x buttons, checkboxes.
+   The site's voice - quiet outline/ghost for secondary, ONE solid ink for
+   the primary; red for focus rings + hover glints, never for button fills.
+   ===================================================================== */
+
+/* secondary action : an ink hairline outline on paper, red on hover. */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-2);
+  padding: 9px 16px;
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  border-radius: var(--r-sm);
+  color: var(--ink-700);
+  font-family: var(--font-ui);
+  font-size: var(--t-sm);
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+  transition: color var(--d-1) var(--ease-standard),
+              border-color var(--d-1) var(--ease-standard),
+              opacity var(--d-1) var(--ease-standard);
+}
+.btn:hover { color: var(--ink-900); border-color: var(--live); }
+.btn:disabled { opacity: 0.45; cursor: default; }
+
+/* even quieter ghost : no fill, lighter weight - for tertiary actions. */
+.btn.ghost {
+  background: none;
+  border-color: var(--hairline);
+  color: var(--ink-500);
+}
+.btn.ghost:hover { color: var(--live); border-color: var(--live); }
+
+/* THE one prominent action : ink fill, the only solid control (mirrors
+   account-base.css .gh / .primary). Red focus ring, never a red fill. */
+.btn.primary {
+  background: var(--ink-900);
+  border-color: var(--ink-900);
+  color: var(--paper);
+}
+.btn.primary:hover { opacity: 0.88; color: var(--paper); border-color: var(--ink-900); }
+
+/* compact variant for in-row / in-card controls. */
+.btn.small { padding: 5px 11px; font-size: var(--t-xs); }
+
+/* link-style button : ink text, the red glint as a hover underline. */
+.link-btn {
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  color: var(--ink-500);
+  padding: 2px 0;
+  border-bottom: 1px solid transparent;
+  transition: color var(--d-1) var(--ease-standard),
+              border-color var(--d-1) var(--ease-standard);
+}
+.link-btn:hover { color: var(--live); border-bottom-color: var(--live); }
+
+/* dismiss / remove glyph button. */
+.x-btn {
+  flex: none;
+  width: 26px; height: 26px;
+  display: inline-grid;
+  place-items: center;
+  font-size: var(--t-body);
+  line-height: 1;
+  color: var(--ink-400);
+  border-radius: var(--r-sm);
+  transition: color var(--d-1) var(--ease-standard);
+}
+.x-btn:hover { color: var(--live); }
+
+/* mono text/number fields : hairline frame, square, the one red focus ring
+   (matches account-base.css inputs + console.css md fields). */
+.inp {
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  font-variant-numeric: tabular-nums slashed-zero;
+  color: var(--ink-900);
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
+  width: 100%;
+  transition: border-color var(--d-1) var(--ease-standard);
+}
+.inp::placeholder { color: var(--ink-400); }
+.inp:focus-visible {
+  outline: none;
+  border-color: var(--live);
+  box-shadow: 0 0 0 1px var(--live) inset;
+}
+.inp.small { width: 9em; padding: 6px 8px; }
+
+/* inline checkbox + label, mono. */
+.chk {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-1);
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  color: var(--ink-500);
+  cursor: pointer;
+}
+.chk input { accent-color: var(--live); }
+
+/* =====================================================================
+   10. MODALS + FIELDS
+   ===================================================================== */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-overlay);
+  display: grid;
+  place-items: center;
+  padding: var(--gutter);
+  background: var(--glass-soft);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+}
+.modal {
+  width: 100%;
+  max-width: 420px;
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  border-radius: var(--r-md);
+  box-shadow: var(--e-4);
+  padding: var(--s-6);
+}
+.modal.wide { max-width: 560px; }
+.modal h3 {
+  font-family: var(--font-ui);
+  font-size: var(--t-h3);
+  font-weight: var(--weight-semi);
+  letter-spacing: var(--tracking-h3);
+  color: var(--ink-900);
+  margin-bottom: var(--s-4);
+}
+.modal h3 .mono { color: var(--ink-900); font-weight: var(--weight-medium); }
+.modal > p { font-size: var(--t-sm); color: var(--ink-500); margin-bottom: var(--s-4); }
+
+/* a labelled field: a mono uppercase caption above its control. */
+.field { display: block; margin-bottom: var(--s-4); }
+.field > span {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--t-micro);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-400);
+  margin-bottom: var(--s-2);
+}
+.price-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--s-4);
+}
+.windows-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-3);
+  margin: var(--s-2) 0 var(--s-3);
+  font-family: var(--font-mono);
+  font-size: var(--t-micro);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-400);
+}
+.windows { display: flex; flex-direction: column; gap: var(--s-2); }
+.window-row {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  flex-wrap: wrap;
+}
+.window-row .inp { width: auto; flex: 1 1 4.5em; min-width: 4.5em; }
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--s-3);
+  margin-top: var(--s-6);
+}
+
+/* =====================================================================
+   11. TOASTS - the site's pill : ink fill, paper text, one red dot.
+   (console.js appends them visible, then fades opacity inline.)
+   ===================================================================== */
+.toasts {
+  position: fixed;
+  left: 50%;
+  bottom: var(--s-6);
+  transform: translateX(-50%);
+  z-index: var(--z-overlay);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s-2);
+  pointer-events: none;
+  width: max-content;
+  max-width: calc(100vw - 2 * var(--gutter));
+}
+.toast {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: 10px 18px;
+  border-radius: var(--r-pill);
+  background: var(--ink-900);
+  color: var(--paper);
+  font-family: var(--font-ui);
+  font-size: var(--t-sm);
+  box-shadow: var(--e-4);
+  animation: toastIn var(--d-3) var(--ease-out-quint);
+}
+.toast::before {
+  content: "";
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--live);
+}
+/* kinds: ok keeps the red glint; warn/err lift it to a steady signal. */
+.toast.warn::before,
+.toast.err::before { background: var(--live); box-shadow: 0 0 0 3px var(--live-wash); }
+
+/* =====================================================================
+   KEYFRAMES - bound to the shared --carrier rhythm where it reads as a
+   heartbeat; durations collapse to 0 under reduced motion (tokens).
+   ===================================================================== */
+@keyframes beat {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.6; transform: scale(0.86); }
+}
+@keyframes pulse {
+  0%, 100% { opacity: 0.45; }
+  50%      { opacity: 1; }
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes toastIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* =====================================================================
+   12. RESPONSIVE + REDUCED MOTION
+   ===================================================================== */
+@media (max-width: 640px) {
+  .topbar { gap: var(--s-3); }
+  .tabs { margin-left: 0; width: 100%; order: 3; gap: var(--s-4); }
+  .topbar-right { margin-left: auto; }
+  .content { padding-top: var(--s-6); }
+  .cards { grid-template-columns: 1fr; }
   .price-grid { grid-template-columns: 1fr; }
-  .window-row { grid-template-columns: 1fr 1fr; }
+  .data-table th, .data-table td { padding: var(--s-2); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .brand-mark::after,
+  .conn-dot,
+  .conn.live .conn-dot,
+  .status-dot.connecting,
+  .spinner,
+  .toast,
+  .meter-fill,
+  .tab::after { animation: none; transition: none; }
 }

--- a/internal/webui/assets/console.css
+++ b/internal/webui/assets/console.css
@@ -92,7 +92,9 @@ h1, h2, h3, p { margin: 0; }
 button { font: inherit; cursor: pointer; border: 0; background: none; color: inherit; }
 code { font-family: var(--font-mono); }
 [hidden] { display: none !important; }
-::selection { background: var(--live); color: var(--paper); }
+/* Red WASH (not a solid red surface) + ink text, so selection stays readable in BOTH
+   themes — a solid --live with --paper text goes near-black-on-red in dark mode. */
+::selection { background: var(--live-tint); color: var(--ink-900); }
 
 noscript {
   display: block;

--- a/internal/webui/assets/console.html
+++ b/internal/webui/assets/console.html
@@ -6,6 +6,9 @@
   <meta name="robots" content="noindex">
   <meta name="color-scheme" content="light dark">
   <title>Roger · Node Console</title>
+  <!-- design tokens (the source of truth) MUST load before the component
+       sheet so console.css can consume the custom properties. -->
+  <link rel="stylesheet" href="/assets/tokens.css">
   <link rel="stylesheet" href="/assets/console.css">
 </head>
 <body>

--- a/internal/webui/assets/tokens.css
+++ b/internal/webui/assets/tokens.css
@@ -1,0 +1,218 @@
+/* =====================================================================
+   RogerAI - Design Tokens
+   "The Live Operating Manual." ~95% warm monochrome + EXACTLY ONE accent:
+   the red on-air beacon. Color is a SIGNAL, never a surface.
+
+   Type: Space Grotesk (display + prose/UI) + JetBrains Mono (all machine
+   truth: numbers, labels, callsigns, commands, endpoints).
+
+   Token NAMES are kept stable so every page inherits the new foundation
+   without edits. The legacy accent names now resolve into the monochrome
+   + one-red system:
+     --volt  -> ink (was indigo "brand/primary"; brand is now ink + red glints)
+     --live  -> THE red beacon (on air / live data / primary action / focus)
+     --ember -> ink (money is expressed in mono weight, not hue)
+     --gold  -> ink (lineage ◆ is sober ink, not festive gold)
+   Every value here is the single source of truth. Do not hardcode.
+   ===================================================================== */
+
+:root {
+  /* ---- SURFACE: warm paper (~95% monochrome ground). ------------- */
+  --white:        #FFFFFF; /* the only "raised" surface (rare) */
+  --paper:        #FBFBFA; /* default page background - warm off-white */
+  --paper-2:      #F4F4F2; /* banded sections / bars */
+  --paper-3:      #EDEDEA; /* deepest neutral fill */
+  --hairline:     #E6E5E1; /* the ONLY divider color */
+  --hairline-2:   #D8D7D2; /* stronger rule (plate top/bottom) */
+
+  /* ---- INK: warm near-black. Pure #000 is BANNED. --------------- */
+  --ink-900:      #15140F; /* headlines, primary text */
+  --ink-700:      #33312B; /* body text */
+  --ink-500:      #6B685F; /* secondary text */
+  --ink-400:      #9A968B; /* tertiary / captions / labels */
+  --ink-300:      #C4C0B5; /* disabled / off-bars */
+
+  /* ---- THE SIGNAL: one red beacon. -------------------------------
+     This is the whole accent budget. It appears only as small glints:
+     the on-air dot, focus rings, the on-air underline, a §-marker rule,
+     install-box hover, the live-market dot. */
+  --live:         #E0231C; /* on air / live / primary action / focus */
+  --live-tint:    #FBE7E5; /* the only red fill (behind a dot / on hover) */
+  --live-glow:    rgba(224, 35, 28, 0.26);
+  --live-wash:    rgba(224, 35, 28, 0.10);
+
+  /* ---- LEGACY ACCENT ALIASES -> collapse into mono + one red. ----
+     Kept so the other pages render acceptably with no body edits. */
+  --volt:         var(--ink-900); /* brand/primary -> ink (outline buttons) */
+  --ember:        var(--ink-900); /* money -> mono ink + weight */
+  --pulse:        var(--live);    /* live data -> the one red */
+  --gold:         var(--ink-700); /* lineage ◆ -> sober ink */
+
+  --volt-tint:    var(--paper-2);
+  --ember-tint:   var(--paper-2);
+  --pulse-tint:   var(--live-tint);
+  --volt-glow:    var(--live-glow);
+  --ember-glow:   var(--live-glow);
+  --pulse-glow:   var(--live-glow);
+  --gold-tint:    var(--paper-2);
+
+  /* frosted-glass backings (nav) - theme aware */
+  --glass:        rgba(251, 251, 250, 0.82);
+  --glass-soft:   rgba(251, 251, 250, 0.55);
+
+  /* ---- TYPE -------------------------------------------------------- */
+  --font-ui:   "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", ui-monospace, "Menlo", monospace;
+
+  /* Type scale - fluid (clamp: mobile floor -> desktop cap). rem on 16px root. */
+  --t-display: clamp(2.4rem, 1.20rem + 4.6vw, 4rem);   /* hero */
+  --t-h1:      clamp(2rem, 1.45rem + 2.2vw, 2.5rem);
+  --t-h2:      clamp(1.6rem, 1.22rem + 1.4vw, 1.9rem);
+  --t-h3:      clamp(1.2rem, 1.12rem + 0.4vw, 1.3rem);
+  --t-lead:    clamp(1.0625rem, 1.0rem + 0.3vw, 1.18rem); /* lead paragraph */
+  --t-body:    1rem;
+  --t-sm:      0.875rem;
+  --t-xs:      0.75rem;
+  --t-micro:   0.6875rem; /* labels / eyebrows */
+
+  --lh-tight:  1.04;
+  --lh-snug:   1.12;
+  --lh-body:   1.55;
+
+  /* Heading tracking: bigger type = tighter set; uppercase labels open. */
+  --tracking-display: -0.02em;  /* hero */
+  --tracking-h1:      -0.018em;
+  --tracking-h2:      -0.015em;
+  --tracking-h3:      -0.01em;
+  --tracking-tight:   -0.012em;
+  --tracking-flat:    0em;
+  --tracking-label:   0.14em;   /* uppercase eyebrows / mono labels */
+
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semi:    600;
+  --weight-bold:    700;
+
+  /* ---- SPACING: 4px base, 8px rhythm ------------------------------ */
+  --s-1:  4px;
+  --s-2:  8px;
+  --s-3:  12px;
+  --s-4:  16px;
+  --s-5:  20px;
+  --s-6:  24px;
+  --s-8:  32px;
+  --s-10: 40px;
+  --s-12: 48px;
+  --s-16: 64px;
+  --s-20: 80px;
+  --s-24: 96px;
+  --s-32: 128px;
+  --s-40: 160px;
+
+  --gutter: clamp(20px, 5vw, 56px);
+  --maxw:   1080px;          /* document feel (down from 1200) */
+  /* the left running-head spine: an intentional operating-manual margin.
+     The document is offset right by exactly this width >=1080px (see .rail). */
+  --spine:  clamp(64px, 7.5vw, 108px);
+
+  /* tighter, document-style section rhythm (cap toward 96px) */
+  --section-y:  clamp(56px, 8vw, 96px);
+  --section-y2: clamp(48px, 7vw, 88px);
+  --head-gap:   clamp(32px, 5vw, 56px); /* section head -> content */
+
+  /* ---- RADII: square-ish; no big rounded cards on the homepage ---- */
+  --r-xs:   2px;
+  --r-sm:   3px;
+  --r-md:   4px;
+  --r-lg:   6px;
+  --r-xl:   8px;
+  --r-pill: 999px;
+
+  /* ---- ELEVATION: flat. Hairlines do the work. -------------------
+     Depth is communicated by rules + spacing, not shadows. Only the
+     terminal demo keeps a real soft shadow (--e-3). The faint --e-1/--e-2
+     remain for legacy account/auth cards so they don't read broken. */
+  --e-0: none;
+  --e-1: none;
+  --e-2: 0 1px 2px rgba(21,20,15,0.04);
+  --e-3: 0 2px 8px rgba(21,20,15,0.06), 0 1px 2px rgba(21,20,15,0.05);
+  --e-4: 0 8px 28px rgba(21,20,15,0.10), 0 2px 6px rgba(21,20,15,0.06);
+  --e-glass: 0 1px 0 rgba(255,255,255,0.5) inset;
+
+  /* ---- MOTION ------------------------------------------------------ */
+  --ease-out-quint: cubic-bezier(.22, 1, .36, 1);
+  --ease-out-expo:  cubic-bezier(.16, 1, .3, 1);
+  --ease-in-out:    cubic-bezier(.65, 0, .35, 1);
+  --ease-standard:  cubic-bezier(.4, 0, .2, 1);
+
+  --d-1: 120ms;
+  --d-2: 200ms;
+  --d-3: 320ms;
+  --d-4: 560ms;
+  --d-5: 820ms;
+
+  /* ---- CARRIER: one shared transmit rhythm the whole page breathes on. */
+  --carrier:    2.2s;
+  --carrier-2x: 4.4s;
+
+  /* z layers */
+  --z-base:   0;
+  --z-card:   10;
+  --z-nav:    100;
+  --z-overlay:1000;
+}
+
+/* =====================================================================
+   DARK THEME - "the ink room" (warm ink, not blue-black).
+   Driven by [data-theme="dark"] on <html>. Same single-accent discipline.
+   ===================================================================== */
+:root[data-theme="dark"] {
+  --white:        #1C1A14; /* raised surface */
+  --paper:        #0E0D0B; /* warm ink ground */
+  --paper-2:      #16140F; /* bands / bars */
+  --paper-3:      #1F1C16; /* deepest neutral fill */
+  --hairline:     #2A2720; /* the ONLY divider */
+  --hairline-2:   #38342B; /* stronger rule */
+
+  --ink-900:      #F3F1EA; /* headlines */
+  --ink-700:      #D7D3C8; /* body */
+  --ink-500:      #9A968B; /* secondary */
+  --ink-400:      #7A766B; /* tertiary / captions */
+  --ink-300:      #555148; /* disabled / off bars */
+
+  --live:         #FF4438; /* beacon, lifted for AA on ink */
+  --live-tint:    rgba(255, 68, 56, 0.16);
+  --live-glow:    rgba(255, 68, 56, 0.32);
+  --live-wash:    rgba(255, 68, 56, 0.14);
+
+  --volt:         var(--ink-900);
+  --ember:        var(--ink-900);
+  --pulse:        var(--live);
+  --gold:         var(--ink-700);
+  --volt-tint:    var(--paper-2);
+  --ember-tint:   var(--paper-2);
+  --pulse-tint:   var(--live-tint);
+  --volt-glow:    var(--live-glow);
+  --ember-glow:   var(--live-glow);
+  --pulse-glow:   var(--live-glow);
+  --gold-tint:    var(--paper-2);
+
+  --e-0: none;
+  --e-1: none;
+  --e-2: 0 1px 2px rgba(0,0,0,0.40);
+  --e-3: 0 10px 34px rgba(0,0,0,0.50), 0 2px 8px rgba(0,0,0,0.40);
+  --e-4: 0 18px 48px rgba(0,0,0,0.58), 0 4px 12px rgba(0,0,0,0.42);
+  --e-glass: 0 1px 0 rgba(255,255,255,0.04) inset;
+
+  --glass:        rgba(14, 13, 11, 0.82);
+  --glass-soft:   rgba(14, 13, 11, 0.55);
+
+  color-scheme: dark;
+}
+
+/* Reduced motion: collapse choreography, keep legibility. */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --d-1: 0ms; --d-2: 0ms; --d-3: 0ms; --d-4: 0ms; --d-5: 0ms;
+  }
+}

--- a/internal/webui/server_test.go
+++ b/internal/webui/server_test.go
@@ -159,8 +159,8 @@ func TestAssetsServe(t *testing.T) {
 	s := New(testCtrl(), Options{})
 	srv := httptest.NewServer(s.Handler())
 	defer srv.Close()
-	// The shell HTML references these; both must serve without a token (static, no data).
-	for _, path := range []string{"/", "/assets/console.css", "/assets/console.js"} {
+	// The shell HTML references these; all must serve without a token (static, no data).
+	for _, path := range []string{"/", "/assets/tokens.css", "/assets/console.css", "/assets/console.js"} {
 		resp, err := http.Get(srv.URL + path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
@@ -179,7 +179,7 @@ func TestAssetsServe(t *testing.T) {
 	resp, _ := http.Get(srv.URL + "/")
 	html, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
-	for _, ref := range []string{"/assets/console.css", "/assets/console.js"} {
+	for _, ref := range []string{"/assets/tokens.css", "/assets/console.css", "/assets/console.js"} {
 		if !strings.Contains(string(html), ref) {
 			t.Errorf("shell HTML does not reference %s", ref)
 		}


### PR DESCRIPTION
Follow-up to the merged web console (PRs #1 + #2). Two commits on `main`.

## 1. Restyle to the rogerai.fyi design system
The console now uses the site's **actual** design tokens, not an approximation:
- Embeds `web/src/styles/tokens.css` **verbatim** as `assets/tokens.css` (byte-identical) and links it before `console.css`.
- `console.css` rewritten to consume only those tokens — "The Live Operating Manual": ~95% warm monochrome with **exactly one** accent, the red on-air beacon (`var(--live)`), as glints only (on-air/live dots, active-tab underline, §-marker rules, focus rings, primary action). Mono tabular tables, flat hairline plates, §-marker headings, quiet outline buttons with one solid-ink primary. Connecting/reconnecting stays a monochrome pulsing ink dot (no second hue).
- **Self-contained / offline**: no CDN or external fonts — the token font stacks (Space Grotesk / JetBrains Mono) fall back to system faces. The console never phones home.
- Dark mode via `prefers-color-scheme` re-applying the tokens' dark values; reduced-motion guarded.
- `console.js` untouched; all 60 element ids it binds to preserved (verified).

## 2. Detection fixes (empty SHARE tab / re-detect no-op)
Two server-side reasons the browser SHARE tab came up empty while the CLI worked:
- `Controller.Detect` ignored the saved/verified upstream — a bare `DetectFull` only scans default ports + listening sockets, so a saved **custom or keyed** endpoint (the one the CLI seeds and finds) was missed. `Detect` now falls back to the saved upstream + its key when no URL is pasted, probing it first like the CLI.
- Nothing detected on launch (the TUI detects lazily on entering SHARE). `startWebConsole` now kicks an initial background detection so SHARE populates on first paint; the SSE stream pushes the result, and re-detect can refine it.

Regression test: a saved upstream on a non-default port is found via a no-arg `Detect` (a bare scan would miss it).

## Verification
`go build`/`vet`/`gofmt` clean; `node` + `webui` + `detect` suites pass (incl. the new `TestDetectFallsBackToSavedUpstream`); a live serve check confirmed `tokens.css` + `console.css` + `console.html` + `console.js` all serve 200 and the CSS is token-driven. Validated against the current `main` (post both merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)