### PR TITLE
release: v5.0.2 prep (version + changelog + current-version badges)

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -40,7 +40,7 @@ import (
 //
 // The default below is the fallback for a plain `go build`. Keep it in sync with
 // releases. Use semver, optionally with a prerelease suffix (e.g. 4.8.0-beta.1).
-var Version = "5.0.1"
+var Version = "5.0.2"
 
 // The production broker is the default - `rogerai` works out of the box, no config.
 // Override per-session with ROGER_BROKER=... or persist with `roger config set broker`.

--- a/web/src/manual.html
+++ b/web/src/manual.html
@@ -35,7 +35,7 @@
         </p>
         <div class="man-cover__meta">
           <span>Set: <b>rogerai</b></span>
-          <span>Version: <b data-cli-version>v5.0.1</b></span>
+          <span>Version: <b data-cli-version>v5.0.2</b></span>
           <span>Broker: <b>broker.rogerai.fyi</b></span>
           <span>Protocol: <b>OpenAI-compatible</b></span>
         </div>
@@ -918,7 +918,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
           <section class="man-sec" id="s9">
             <span class="man-sec__no">§9 · Command reference</span>
             <h2>Every command, every key</h2>
-            <p>The full surface as of <b data-cli-version>v5.0.1</b>: the top-level CLI
+            <p>The full surface as of <b data-cli-version>v5.0.2</b>: the top-level CLI
               commands with their key flags, then the in-app keys and slash commands grouped
               by context. Run any command with <code>--help</code> for its flags; advanced
               flags hide behind <code>--advanced</code>. Run <code>rogerai</code> with no
@@ -1198,6 +1198,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
               Newest first. The set self-updates - <code>roger upgrade</code> pulls the
               latest, <code>roger upgrade --check</code> just reports.</p>
             <div class="man-plate">
+              <div class="man-plate__row"><span class="man-plate__k">v5.0.2</span><span class="man-plate__v">Operator alerts and steadier broadcasts. When <code>ADMIN_EMAIL</code> is set, the founder now gets ops-alert emails (provider drift, zero providers, DB/Valkey trouble, the first live top-up, ban, dispute and report, and the CSAM SLA clock). Vision-capable chat models are labeled end-to-end in <code>/market capabilities</code>, <code>/me</code> reports your linked GitHub/Apple sign-ins, config saves are durable (unknown keys preserved, atomic write, and clearing a field is honored), and the Base Station roster self-cleans ended and long-idle sessions. Fixes: Ping no longer leaks gpt-oss reasoning into public replies, Base Station live-stream no longer 500s, node registration no longer 401s, and a headless voice share recovers its identity on node-id drift.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.0.1</span><span class="man-plate__v">Hardening and fixes. One broadcaster per node id on every surface (a second <code>roger share</code> or TUI now refuses cleanly instead of fighting for the frequency), voice shares keep their name and sample, and stations fail honestly (a dead voice band times out with a clear message; a seed hiccup retries instead of a false "add funds"). Plus a security pass across job delivery, grant scope, and moderation.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.0.0</span><span class="man-plate__v">Remote control + BASE STATION - run <code>/remote-control</code> in the agent to put a live session on the air, then continue it from another terminal (<code>roger remote attach</code>), the web console (Base Station), or the app. Private to your account, one-time link codes for a phone, broker-relayed (not end-to-end encrypted); tools still run on the host and still confirm first.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v4.15.0</span><span class="man-plate__v">Voices, first-class - cue shared DJ voices in TUNE IN, share your own in the VOICE BOOTH (pick/blend/speed/preview), namespaced + attributed by operator; public roster at <code>/voices</code>.</span></div>


### PR DESCRIPTION
## v5.0.2 release prep

Version + changelog + current-version badges only. The git tag drives the built binary version; this keeps the in-tree fallback and the docs honest. **Do not merge, tag, or publish yet** - the tag/publish steps below are deliberate founder actions.

### Version bumped in every place v5.0.1 set it
Matches exactly what the v5.0.1 prep commit (`9147c32`) touched - the same two files:

| File | Location | 5.0.1 -> 5.0.2 |
|---|---|---|
| `cmd/rogerai/main.go` | `var Version` (the `go build` fallback; the tag overrides it via `-X main.Version`) | yes |
| `web/src/manual.html` | cover `data-cli-version` badge (cover) | yes |
| `web/src/manual.html` | section 9 command-reference `data-cli-version` badge | yes |
| `web/src/manual.html` | Appendix C changelog: new `v5.0.2` `man-plate__row` at top | yes |

There is no separate `CHANGELOG.md`, `install.sh` version pin, or Homebrew formula in this repo. `web/install.sh` fetches the latest GitHub release asset (no version literal to bump), and the changelog lives in `manual.html` (Appendix C). `web/dist/*` is built and gitignored - not committed.

### Version-sync result
The pre-push hook runs `make cover-gate-fast` for doc/web-only pushes; it rebuilds the manual and asserts it mentions the `const Version` from `main.go`:

```
[cover-gate-fast] no-Go push: build + vet + web build + version-sync (Postgres coverage skipped)
[cover-gate-fast] OK - built manual mentions v5.0.2
```

(The pre-push `claude-audit` also returned `VERDICT=PASS`, build pass.)

### What shipped since v5.0.1 (grounded in `git log v5.0.1..origin/main`)

**Added**
- Founder ops-alert emails: provider drift, zero providers, DB/Valkey trouble, the first live top-up / ban / dispute / report, and the CSAM SLA clock. Off unless `ADMIN_EMAIL` is set. (`b1b9fa6`, #6)
- Vision-capability labeling flows end-to-end and is shown in `/market capabilities`; explicit `--upstream` + wire-preserve `[]`. (`74b109f`, `ceb327b`)
- `GET /me` reports linked sign-in providers (github/apple). (`cf25b0a`)
- Homepage hero speed line "In under 30 seconds." (`93ec0c8`, #8)

**Fixed**
- Ping no longer leaks gpt-oss reasoning into public replies. (`8f752af`, #7)
- Base Station live-stream 500 - RC SSE now bypasses the `TimeoutHandler`. (`3df54b1`)
- Node registration 401 - capabilities excluded from the possession proof. (`25337f7`)
- Headless voice share recovers its identity from the sole saved profile on node-id drift. (`b619ec7`)

**Changed**
- Durable config saves: preserve unknown keys, atomic write, merge; clearing a known `omitempty` field is honored. (`a05259b`, `7a4615e`)
- The remote-control roster self-cleans ended + long-idle sessions. (`e7f8554`)

_Internal-only, not in the user changelog: `d1e99fb` (RC invariant specs made executable), `962dc72` (drop a dead nil-branch)._

> Note: the "roger-admin Ops panel + Cloudflare Access" and an "operators-on-air headline" mentioned in the tasking do **not** appear in `v5.0.1..origin/main` for this repo, so they are not listed here (not invented). Everything above is grounded in the 14 commits in range.

---

## To cut v5.0.2 (founder runbook - do NOT run from this PR)

1. **Merge this PR** into `main` (base `main`).
2. **Pull the merged main locally:** `git checkout main && git pull origin main`.
3. **Tag the release commit** (annotated, matching the v5.0.1 pattern - the tag is the single source of truth for the binary version, `v5.0.2` -> `main.Version=5.0.2`):
   ```
   git tag -a v5.0.2 -m "v5.0.2 - <release title>"
   ```
4. **Push the tag** - this is what publishes:
   ```
   git push origin v5.0.2
   ```
5. **CI does the build + publish.** Pushing a `v*` tag triggers `.github/workflows/release.yml`:
   - `gate` job: full test suite + `scripts/cover-gate.sh` on the tagged commit (a release never ships over a red gate).
   - `release` job (needs `gate`): cross-compiles the `roger`/`rogerai` CLI for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64 via `CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.Version=${TAG#v}"`, writes `dist/checksums.txt`, and publishes a GitHub Release with those assets + auto-generated notes (`softprops/action-gh-release@v2`).
   - No goreleaser and no Makefile release target - the workflow is the whole pipeline.
6. **No install.sh / Homebrew edit needed.** `web/install.sh` pulls the latest GitHub Release asset (`roger-<os>-<arch>`), so it picks up v5.0.2 automatically once the release is published. `roger upgrade` / `roger upgrade --check` then see the new version.
7. **Verify** after CI is green: the Release lists all 6 binaries + `checksums.txt`, and `roger version` on a freshly-installed binary prints `5.0.2`.

_Not part of cutting the release: the web deploy (DigitalOcean App Platform behind Cloudflare) ships the updated `manual.html` badges/changelog on the normal `main` deploy._
