### PR TITLE
web: add 'In under 30 seconds.' speed line to the hero

### DIFF
--- a/web/src/index.html
+++ b/web/src/index.html
@@ -31,7 +31,7 @@
       </span>
 
       <h1 class="hero__title" data-reveal data-reveal-delay="60">
-        Tune in to the world's<br /><span class="hero__op">home GPUs</span>.
+        Tune in to the world's<br /><span class="hero__op">home GPUs</span>.<br /><span class="hero__fast">In under 30 seconds.</span>
       </h1>
 
       <p class="hero__sub" data-reveal data-reveal-delay="120">

--- a/web/src/styles/home.css
+++ b/web/src/styles/home.css
@@ -35,6 +35,12 @@
   content: ""; position: absolute; left: 0; right: 0; bottom: -0.04em;
   height: 3px; background: var(--live);
 }
+/* the speed beat: a smaller, muted line under the main statement (still part of the H1) */
+.hero__fast {
+  display: inline-block; margin-top: 0.12em;
+  font-size: 0.58em; font-weight: var(--weight-semi);
+  letter-spacing: var(--tracking-display); color: var(--ink-500);
+}
 .hero__sub {
   margin-top: var(--s-6); max-width: 56ch;
   font-size: var(--t-lead); color: var(--ink-500); line-height: 1.5;


### PR DESCRIPTION
Adds a smaller, muted third line under the homepage headline: 'Tune in to the world's home GPUs. / In under 30 seconds.' - reinforces the one-line install. New `.hero__fast` style (0.58em, muted ink-500), part of the H1. Built clean (22 pages).