### PR TITLE
broker: stop Ping leaking gpt-oss reasoning into public replies

### DIFF
--- a/cmd/rogerai-broker/concierge.go
+++ b/cmd/rogerai-broker/concierge.go
@@ -370,7 +370,7 @@ func (b *broker) dogfoodRelay(messages []chatMsg) (reply string, served bool) {
 		if res.Status < 200 || res.Status >= 300 {
 			return "", false
 		}
-		return completionText(res.Body), true
+		return conciergeReplyText(res.Body), true
 	case <-time.After(c.relayWait()):
 		return "", false
 	}
@@ -536,7 +536,7 @@ func (b *broker) grantRelayOnce(t *nodeTunnel, model, node string, rawBody []byt
 			log.Printf("CONCIERGE grant-dogfood miss: relay-error (status %d) model=%q node=%s", res.Status, model, node)
 			return "", false, true
 		}
-		return completionText(res.Body), true, true
+		return conciergeReplyText(res.Body), true, true
 	case <-time.After(c.relayWait()):
 		log.Printf("CONCIERGE grant-dogfood miss: relay-error (result timeout) model=%q node=%s", model, node)
 		return "", false, true
@@ -678,7 +678,7 @@ func (b *broker) groqCall(messages []chatMsg) (reply string, ok bool) {
 		return "", false
 	}
 	rb, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	return completionText(rb), true
+	return conciergeReplyText(rb), true
 }
 
 // defaultRelayTimeout is the result-wait used when relayTimeout was never configured
@@ -761,6 +761,62 @@ func lastUserText(msgs []chatMsg) string {
 		}
 	}
 	return ""
+}
+
+// conciergeReplyText extracts ONLY the user-facing answer from an OpenAI chat-completions
+// body for the PUBLIC Ping surface. Unlike completionText (which counts content AND
+// reasoning together for the anti-fraud recount/void path - everything the node generated),
+// this returns just the VISIBLE reply and never concatenates the model's private analysis:
+//
+//   - `content` when it has non-whitespace text (the clean answer);
+//   - else the `reasoning` field (some reasoning models put the whole answer there with
+//     empty content - preserve that as a fallback, never as an addition);
+//   - else the legacy `text` field as a last resort.
+//
+// Concatenating content+reasoning leaked gpt-oss's chain-of-thought into Ping's reply (the
+// real bug: a clean greeting followed by "We need to respond in character... Politely
+// decline."). It also normalizes the founder's public-copy house style: any em/en dash
+// becomes a spaced hyphen and accidental double spaces collapse, so every Ping reply is clean.
+func conciergeReplyText(body []byte) string {
+	var resp struct {
+		Choices []struct {
+			Message struct {
+				Content   string `json:"content"`
+				Reasoning string `json:"reasoning"`
+			} `json:"message"`
+			Text string `json:"text"`
+		} `json:"choices"`
+	}
+	if json.Unmarshal(body, &resp) != nil {
+		return ""
+	}
+	var out bytes.Buffer
+	for _, c := range resp.Choices {
+		switch {
+		case strings.TrimSpace(c.Message.Content) != "":
+			out.WriteString(c.Message.Content) // the visible answer - never appended to
+		case strings.TrimSpace(c.Message.Reasoning) != "":
+			out.WriteString(c.Message.Reasoning) // fallback ONLY when content is empty
+		case strings.TrimSpace(c.Text) != "":
+			out.WriteString(c.Text) // legacy completions shape, last resort
+		}
+	}
+	return normalizeHouseDashes(out.String())
+}
+
+// normalizeHouseDashes enforces the founder's public-copy rule (NO em dashes): it replaces
+// every em dash (U+2014) and en dash (U+2013) with a spaced hyphen and collapses the
+// accidental double spaces that leaves (or that an already-spaced dash produced), so the
+// public Ping reply reads in the house " - " style.
+func normalizeHouseDashes(s string) string {
+	if !strings.ContainsRune(s, '—') && !strings.ContainsRune(s, '–') {
+		return s
+	}
+	s = strings.NewReplacer("—", " - ", "–", " - ").Replace(s)
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	return s
 }
 
 // isUnsafe is the blatant-keyword precheck (stopgap; see concierge doc comment).

