### PR TITLE
broker: founder ops-alert emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,20 @@ ROGERAI_PAYOUT_SCHEDULE=monthly
 RESEND_API_KEY=
 RESEND_FROM=RogerAI <noreply@rogerai.fyi>
 
+# --- Founder ops ALERTS (OPTIONAL, flag-gated) --------------------------------
+# ADMIN_EMAIL pages the founder on operationally important events via the Resend
+# mailer above (needs RESEND_API_KEY to actually deliver). It is a COMMA-SEPARATED
+# list - every address is alerted. UNSET/blank => alerting is entirely OFF (zero
+# behavior change; events stay log-only). Alerts fire once on a condition's ONSET
+# (deduped in memory, resets on restart) and re-fire only after the condition clears.
+# Triggers: ledger drift (balance vs re-derived ledger), a live model dropping to 0
+# providers, DB/Valkey unreachable, the first REAL (live) Stripe top-up, the first
+# ban/dispute/abuse|csam report, and a CSAM queue item past its filing SLA.
+ADMIN_EMAIL=
+# ROGERAI_CSAM_SLA_HOURS: age (hours) past which a still-queued CyberTipline report
+# pages ADMIN_EMAIL (18 USC 2258A). Default 24.
+ROGERAI_CSAM_SLA_HOURS=24
+
 # --- GitHub OAuth (P0 auth: login + monetization) -----------------------------
 # OAuth App "RogerAI" owned by the rogerai-fyi org. The Client ID is public; the
 # secret is sensitive - set it in .env / DO secrets ONLY, never commit it.

--- a/cmd/rogerai-broker/account.go
+++ b/cmd/rogerai-broker/account.go
@@ -185,6 +185,10 @@ func (b *broker) billing(w http.ResponseWriter, r *http.Request) {
 	}
 	bal, _ := b.db.BalanceOf(user, b.seedFunds)
 	derived, _ := b.db.DeriveBalance(user)
+	// Founder ops alert: the existing verify-vs-balance drift check. When a wallet's cached
+	// balance diverges from its re-derived ledger sum (a money invariant broke), page the
+	// founder once (onset dedup, clears when it reconciles). No-op when ADMIN_EMAIL is unset.
+	b.checkDriftAlert(user, bal, derived)
 	topups, _ := b.db.LedgerOf(user, []string{store.KindTopup}, recentLimit(r))
 	writeJSON(w, http.StatusOK, map[string]any{
 		"balance":        round6(bal),

--- a/cmd/rogerai-broker/alerts.go
+++ b/cmd/rogerai-broker/alerts.go
@@ -1,0 +1,359 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// alerts.go is the FOUNDER OPS ALERTS layer: operationally important conditions PAGE the
+// founder (ADMIN_EMAIL) via the existing async mailer instead of being log-only. It is a
+// thin, side-channel overlay on top of the money/relay path - it NEVER mutates state a
+// request depends on and NEVER blocks or fails a request/checker.
+//
+// FAIL-SAFE: ADMIN_EMAIL unset => alerting is entirely OFF (zero behavior change). A mailer
+// error is swallowed by the async mailer (log + move on), so an alert can never break the
+// triggering operation.
+//
+// DEDUP: an alert fires ONCE on a condition's ONSET (a clear->fire transition) and never
+// again while it stays fired; it re-fires only after it CLEARS and re-onsets. State lives
+// in memory (alertFiring), so it resets on restart - acceptable for an ops page (a still-true
+// condition simply re-pages once after a redeploy). Milestone alerts (first live top-up,
+// first ban/dispute/report) use a constant key and are never cleared, so they fire exactly
+// once per process lifetime.
+//
+// The alert email reuses the branded transactional shell (emailtemplates.go) with a clear
+// "[RogerAI ALERT] ..." subject, the key facts as a receipt, and a CTA to the control panel.
+
+// alertSubjectPrefix marks every ops alert so a filter/rule can route them.
+const alertSubjectPrefix = "[RogerAI ALERT] "
+
+// alertControlURL is the founder control panel the alert CTA links to.
+const alertControlURL = "https://control.rogerai.fyi"
+
+// alertCheckInterval is how often the periodic checker re-evaluates the STATE/threshold
+// conditions (0-providers, db/valkey health, CSAM SLA). Frequent enough to page promptly,
+// cheap enough to run on a small instance (a market recompute + two health pings + one
+// queue-stats read).
+const alertCheckInterval = time.Minute
+
+// defaultCSAMSLAHours is the age past which a still-queued CyberTipline report pages the
+// founder (18 USC 2258A obligation). Override with ROGERAI_CSAM_SLA_HOURS.
+const defaultCSAMSLAHours = 24
+
+// driftEpsilon is the credit tolerance below which a balance-vs-derived difference is
+// treated as float noise, not a real money invariant break. Real drift is materially
+// larger than accumulated float rounding across a wallet's ledger rows.
+const driftEpsilon = 1e-4
+
+// parseAdminEmails splits ADMIN_EMAIL into a trimmed recipient list, dropping blanks. An
+// unset/blank/comma-only value yields nil, which turns alerting entirely OFF (fail-safe).
+func parseAdminEmails(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if e := strings.TrimSpace(part); e != "" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// csamSLAHoursEnv reads ROGERAI_CSAM_SLA_HOURS (>0), else the default.
+func csamSLAHoursEnv() int {
+	if v := os.Getenv("ROGERAI_CSAM_SLA_HOURS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultCSAMSLAHours
+}
+
+// alertingOn reports whether founder alerting is enabled (at least one ADMIN_EMAIL
+// recipient is configured).
+func (b *broker) alertingOn() bool { return len(b.adminEmails) > 0 }
+
+// adminAlert fires ONE founder ops alert for `key` on the CLEAR->FIRE transition only
+// (onset dedup), delivering to EVERY ADMIN_EMAIL recipient. It is a no-op when alerting is
+// off (no recipients) or the condition is already firing. It never blocks and never errors:
+// the underlying mailer is async and swallows failures.
+//
+//	key        - the dedup key for this condition instance (e.g. "noproviders:<model>")
+//	subjectTail- appended to the "[RogerAI ALERT] " subject prefix
+//	heading    - the human headline in the email body
+//	rows       - key/value facts rendered as a receipt
+//	body       - a short plain sentence of context
+func (b *broker) adminAlert(key, subjectTail, heading string, rows [][2]string, body string) {
+	if !b.alertingOn() {
+		return // fail-safe: ADMIN_EMAIL unset => alerting entirely OFF
+	}
+	b.alertMu.Lock()
+	if b.alertFiring == nil {
+		b.alertFiring = map[string]bool{}
+	}
+	if b.alertFiring[key] {
+		b.alertMu.Unlock()
+		return // already firing on this onset - dedup, do not re-page
+	}
+	b.alertFiring[key] = true
+	b.alertMu.Unlock()
+
+	subj := alertSubjectPrefix + subjectTail
+	d := emailDoc{
+		kicker:    "Ops alert",
+		heading:   heading,
+		preheader: subjectTail,
+		bodyHTML:  receipt("", rows) + p(esc(body)),
+		bodyText:  alertText(rows, body),
+		ctaLabel:  "Open control",
+		ctaHref:   alertControlURL,
+	}
+	htmlBody, textBody := renderHTML(d), renderText(d)
+	// Deliver to every recipient. Each send is async + failure-swallowing (email.go), so a
+	// slow/broken recipient can never block or fail the alert path.
+	for _, to := range b.adminEmails {
+		b.mail.sendEmail(to, subj, htmlBody, textBody)
+	}
+	log.Printf("alert: FIRED %q -> %d recipient(s): %s", key, len(b.adminEmails), subjectTail)
+}
+
+// alertClear marks a condition resolved so a later re-onset re-fires. A no-op when alerting
+// is off or the condition was not firing.
+func (b *broker) alertClear(key string) {
+	if !b.alertingOn() {
+		return
+	}
+	b.alertMu.Lock()
+	was := b.alertFiring[key]
+	delete(b.alertFiring, key)
+	b.alertMu.Unlock()
+	if was {
+		log.Printf("alert: CLEARED %q", key)
+	}
+}
+
+// alertText renders the plain-text body for an alert: the facts as "LABEL: value" lines
+// followed by the context sentence.
+func alertText(rows [][2]string, body string) string {
+	var b strings.Builder
+	for _, r := range rows {
+		b.WriteString(r[0] + ": " + r[1] + "\n")
+	}
+	if len(rows) > 0 {
+		b.WriteString("\n")
+	}
+	b.WriteString(body)
+	return b.String()
+}
+
+// ---- periodic checker ---------------------------------------------------------
+
+// alertCheckerLoop periodically re-evaluates the STATE/threshold alert conditions (a live
+// model dropping to 0 providers, db/Valkey unreachable, a CSAM item past its SLA) and pages
+// the founder on each condition's onset. It is a single small goroutine, started only when
+// alerting is on. stop is the nil-in-production test seam (a nil channel case never fires,
+// so the loop waits on the ticker exactly as the other sweeps do).
+func (b *broker) alertCheckerLoop(stop <-chan struct{}) {
+	if !b.alertingOn() {
+		log.Printf("alerts: ADMIN_EMAIL unset - founder ops alerts DISABLED (log-only)")
+		return
+	}
+	log.Printf("alerts: ON - founder ops alerts to %d recipient(s) (checker every %s, CSAM SLA %dh)", len(b.adminEmails), alertCheckInterval, b.csamSLAHours)
+	t := time.NewTicker(alertCheckInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-t.C:
+			b.alertCheckOnce(time.Now())
+		}
+	}
+}
+
+// alertCheckOnce runs one pass of every periodic (state-derived) alert check. Split out of
+// the loop so it is testable without the ticker.
+func (b *broker) alertCheckOnce(now time.Time) {
+	b.checkHealthAlerts()
+	b.checkProviderGapAlerts()
+	b.checkCSAMSLAAlert(now)
+}
+
+// checkHealthAlerts pages when the durable store (Postgres) or the optional shared state
+// layer (Valkey) is unreachable, and clears when it recovers. The shared layer is only a
+// dependency when configured (nil = unconfigured = never alerts).
+func (b *broker) checkHealthAlerts() {
+	// Durable store.
+	if b.db == nil {
+		b.adminAlert("db_down", "broker database unreachable", "Broker database is unreachable",
+			[][2]string{{"Component", "database"}, {"Status", "nil handle"}},
+			"The broker has no durable store handle - it cannot serve money/ledger operations.")
+	} else if err := b.db.Healthy(); err != nil {
+		b.adminAlert("db_down", "broker database unreachable", "Broker database is unreachable",
+			[][2]string{{"Component", "database (Postgres)"}, {"Error", err.Error()}},
+			"The durable store failed its health ping - the broker is degraded/unhealthy.")
+	} else {
+		b.alertClear("db_down")
+	}
+
+	// Optional shared state layer (Valkey): only a dependency when wired.
+	if b.shared != nil {
+		if b.shared.healthy() {
+			b.alertClear("valkey_down")
+		} else {
+			b.adminAlert("valkey_down", "shared state (Valkey) unreachable", "Shared state layer (Valkey) is unreachable",
+				[][2]string{{"Component", "Valkey / shared store"}, {"Status", "unreachable"}},
+				"The shared state layer failed its health check - cross-instance rate-limit/liveness sharing is degraded.")
+		}
+	}
+}
+
+// checkProviderGapAlerts pages when a model that WAS on air drops to 0 providers (a supply
+// gap), and clears when supply returns. It tracks every model ever seen on air so the
+// drop-to-zero transition is detectable even though a 0-provider model no longer appears in
+// the market view.
+func (b *broker) checkProviderGapAlerts() {
+	nowOnAir := b.liveModelProviders() // model -> provider count (every entry >= 1)
+
+	b.alertMu.Lock()
+	if b.alertOnAirSeen == nil {
+		b.alertOnAirSeen = map[string]bool{}
+	}
+	for model := range nowOnAir {
+		b.alertOnAirSeen[model] = true
+	}
+	var restored, dropped []string
+	for model := range b.alertOnAirSeen {
+		if _, ok := nowOnAir[model]; ok {
+			restored = append(restored, model)
+		} else {
+			dropped = append(dropped, model)
+		}
+	}
+	b.alertMu.Unlock()
+
+	// Clear first (a model back on air), then fire the drops. adminAlert/alertClear take
+	// alertMu themselves, so this runs outside the lock above.
+	for _, model := range restored {
+		b.alertClear("noproviders:" + model)
+	}
+	for _, model := range dropped {
+		b.adminAlert("noproviders:"+model, "model "+model+" has 0 providers",
+			"Model "+model+" dropped to 0 providers",
+			[][2]string{{"Model", model}, {"Providers", "0"}},
+			"This model was on air and now has no provider serving it - a supply gap. Requests for it will fail until a provider returns.")
+	}
+}
+
+// liveModelProviders returns the count of on-air providers per model, derived from the SAME
+// aggregation /market serves (respecting node TTL, bans, and private bands). Only models
+// with at least one live provider appear, so a model absent from the result is off air.
+func (b *broker) liveModelProviders() map[string]int {
+	out := map[string]int{}
+	res, ok := b.computeMarket().(map[string]any)
+	if !ok {
+		return out
+	}
+	views, ok := res["market"].([]marketView)
+	if !ok {
+		return out
+	}
+	for _, v := range views {
+		if v.Providers > 0 {
+			out[v.Model] = v.Providers
+		}
+	}
+	return out
+}
+
+// checkCSAMSLAAlert pages when a preserved CSAM incident still owes a CyberTipline report
+// past the SLA threshold (a legal-obligation escalation), and clears when the queue drains
+// or the oldest item is back within SLA.
+func (b *broker) checkCSAMSLAAlert(now time.Time) {
+	if b.db == nil {
+		return
+	}
+	depth, oldestAgeSecs, err := b.db.CSAMQueueStats(now)
+	if err != nil {
+		return // a transient store error is handled by the db-down health check
+	}
+	slaSecs := int64(b.csamSLAHours) * 3600
+	if depth > 0 && oldestAgeSecs >= slaSecs {
+		b.adminAlert("csam_sla", "CSAM report past SLA", "A CSAM report is past its filing SLA",
+			[][2]string{
+				{"Queue depth", strconv.Itoa(depth)},
+				{"Oldest queued", strconv.FormatInt(oldestAgeSecs/3600, 10) + "h"},
+				{"SLA", strconv.Itoa(b.csamSLAHours) + "h"},
+			},
+			"A preserved CSAM incident still owes a CyberTipline report past the SLA (18 USC 2258A). Drain via /admin/csam.")
+	} else {
+		b.alertClear("csam_sla")
+	}
+}
+
+// ---- milestone / event alerts -------------------------------------------------
+
+// alertFirstBan pages the founder on the FIRST account/node ban of this process lifetime (a
+// safety escalation). Deduped on a constant key, so only the first ban ever pages.
+func (b *broker) alertFirstBan(what, subject, evidence string) {
+	b.adminAlert("first_ban", "first ban - "+subject, "First "+what+" ban",
+		[][2]string{{"Subject", subject}, {"Evidence", evidence}},
+		"The first ban of this broker's lifetime was just applied. Confirm it looks right.")
+}
+
+// alertFirstDispute pages the founder on the FIRST Stripe charge dispute (chargeback) of
+// this process lifetime.
+func (b *broker) alertFirstDispute(disputeID string, amountCredits float64) {
+	b.adminAlert("first_dispute", "first charge dispute "+disputeID, "First charge dispute opened",
+		[][2]string{{"Dispute", disputeID}, {"Amount", fmt.Sprintf("$%.2f", round6(amountCredits*b.bill.creditUSD))}},
+		"A consumer opened the first chargeback dispute against a funding charge. Review the lineage clawback.")
+}
+
+// alertFirstReport pages the founder on the FIRST safety report (abuse/CSAM) of this process
+// lifetime.
+func (b *broker) alertFirstReport(category, nodeID string) {
+	b.adminAlert("first_report", "first "+category+" report", "First "+category+" report received",
+		[][2]string{{"Category", category}, {"Node", nodeID}},
+		"The first safety report of this broker's lifetime just came in.")
+}
+
+// alertFirstLiveTopup pages the founder on the FIRST REAL (live-mode) Stripe top-up - the
+// billing-works-end-to-end milestone. Only ever called on the sk_live path.
+func (b *broker) alertFirstLiveTopup(user string, credits, newBalance float64) {
+	b.adminAlert("first_live_topup", "first LIVE Stripe top-up", "First live Stripe top-up landed",
+		[][2]string{
+			{"Wallet", user},
+			{"Amount", fmt.Sprintf("$%.2f", round6(credits*b.bill.creditUSD))},
+			{"New balance", fmt.Sprintf("%.4f credits", newBalance)},
+		},
+		"The first real (live-mode) top-up credited a wallet - billing works end to end.")
+}
+
+// checkDriftAlert compares a wallet's cached balance against its independently re-derived
+// ledger sum (the existing verify-vs-balance drift check) and pages when they diverge past
+// the float-noise epsilon (a money invariant broke). Clears when they reconcile. Called from
+// the /billing handler where both figures are already computed - no extra store reads.
+func (b *broker) checkDriftAlert(user string, balance, derived float64) {
+	if !b.alertingOn() {
+		return
+	}
+	delta := balance - derived
+	if delta < 0 {
+		delta = -delta
+	}
+	key := "drift:" + user
+	if delta > driftEpsilon {
+		b.adminAlert(key, "ledger drift on wallet "+user, "Ledger drift detected",
+			[][2]string{
+				{"Wallet", user},
+				{"Cached balance", fmt.Sprintf("%.6f", balance)},
+				{"Derived (ledger sum)", fmt.Sprintf("%.6f", derived)},
+				{"Delta", fmt.Sprintf("%.6f", delta)},
+			},
+			"A wallet's cached balance diverged from its re-derived ledger sum - a money invariant broke. Investigate before payouts.")
+	} else {
+		b.alertClear(key)
+	}
+}

--- a/cmd/rogerai-broker/alerts_test.go
+++ b/cmd/rogerai-broker/alerts_test.go
@@ -1,0 +1,589 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// alerts_test.go is the spec for the FOUNDER OPS ALERTS layer (alerts.go): operationally
+// important conditions page ADMIN_EMAIL via the existing async mailer instead of being
+// log-only. The invariants under test:
+//   - each condition FIRES exactly one email (per recipient) on its ONSET,
+//   - a repeat of the same still-firing condition does NOT refire (dedup),
+//   - a refire happens after the condition CLEARS and re-onsets,
+//   - NOTHING fires when ADMIN_EMAIL is unset (alerting entirely OFF),
+//   - a mailer error is swallowed (never panics / blocks the checker or request path),
+//   - a comma-separated ADMIN_EMAIL delivers to EVERY address.
+// The mailer is injected as a recording seam (no real emails, no network).
+
+// alertBroker builds a broker with a recording mailer + the given admin recipients wired
+// for alerting. sends receives one payload per delivered email (async).
+func alertBroker(t *testing.T, recipients ...string) (*broker, chan map[string]any) {
+	t.Helper()
+	b := relayBroker(store.NewMem())
+	sends := make(chan map[string]any, 64)
+	b.mail = enabledMailer(func(r *http.Request) (*http.Response, error) {
+		by, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		_ = json.Unmarshal(by, &payload)
+		sends <- payload
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(emptyBody{})}, nil
+	})
+	b.adminEmails = recipients
+	b.alertFiring = map[string]bool{}
+	b.alertOnAirSeen = map[string]bool{}
+	b.csamSLAHours = 24
+	return b, sends
+}
+
+// alertRecipients collects the single "to" recipient of each delivered email within wait.
+func alertRecipients(sends chan map[string]any, want int, wait time.Duration) []string {
+	var got []string
+	deadline := time.After(wait)
+	for len(got) < want {
+		select {
+		case p := <-sends:
+			if to, ok := p["to"].([]any); ok && len(to) == 1 {
+				if s, ok := to[0].(string); ok {
+					got = append(got, s)
+				}
+			}
+		case <-deadline:
+			return got
+		}
+	}
+	return got
+}
+
+// firstAlert returns the first delivered email payload, or fails.
+func firstAlert(t *testing.T, sends chan map[string]any) map[string]any {
+	t.Helper()
+	select {
+	case p := <-sends:
+		return p
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected an alert email, none was sent")
+		return nil
+	}
+}
+
+// noAlert asserts nothing was delivered within a short window.
+func noAlert(t *testing.T, sends chan map[string]any) {
+	t.Helper()
+	select {
+	case p := <-sends:
+		t.Fatalf("expected NO alert, but one was sent: subj=%v", p["subject"])
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// TestCSAMSLAHoursEnv covers the SLA env override + default fallback.
+func TestCSAMSLAHoursEnv(t *testing.T) {
+	t.Setenv("ROGERAI_CSAM_SLA_HOURS", "48")
+	if got := csamSLAHoursEnv(); got != 48 {
+		t.Errorf("csamSLAHoursEnv() = %d, want 48", got)
+	}
+	t.Setenv("ROGERAI_CSAM_SLA_HOURS", "bogus")
+	if got := csamSLAHoursEnv(); got != defaultCSAMSLAHours {
+		t.Errorf("csamSLAHoursEnv() with bogus = %d, want default %d", got, defaultCSAMSLAHours)
+	}
+	t.Setenv("ROGERAI_CSAM_SLA_HOURS", "0") // non-positive rejected -> default
+	if got := csamSLAHoursEnv(); got != defaultCSAMSLAHours {
+		t.Errorf("csamSLAHoursEnv() with 0 = %d, want default %d", got, defaultCSAMSLAHours)
+	}
+}
+
+// TestAlertCheckOnceHealthyBrokerIsQuiet proves the periodic pass fires nothing on a
+// healthy, empty broker (all three checks clear) and exercises the aggregate entrypoint.
+func TestAlertCheckOnceHealthyBrokerIsQuiet(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+	b.alertCheckOnce(time.Now())
+	noAlert(t, sends)
+}
+
+// TestAlertCheckerLoopDisabledReturns proves the checker goroutine is a no-op (returns
+// immediately) when alerting is OFF, and honors the stop seam when ON.
+func TestAlertCheckerLoopDisabledReturns(t *testing.T) {
+	// OFF: no recipients -> returns at once.
+	off, _ := alertBroker(t)
+	done := make(chan struct{})
+	go func() { off.alertCheckerLoop(nil); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("alertCheckerLoop must return immediately when alerting is OFF")
+	}
+
+	// ON: honors a closed stop channel.
+	on, _ := alertBroker(t, "ops@example.com")
+	stop := make(chan struct{})
+	close(stop)
+	done2 := make(chan struct{})
+	go func() { on.alertCheckerLoop(stop); close(done2) }()
+	select {
+	case <-done2:
+	case <-time.After(time.Second):
+		t.Fatal("alertCheckerLoop must return when stop is closed")
+	}
+}
+
+// TestHealthAndCSAMNilDB proves the checks are nil-db safe: a nil durable store pages
+// db_down (health) and never panics (CSAM SLA just returns).
+func TestHealthAndCSAMNilDB(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+	b.db = nil
+	b.shared = nil
+	b.checkHealthAlerts()
+	got := firstAlert(t, sends)
+	if !strings.Contains(strings.ToLower(got["subject"].(string)), "database") {
+		t.Errorf("nil-db subject = %v", got["subject"])
+	}
+	b.checkCSAMSLAAlert(time.Now()) // must not panic with a nil store
+	noAlert(t, sends)
+}
+
+// TestParseAdminEmails covers the comma-separated recipient parse: trimmed, empties
+// dropped, unset/blank => nil (alerting OFF).
+func TestParseAdminEmails(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{" , ,", nil},
+		{"a@b.com", []string{"a@b.com"}},
+		{"a@b.com,c@d.com", []string{"a@b.com", "c@d.com"}},
+		{" a@b.com , c@d.com ,e@f.com ", []string{"a@b.com", "c@d.com", "e@f.com"}},
+		{"a@b.com,,c@d.com", []string{"a@b.com", "c@d.com"}},
+	}
+	for _, tc := range cases {
+		got := parseAdminEmails(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("parseAdminEmails(%q) = %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("parseAdminEmails(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+// TestAdminAlertFiresOnceDedupsAndRefires is the core onset/dedup/refire contract.
+func TestAdminAlertFiresOnceDedupsAndRefires(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+
+	b.adminAlert("cond:x", "thing broke", "Thing broke", [][2]string{{"Key", "val"}}, "the body")
+	got := firstAlert(t, sends)
+	subj, _ := got["subject"].(string)
+	if !strings.HasPrefix(subj, "[RogerAI ALERT] ") {
+		t.Errorf("subject = %q, want [RogerAI ALERT] prefix", subj)
+	}
+	if !strings.Contains(subj, "thing broke") {
+		t.Errorf("subject = %q, want the condition tail", subj)
+	}
+	htmlBody, _ := got["html"].(string)
+	if !strings.Contains(htmlBody, "control.rogerai.fyi") {
+		t.Errorf("alert HTML missing the control.rogerai.fyi link")
+	}
+	textBody, _ := got["text"].(string)
+	if !strings.Contains(textBody, "control.rogerai.fyi") {
+		t.Errorf("alert text missing the control.rogerai.fyi link")
+	}
+
+	// Repeat while still firing: NO refire (dedup).
+	b.adminAlert("cond:x", "thing broke", "Thing broke", nil, "again")
+	noAlert(t, sends)
+
+	// Clear, then re-onset: refires.
+	b.alertClear("cond:x")
+	b.adminAlert("cond:x", "thing broke again", "Thing broke", nil, "reonset")
+	if got := firstAlert(t, sends); !strings.Contains(got["subject"].(string), "again") {
+		t.Errorf("refire subject = %v, want the new tail", got["subject"])
+	}
+}
+
+// TestAdminAlertOffWhenNoRecipients proves an unset ADMIN_EMAIL makes alerting a no-op.
+func TestAdminAlertOffWhenNoRecipients(t *testing.T) {
+	b, sends := alertBroker(t) // no recipients
+	if b.alertingOn() {
+		t.Fatal("alertingOn must be false with no recipients")
+	}
+	b.adminAlert("cond:x", "broke", "Broke", nil, "body")
+	b.alertClear("cond:x")
+	noAlert(t, sends)
+}
+
+// TestAdminAlertMultipleRecipients proves a comma-separated ADMIN_EMAIL delivers to
+// EVERY address, once each, on a single onset.
+func TestAdminAlertMultipleRecipients(t *testing.T) {
+	recips := []string{"lramos85@gmail.com", "rossi.ramos@icloud.com", "larry_rivera@mac.com"}
+	b, sends := alertBroker(t, recips...)
+	b.adminAlert("cond:multi", "supply gap", "Supply gap", nil, "body")
+
+	got := alertRecipients(sends, len(recips), 2*time.Second)
+	if len(got) != len(recips) {
+		t.Fatalf("delivered to %d recipients (%v), want %d (%v)", len(got), got, len(recips), recips)
+	}
+	seen := map[string]bool{}
+	for _, r := range got {
+		seen[r] = true
+	}
+	for _, r := range recips {
+		if !seen[r] {
+			t.Errorf("recipient %q was not alerted", r)
+		}
+	}
+	// A repeat still does NOT refire even across many recipients.
+	b.adminAlert("cond:multi", "supply gap", "Supply gap", nil, "body")
+	noAlert(t, sends)
+}
+
+// TestAdminAlertMailerErrorSwallowed proves a transport error inside the mailer never
+// panics or blocks the alert path.
+func TestAdminAlertMailerErrorSwallowed(t *testing.T) {
+	b := relayBroker(store.NewMem())
+	b.mail = enabledMailer(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("resend down")
+	})
+	b.adminEmails = []string{"ops@example.com"}
+	b.alertFiring = map[string]bool{}
+	b.alertOnAirSeen = map[string]bool{}
+	// Must return cleanly (the send is async + swallows); give the goroutine time to run.
+	b.adminAlert("cond:x", "broke", "Broke", nil, "body")
+	time.Sleep(80 * time.Millisecond)
+}
+
+// TestCheckDriftAlert proves the ledger verify-vs-balance drift condition fires on a
+// divergence, dedups, and clears when balance re-derives cleanly.
+func TestCheckDriftAlert(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+
+	// No drift: balance == derived -> nothing fires.
+	b.checkDriftAlert("u_gh_1", 10.0, 10.0)
+	noAlert(t, sends)
+
+	// Drift: cached balance diverges from the re-derived ledger sum -> one alert.
+	b.checkDriftAlert("u_gh_1", 10.0, 7.5)
+	got := firstAlert(t, sends)
+	if !strings.Contains(got["subject"].(string), "u_gh_1") {
+		t.Errorf("drift subject = %v, want the wallet id", got["subject"])
+	}
+
+	// Still drifting: dedup, no refire.
+	b.checkDriftAlert("u_gh_1", 10.0, 7.5)
+	noAlert(t, sends)
+
+	// Reconciled: clears, and a later drift refires.
+	b.checkDriftAlert("u_gh_1", 10.0, 10.0)
+	b.checkDriftAlert("u_gh_1", 10.0, 6.0)
+	if got := firstAlert(t, sends); !strings.Contains(got["subject"].(string), "u_gh_1") {
+		t.Errorf("drift refire subject = %v", got["subject"])
+	}
+
+	// Sub-epsilon float noise is NOT drift.
+	b.checkDriftAlert("u_gh_2", 3.0, 3.00000001)
+	noAlert(t, sends)
+}
+
+// toggleStore wraps a store whose Healthy() can be flipped to unreachable.
+type toggleStore struct {
+	store.Store
+	down bool
+}
+
+func (s *toggleStore) Healthy() error {
+	if s.down {
+		return errors.New("db down")
+	}
+	return s.Store.Healthy()
+}
+
+// TestCheckHealthAlertsDB proves an unreachable durable store fires once, dedups, and
+// clears on recovery.
+func TestCheckHealthAlertsDB(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+	ts := &toggleStore{Store: b.db}
+	b.db = ts
+
+	// Healthy: nothing.
+	b.checkHealthAlerts()
+	noAlert(t, sends)
+
+	// Down: one alert.
+	ts.down = true
+	b.checkHealthAlerts()
+	got := firstAlert(t, sends)
+	if !strings.Contains(strings.ToLower(got["subject"].(string)), "database") {
+		t.Errorf("db-down subject = %v, want mention of the database", got["subject"])
+	}
+	// Still down: dedup.
+	b.checkHealthAlerts()
+	noAlert(t, sends)
+
+	// Recover then fail again: refire.
+	ts.down = false
+	b.checkHealthAlerts()
+	ts.down = true
+	b.checkHealthAlerts()
+	firstAlert(t, sends)
+}
+
+// toggleShared is a shared-store fake whose healthy() can be flipped.
+type toggleShared struct {
+	*memStore
+	up bool
+}
+
+func (s *toggleShared) healthy() bool { return s.up }
+
+// TestCheckHealthAlertsValkey proves an unreachable shared (Valkey) store fires once and
+// clears on recovery, and that a NIL shared store (unconfigured) never alerts.
+func TestCheckHealthAlertsValkey(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+
+	// nil shared (unconfigured): never a readiness dependency, no alert.
+	b.shared = nil
+	b.checkHealthAlerts()
+	noAlert(t, sends)
+
+	sh := &toggleShared{memStore: newMemStore(), up: true}
+	b.shared = sh
+	b.checkHealthAlerts()
+	noAlert(t, sends)
+
+	// Down: one alert.
+	sh.up = false
+	b.checkHealthAlerts()
+	got := firstAlert(t, sends)
+	if !strings.Contains(strings.ToLower(got["subject"].(string)), "valkey") {
+		t.Errorf("valkey-down subject = %v, want mention of Valkey", got["subject"])
+	}
+	// Dedup.
+	b.checkHealthAlerts()
+	noAlert(t, sends)
+	// Recover -> clear.
+	sh.up = true
+	b.checkHealthAlerts()
+	noAlert(t, sends)
+}
+
+// TestCheckCSAMSLAAlert proves a CSAM incident unactioned past the SLA fires once, dedups,
+// and clears when the queue drains.
+func TestCheckCSAMSLAAlert(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+	b.csamSLAHours = 24
+	mem := b.db.(*store.Mem)
+
+	if _, err := mem.PreserveCSAM(store.CSAMIncident{Pseudonym: "u_x", Category: "csam", ReportState: store.CSAMQueued}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+
+	// Within SLA: no alert.
+	b.checkCSAMSLAAlert(now)
+	noAlert(t, sends)
+
+	// Past SLA (25h later): one alert.
+	b.checkCSAMSLAAlert(now.Add(25 * time.Hour))
+	got := firstAlert(t, sends)
+	if !strings.Contains(strings.ToUpper(got["subject"].(string)), "CSAM") {
+		t.Errorf("csam-sla subject = %v, want mention of CSAM", got["subject"])
+	}
+	// Dedup.
+	b.checkCSAMSLAAlert(now.Add(26 * time.Hour))
+	noAlert(t, sends)
+}
+
+// registerLiveOffer puts one on-air node offering `model` into the broker's live state.
+func registerLiveOffer(b *broker, nodeID, model string) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	b.mu.Lock()
+	b.nodes[nodeID] = protocol.NodeRegistration{NodeID: nodeID, PubKey: hex.EncodeToString(pub),
+		Offers: []protocol.ModelOffer{{Model: model, PriceOut: 0.1}}}
+	b.lastSeen[nodeID] = time.Now()
+	b.mu.Unlock()
+}
+
+// TestCheckProviderGapAlert proves a model that was ON AIR and drops to 0 providers fires
+// a supply-gap alert once, and clears/refires when supply returns and drops again.
+func TestCheckProviderGapAlert(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+	registerLiveOffer(b, "n1", "gpt-oss-120b")
+
+	// On air: no gap.
+	b.checkProviderGapAlerts()
+	noAlert(t, sends)
+
+	// Node goes dark -> 0 providers for a model we saw on air -> one alert.
+	b.mu.Lock()
+	delete(b.nodes, "n1")
+	delete(b.lastSeen, "n1")
+	b.mu.Unlock()
+	b.checkProviderGapAlerts()
+	got := firstAlert(t, sends)
+	if !strings.Contains(got["subject"].(string), "gpt-oss-120b") || !strings.Contains(got["subject"].(string), "0 providers") {
+		t.Errorf("supply-gap subject = %v, want the model + 0 providers", got["subject"])
+	}
+	// Still gone: dedup.
+	b.checkProviderGapAlerts()
+	noAlert(t, sends)
+
+	// Supply returns (clear), then drops again (refire).
+	registerLiveOffer(b, "n2", "gpt-oss-120b")
+	b.checkProviderGapAlerts()
+	noAlert(t, sends)
+	b.mu.Lock()
+	delete(b.nodes, "n2")
+	delete(b.lastSeen, "n2")
+	b.mu.Unlock()
+	b.checkProviderGapAlerts()
+	firstAlert(t, sends)
+}
+
+// TestFirstBanAlert proves the first NEW ban (node or owner) pages the founder once.
+func TestFirstBanAlert(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+	b.banNode("n1", "report threshold (5 distinct reporters)")
+	got := firstAlert(t, sends)
+	if !strings.Contains(strings.ToLower(got["subject"].(string)), "ban") {
+		t.Errorf("first-ban subject = %v", got["subject"])
+	}
+	// A second ban (node or owner) is not the FIRST ban: dedup.
+	b.banNode("n2", "report threshold (5 distinct reporters)")
+	b.banOwner("pk_bad", "impossible_input", `{"x":1}`)
+	noAlert(t, sends)
+}
+
+// TestFirstReportAlert proves the first abuse report pages the founder once.
+func TestFirstReportAlert(t *testing.T) {
+	b, sends := alertBroker(t, "ops@example.com")
+	post := func() {
+		body, _ := json.Marshal(reportRequest{Category: "abuse", NodeID: "n1", Detail: "bad"})
+		r := httptest.NewRequest(http.MethodPost, "/report", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		b.report(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("/report = %d, want 200", w.Code)
+		}
+	}
+	post()
+	got := firstAlert(t, sends)
+	if !strings.Contains(strings.ToLower(got["subject"].(string)), "report") {
+		t.Errorf("first-report subject = %v", got["subject"])
+	}
+	// Second report: not the first -> dedup.
+	post()
+	noAlert(t, sends)
+}
+
+// TestFirstDisputeAlert drives a real charge.dispute.created webhook and asserts the first
+// dispute pages the founder once.
+func TestFirstDisputeAlert(t *testing.T) {
+	t.Setenv("STRIPE_SECRET_KEY", "sk_test_dummy")
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "whsec_test")
+	t.Setenv("ROGERAI_CREDIT_USD", "1")
+	b, sends := alertBroker(t, "ops@example.com")
+	b.bill = loadBilling()
+	mem := b.db.(*store.Mem)
+	_ = mem.BindOwner(store.Owner{GitHubID: 9, Login: "op", Pubkey: "pk1"})
+	_ = mem.BindNode("n", "pk1")
+
+	// Fund the wallet + persist the charge mapping so the dispute resolves.
+	csPayload, _ := json.Marshal(map[string]any{
+		"type": "checkout.session.completed",
+		"data": map[string]any{"object": map[string]any{
+			"id": "cs_d", "amount_total": 5000, "payment_intent": "pi_d",
+			"metadata": map[string]any{"user": "u_gh_9"},
+		}},
+	})
+	rcs := httptest.NewRequest(http.MethodPost, "/billing/webhook", bytes.NewReader(csPayload))
+	rcs.Header.Set("Stripe-Signature", stripeSig(csPayload, "whsec_test", time.Now().Unix()))
+	b.webhook(httptest.NewRecorder(), rcs)
+	// A test-mode key must NOT alert on the top-up, so nothing here.
+	noAlert(t, sends)
+
+	dp, _ := json.Marshal(map[string]any{
+		"type": "charge.dispute.created",
+		"data": map[string]any{"object": map[string]any{
+			"id": "dp_1", "amount": 5000, "payment_intent": "pi_d", "charge": "ch_d",
+		}},
+	})
+	r := httptest.NewRequest(http.MethodPost, "/billing/webhook", bytes.NewReader(dp))
+	r.Header.Set("Stripe-Signature", stripeSig(dp, "whsec_test", time.Now().Unix()))
+	w := httptest.NewRecorder()
+	b.webhook(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("dispute webhook = %d, want 200", w.Code)
+	}
+	got := firstAlert(t, sends)
+	if !strings.Contains(strings.ToLower(got["subject"].(string)), "dispute") {
+		t.Errorf("first-dispute subject = %v", got["subject"])
+	}
+}
+
+// TestFirstLiveTopupAlert proves the first REAL (sk_live) Stripe top-up pages the founder,
+// and that a TEST-mode top-up does NOT.
+func TestFirstLiveTopupAlert(t *testing.T) {
+	deliver := func(t *testing.T, secretKey string) (*broker, chan map[string]any) {
+		t.Setenv("STRIPE_SECRET_KEY", secretKey)
+		t.Setenv("STRIPE_WEBHOOK_SECRET", "whsec_test")
+		t.Setenv("ROGERAI_CREDIT_USD", "1")
+		b, sends := alertBroker(t, "ops@example.com")
+		b.bill = loadBilling()
+		p, _ := json.Marshal(map[string]any{
+			"type": "checkout.session.completed",
+			"data": map[string]any{"object": map[string]any{
+				"id": "cs_live", "amount_total": 2500, "payment_intent": "pi_live",
+				"metadata": map[string]any{"user": "u_gh_5"},
+			}},
+		})
+		r := httptest.NewRequest(http.MethodPost, "/billing/webhook", bytes.NewReader(p))
+		r.Header.Set("Stripe-Signature", stripeSig(p, "whsec_test", time.Now().Unix()))
+		w := httptest.NewRecorder()
+		b.webhook(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("topup webhook = %d, want 200", w.Code)
+		}
+		return b, sends
+	}
+
+	t.Run("test-mode does not alert", func(t *testing.T) {
+		_, sends := deliver(t, "sk_test_dummy")
+		noAlert(t, sends)
+	})
+
+	t.Run("live-mode alerts once", func(t *testing.T) {
+		b, sends := deliver(t, "sk_live_dummy")
+		got := firstAlert(t, sends)
+		if !strings.Contains(strings.ToLower(got["subject"].(string)), "top-up") {
+			t.Errorf("first-live-topup subject = %v", got["subject"])
+		}
+		// A second live top-up is not the FIRST: dedup.
+		p, _ := json.Marshal(map[string]any{
+			"type": "checkout.session.completed",
+			"data": map[string]any{"object": map[string]any{
+				"id": "cs_live2", "amount_total": 2500, "payment_intent": "pi_live2",
+				"metadata": map[string]any{"user": "u_gh_6"},
+			}},
+		})
+		r := httptest.NewRequest(http.MethodPost, "/billing/webhook", bytes.NewReader(p))
+		r.Header.Set("Stripe-Signature", stripeSig(p, "whsec_test", time.Now().Unix()))
+		b.webhook(httptest.NewRecorder(), r)
+		noAlert(t, sends)
+	})
+}

--- a/cmd/rogerai-broker/billing.go
+++ b/cmd/rogerai-broker/billing.go
@@ -264,6 +264,8 @@ func (b *broker) webhook(w http.ResponseWriter, r *http.Request) {
 			// Flag-gated transactional notice (async, best-effort): tell the consumer
 			// whose charge was disputed. No-op when RESEND_API_KEY is unset or no email.
 			b.emailDisputeOpened(b.emailOf(user), amount, o.ID)
+			// Founder ops alert: page on the FIRST chargeback dispute of this lifetime.
+			b.alertFirstDispute(o.ID, amount)
 			log.Printf("stripe: dispute %s on %s -%.4f credits (clawed %.4f from held/payable, %d paid-lot reversal(s), platform loss %.4f)",
 				o.ID, user, amount, res.Clawed, len(res.Reversals), res.PlatformLoss)
 		} else {
@@ -349,6 +351,11 @@ func (b *broker) webhook(w http.ResponseWriter, r *http.Request) {
 			}
 			if credited {
 				log.Printf("stripe: credited %s +%.4f -> %.4f (session %s)", user, credits, newBal, o.ID)
+				// Founder ops alert: page on the FIRST REAL (live-mode) top-up - the
+				// billing-works-end-to-end milestone. Test-mode top-ups never page.
+				if strings.HasPrefix(b.bill.secretKey, "sk_live") {
+					b.alertFirstLiveTopup(user, credits, newBal)
+				}
 			} else {
 				log.Printf("stripe: duplicate session %s ignored", o.ID)
 			}

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -281,6 +281,19 @@ type broker struct {
 	freeRegPerIP  int           // max NEW free node registrations per CF-IP per window (0 disables)
 	freeRegWindow time.Duration // the sliding window for the per-IP free-reg cap
 
+	// --- founder ops alerts (alerts.go) ---------------------------------------
+	// adminEmails is the parsed ADMIN_EMAIL recipient list; EMPTY => alerting is entirely
+	// OFF (fail-safe, zero behavior change). alertFiring tracks each condition's fired state
+	// for ONSET dedup (fire once on clear->fire, re-fire only after it clears); alertOnAirSeen
+	// tracks every model ever seen on air so the drop-to-0-providers transition is detectable.
+	// Both reset on restart (acceptable for an ops page). csamSLAHours is the CyberTipline
+	// filing SLA past which a still-queued incident pages the founder. All guarded by alertMu.
+	adminEmails    []string
+	alertMu        sync.Mutex
+	alertFiring    map[string]bool
+	alertOnAirSeen map[string]bool
+	csamSLAHours   int
+
 	// maxNodesPerOwner is the HARD server backstop: the max number of SIMULTANEOUSLY
 	// on-air nodes a single owner account may have live (within nodeTTL) across all of
 	// their machines. Enforced at register (the (limit+1)th owner-bound node is
@@ -383,6 +396,7 @@ func runServe(ln net.Listener, fee, seed float64, lock time.Duration, stop <-cha
 	go b.pruneStaleNodesSweep(stop)   // remove long-dead node registrations (old hostname ids that never re-register)
 	go b.refPriceSync(stop)           // refresh same-model external reference prices for the buyer-facing $-tier
 	go b.releaseStaleHoldsSweep(stop) // reclaim relay pre-auth holds stranded by a SIGKILLed redeploy (deploy-orphan backstop)
+	go b.alertCheckerLoop(stop)       // page the founder (ADMIN_EMAIL) on state-derived ops conditions (0-providers, db/valkey down, CSAM SLA); no-op when ADMIN_EMAIL is unset
 
 	log.Printf("rogerai-broker %s: addr=%s fee=%.0f%% (node-dials-out long-poll tunnel)", version, ln.Addr(), fee*100)
 
@@ -482,6 +496,12 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		strikeCorroborateKinds: strikeCorroborateKinds(),
 		recountHoldDays:        recountHoldDays(),
 		holdTTL:                holdTTL(),
+		// Founder ops alerts: ADMIN_EMAIL (comma-separated) => page the founder on
+		// operationally important events; unset => alerting entirely OFF (zero behavior change).
+		adminEmails:    parseAdminEmails(os.Getenv("ADMIN_EMAIL")),
+		alertFiring:    map[string]bool{},
+		alertOnAirSeen: map[string]bool{},
+		csamSLAHours:   csamSLAHoursEnv(),
 		// Admin surface is gated on the STABLE broker secret (BROKER_PRIVATE_KEY hex). An
 		// ephemeral/unset key leaves adminKey empty => the key path is CLOSED.
 		adminKey: validAdminKey(os.Getenv("BROKER_PRIVATE_KEY")),

--- a/cmd/rogerai-broker/report.go
+++ b/cmd/rogerai-broker/report.go
@@ -336,6 +336,8 @@ func (b *broker) banNode(nodeID, reason string) {
 			b.bumpBanRev()
 		}
 		log.Printf("ban: node=%s EJECTED from routing (%s)", nodeID, reason)
+		// Founder ops alert: page on the FIRST ban of this lifetime (safety escalation).
+		b.alertFirstBan("node", nodeID, reason)
 	}
 }
 
@@ -480,6 +482,13 @@ func (b *broker) report(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Printf("report: category=%s node=%q request=%q ip=%s", cat, nodeID, strings.TrimSpace(req.RequestID), ip)
+
+	// Founder ops alert: page on the FIRST safety report (abuse/CSAM) of this lifetime.
+	// Low-signal categories (quality/spam) downrank via trust and are not a safety
+	// escalation, so they do not page. Deduped on a constant key (first ever only).
+	if cat == "abuse" || cat == "csam" {
+		b.alertFirstReport(cat, nodeID)
+	}
 
 	// Per-node CORROBORATED auto-eject: a node is suspended only once enough DISTINCT
 	// reporters (distinct reporter IPs) name it WITHIN the decay window - never on a raw

--- a/cmd/rogerai-broker/strikes.go
+++ b/cmd/rogerai-broker/strikes.go
@@ -197,6 +197,8 @@ func (b *broker) banOwner(accountID, reason, evidenceJSON string) {
 			b.bumpBanRev()
 		}
 		log.Printf("BAN owner=%s EJECTED (durable, anti-rotation): %s - blocked at register + relay pick + settle for ALL current/future nodes", accountID, reason)
+		// Founder ops alert: page on the FIRST ban of this lifetime (safety escalation).
+		b.alertFirstBan("account", accountID, reason)
 	}
 }
 


### PR DESCRIPTION
Pages the founder (all recipients in ADMIN_EMAIL) on operationally important events, instead of them being log-only. Spec-first; ships OFF unless ADMIN_EMAIL is set (unset = zero behavior change).

## Alerts (fire once on onset, dedup, re-fire after clear)
- Ledger drift (verify-vs-balance invariant broke)
- A live model dropped to 0 providers (supply gap)
- DB / Valkey unreachable
- First REAL (sk_live) Stripe top-up - billing-works milestone (test-mode never pages)
- First ban / dispute / abuse-or-csam report (safety escalation)
- CSAM item past SLA (ROGERAI_CSAM_SLA_HOURS, default 24)

## Safety
- All hooks are additive calls placed AFTER existing money logic - no control-flow or ledger changes.
- Fail-safe: no ADMIN_EMAIL => alerting fully off; reuses the existing async failure-swallowing mailer; alert paths never block/error the request.
- ADMIN_EMAIL is comma-separated; every address is alerted.

## Verify
- Spec-first TDD (alerts_test.go), make cover-gate PASS (total 92.2%, cmd/rogerai-broker 90.6%), go vet clean, full broker suite + race green.

## To activate after merge
Set on the broker app: ADMIN_EMAIL=lramos85@gmail.com,rossi.ramos@icloud.com,larry_rivera@mac.com