--- a/cmd/rogerai-broker/concierge_reply_text_test.go
+++ b/cmd/rogerai-broker/concierge_reply_text_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestConciergeReplyText pins the PUBLIC concierge reply extractor: it returns ONLY the
+// user-facing answer and NEVER leaks the gpt-oss `reasoning` (chain-of-thought) into the
+// visible reply. The real production leak: a reply whose visible `content` was the greeting
+// AND whose `reasoning` was "We need to respond in character..." got both concatenated, so
+// Ping showed the model's private analysis to the public homepage. conciergeReplyText must
+// return the content alone; reasoning is only a FALLBACK when content is empty. It also
+// normalizes the founder house style: no em/en dashes in public copy.
+func TestConciergeReplyText(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		want    string
+		absent  string // substring that must NOT appear (leak guard); "" = skip
+		noEmDsh bool   // assert no em/en dash remains
+	}{
+		{
+			name:   "content and reasoning both present -> ONLY content (the regression)",
+			body:   `{"choices":[{"message":{"role":"assistant","content":"I'm here to guide you on tuning in to RogerAI or sharing your GPU to earn - let me know!","reasoning":"We need to respond in character, short, on-topic. User asks is this real? It's off-topic. Politely decline."}}]}`,
+			want:   "I'm here to guide you on tuning in to RogerAI or sharing your GPU to earn - let me know!",
+			absent: "We need to respond in character",
+		},
+		{
+			name: "empty content + reasoning present -> reasoning (fallback preserved)",
+			body: `{"choices":[{"message":{"content":"","reasoning":"the answer is 42"}}]}`,
+			want: "the answer is 42",
+		},
+		{
+			name: "whitespace-only content + reasoning present -> reasoning (fallback)",
+			body: `{"choices":[{"message":{"content":"   ","reasoning":"tune in with the install script"}}]}`,
+			want: "tune in with the install script",
+		},
+		{
+			name: "content only -> content",
+			body: `{"choices":[{"message":{"content":"hello from Ping"}}]}`,
+			want: "hello from Ping",
+		},
+		{
+			name: "neither content nor reasoning -> empty",
+			body: `{"choices":[{"message":{"content":""}}]}`,
+			want: "",
+		},
+		{
+			name: "text field as a secondary when content+reasoning empty",
+			body: `{"choices":[{"message":{"content":"","reasoning":""},"text":"legacy completion text"}]}`,
+			want: "legacy completion text",
+		},
+		{
+			name: "unparseable body -> empty",
+			body: `not json at all`,
+			want: "",
+		},
+		{
+			name: "multi-choice joins each choice's visible content (no reasoning leak)",
+			body: `{"choices":[{"message":{"content":"first.","reasoning":"secret one"}},{"message":{"content":"second.","reasoning":"secret two"}}]}`,
+			want: "first.second.",
+		},
+		{
+			name:    "em dash in content becomes a spaced hyphen",
+			body:    `{"choices":[{"message":{"content":"owners keep 70%—the platform takes 30%"}}]}`,
+			want:    "owners keep 70% - the platform takes 30%",
+			noEmDsh: true,
+		},
+		{
+			name:    "en dash in content becomes a spaced hyphen",
+			body:    `{"choices":[{"message":{"content":"one–two"}}]}`,
+			want:    "one - two",
+			noEmDsh: true,
+		},
+		{
+			name:    "already-spaced em dash collapses to a single spaced hyphen",
+			body:    `{"choices":[{"message":{"content":"share — earn"}}]}`,
+			want:    "share - earn",
+			noEmDsh: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := conciergeReplyText([]byte(tc.body))
+			if got != tc.want {
+				t.Fatalf("conciergeReplyText:\n got  %q\n want %q", got, tc.want)
+			}
+			if tc.absent != "" && strings.Contains(got, tc.absent) {
+				t.Fatalf("reasoning LEAKED into visible reply: %q still contains %q", got, tc.absent)
+			}
+			if tc.noEmDsh && (strings.ContainsRune(got, '—') || strings.ContainsRune(got, '–')) {
+				t.Fatalf("em/en dash survived normalization: %q", got)
+			}
+		})
+	}
+}
+
+// TestCompletionTextUnchangedByConciergeFix guards the anti-fraud invariant: the recount /
+// probe / void path still counts content AND reasoning together (everything the node
+// generated), so the concierge fix must NOT alter completionText. A body with both fields
+// still returns content+reasoning concatenated for the billing/verification path.
+func TestCompletionTextUnchangedByConciergeFix(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"content":"visible answer","reasoning":"hidden analysis"}}]}`)
+	got := completionText(body)
+	if !strings.Contains(got, "visible answer") || !strings.Contains(got, "hidden analysis") {
+		t.Fatalf("completionText must still count content+reasoning for recount: got %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

The public homepage concierge (\"Ping\") leaked the gpt-oss model's private reasoning / chain-of-thought into its visible reply. Real observed leak:

> I'm here to guide you on tuning in to RogerAI or sharing your GPU to earn - let me know!**We need to respond in character, short, on-topic. User asks \"is this real?\" It's off-topic. Politely decline.**

The bolded second sentence is the model's private analysis, shown to the public.

## Root cause

The three concierge relay/fallback paths extracted the reply with `completionText()`, which by design concatenates the assistant `content` AND the `reasoning` field. gpt-oss returns a clean answer in `content` AND its analysis in `reasoning`, so concatenating them exposed the chain-of-thought on the public surface.

`completionText` is ALSO used by the anti-fraud recount / quality / void path (`recount.go`, `tunnel.go`, `probe.go`), where counting `content + reasoning` together is CORRECT: it verifies everything the node actually generated (and prevents a false empty-output ban of honest reasoning-model nodes). So that behavior must NOT change.

## Fix

- New `conciergeReplyText(body []byte) string`: a user-facing extractor that returns ONLY the visible answer - `content` when non-empty, falling back to `reasoning` ONLY when content is empty/whitespace (some reasoning models put the whole answer there), then `text` as a last resort. It NEVER concatenates content + reasoning.
- The three concierge callers switch to it: `dogfoodRelay`, `grantRelayOnce`, `groqCall`.
- `completionText` is left intact; the recount / probe / tunnel callers stay on it (invariant preserved).
- Public-copy house style: `conciergeReplyText` normalizes any em/en dash to a spaced hyphen and collapses accidental double spaces, so every Ping reply is clean (founder rule: no em dashes in public copy).

## Tests (spec-first, RED then GREEN)

RED (before implementation):
```
cmd/rogerai-broker/concierge_reply_text_test.go:85:11: undefined: conciergeReplyText
FAIL	github.com/rogerai-fyi/roger/cmd/rogerai-broker [build failed]
```

GREEN table test `TestConciergeReplyText` covers: content+reasoning both present -> ONLY content (the exact regression, asserts the reasoning text is ABSENT); empty/whitespace content + reasoning -> reasoning (fallback preserved); content only; neither -> \"\"; text secondary; unparseable -> \"\"; multi-choice; em dash and en dash -> spaced hyphen with no dash remaining. `TestCompletionTextUnchangedByConciergeFix` pins that `completionText` still returns content+reasoning for the recount path.

- Full broker suite: `ok` (144s)
- `go vet ./cmd/rogerai-broker/`: clean
- Broker package coverage: 90.5% (>= 90% GREEN bar); `conciergeReplyText` and `normalizeHouseDashes` at 100%, `completionText` still 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ny8VyF5BQCpazjDsxqXC6t