### PR TITLE
broker: add infra (topology) block to /admin/live

### DIFF
--- a/cmd/rogerai-broker/admin.go
+++ b/cmd/rogerai-broker/admin.go
@@ -76,6 +76,53 @@ func (b *broker) liveMarket(now time.Time) map[string]any {
 	}
 }
 
+// instancesLive reports the number of DISTINCT live broker instances. In single-instance mode
+// it is always 1 (this process). In multi-instance mode it counts the live presence heartbeats
+// in the shared store, falling back to 1 (this instance is always live) when the store is
+// unreachable or reports none - so the ops panel never renders a bogus 0-live-instances fleet.
+func (b *broker) instancesLive() int {
+	if !b.multiInstance || b.shared == nil {
+		return 1
+	}
+	n, err := b.shared.liveInstances()
+	if err != nil || n < 1 {
+		return 1
+	}
+	return n
+}
+
+// infra is the topology/redundancy block of /admin/live: the cross-instance posture the ops
+// panel renders (fleet size + redundancy, bus mode, shared-store reachability). A pure,
+// non-blocking read of broker state — every backend touch is bounded and degrades to a safe
+// fallback (never panics, never blocks). db/version/uptime_seconds stay in the health block
+// (reused, not duplicated). instances_live is read FIRST so its shared-store read refreshes
+// reachability before shared_store.reachable is snapshotted.
+func (b *broker) infra() map[string]any {
+	live := b.instancesLive()
+	role := "none"
+	reachable := false
+	if b.shared != nil {
+		reachable = b.shared.healthy()
+		kind := "memory"
+		if _, ok := b.shared.(*valkeyStore); ok {
+			kind = "valkey"
+		}
+		mode := "accelerator"
+		if b.multiInstance {
+			mode = "accelerator+bus"
+		}
+		role = kind + " " + mode
+	}
+	return map[string]any{
+		"multi_instance": b.multiInstance,
+		"instances_live": live,
+		"shared_store": map[string]any{
+			"reachable": reachable,
+			"role":      role,
+		},
+	}
+}
+
 // adminLive handles GET /admin/live: the broker's LIVE operational snapshot — the in-memory
 // state that exists ONLY in this process and so can't be read from Postgres by roger-admin:
 // readiness/health, the live marketplace counts, the cross-instance dispatch counters, and the
@@ -132,6 +179,7 @@ func (b *broker) adminLive(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"now":              now.Unix(),
 		"health":           health,
+		"infra":            b.infra(),
 		"marketplace_live": b.liveMarket(now),
 		"seed_funded":      seeded,
 		"seed_limit":       seedLimit,

--- a/cmd/rogerai-broker/admin_infra_test.go
+++ b/cmd/rogerai-broker/admin_infra_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// liveInfra drives an admin-keyed GET /admin/live and returns the parsed infra + health blocks.
+func liveInfra(t *testing.T, b *broker) (infra, health map[string]any) {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, "/admin/live", nil)
+	r.Header.Set("X-Roger-Admin", b.adminKey)
+	w := httptest.NewRecorder()
+	b.adminLive(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("adminLive = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("live not JSON: %v", err)
+	}
+	in, ok := resp["infra"].(map[string]any)
+	if !ok {
+		t.Fatalf("response missing infra block; keys=%v", keysOf(resp))
+	}
+	h, ok := resp["health"].(map[string]any)
+	if !ok {
+		t.Fatalf("response missing health block; keys=%v", keysOf(resp))
+	}
+	return in, h
+}
+
+// TestAdminLiveInfraSingleInstance: with the bus OFF (no shared store), infra reports
+// multi_instance=false, exactly 1 live instance, and shared_store reachable=false role=none,
+// while health still carries version/uptime_seconds/db (reused, not duplicated into infra).
+func TestAdminLiveInfraSingleInstance(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("ROGERAI_REDIS_URL", "")
+	t.Setenv("ROGERAI_MULTI_INSTANCE", "")
+	_, priv, _ := ed25519.GenerateKey(nil)
+	b := buildBroker(store.NewMem(), priv, 0.30, 100, time.Hour)
+	b.adminKey = "k"
+
+	infra, health := liveInfra(t, b)
+	if infra["multi_instance"] != false {
+		t.Errorf("multi_instance = %v, want false", infra["multi_instance"])
+	}
+	if infra["instances_live"] != float64(1) {
+		t.Errorf("instances_live = %v, want 1", infra["instances_live"])
+	}
+	ss, ok := infra["shared_store"].(map[string]any)
+	if !ok {
+		t.Fatalf("infra missing shared_store")
+	}
+	if ss["reachable"] != false {
+		t.Errorf("shared_store.reachable = %v, want false", ss["reachable"])
+	}
+	if ss["role"] != "none" {
+		t.Errorf("shared_store.role = %v, want none", ss["role"])
+	}
+	// db/version/uptime are reused from health, not re-emitted under infra.
+	for _, k := range []string{"version", "uptime_seconds", "db"} {
+		if _, ok := health[k]; !ok {
+			t.Errorf("health missing %q; got %v", k, keysOf(health))
+		}
+	}
+}
+
+// TestAdminLiveInfraMultiInstancePeers: with the bus ON over a reachable Valkey, instances_live
+// reflects the DISTINCT live presence heartbeats in the shared store (this instance + 2 seeded
+// peers = 3), shared_store is reachable with the valkey accelerator+bus role.
+func TestAdminLiveInfraMultiInstancePeers(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	mr := miniredis.RunT(t)
+	t.Setenv("ROGERAI_REDIS_URL", "redis://"+mr.Addr())
+	t.Setenv("ROGERAI_MULTI_INSTANCE", "1")
+	_, priv, _ := ed25519.GenerateKey(nil)
+	b := buildBroker(store.NewMem(), priv, 0.30, 100, time.Hour)
+	t.Cleanup(func() { _ = b.shared.Close() })
+	b.adminKey = "k"
+
+	if !b.multiInstance {
+		t.Fatal("multi-instance must be ON")
+	}
+	// buildBroker marks THIS instance present at startup; seed two peers directly.
+	now := time.Now()
+	if err := b.shared.markInstance("peer-a", now); err != nil {
+		t.Fatalf("markInstance peer-a: %v", err)
+	}
+	if err := b.shared.markInstance("peer-b", now); err != nil {
+		t.Fatalf("markInstance peer-b: %v", err)
+	}
+
+	infra, _ := liveInfra(t, b)
+	if infra["multi_instance"] != true {
+		t.Errorf("multi_instance = %v, want true", infra["multi_instance"])
+	}
+	if infra["instances_live"] != float64(3) {
+		t.Errorf("instances_live = %v, want 3 (self + 2 peers)", infra["instances_live"])
+	}
+	ss := infra["shared_store"].(map[string]any)
+	if ss["reachable"] != true {
+		t.Errorf("shared_store.reachable = %v, want true", ss["reachable"])
+	}
+	if ss["role"] != "valkey accelerator+bus" {
+		t.Errorf("shared_store.role = %v, want 'valkey accelerator+bus'", ss["role"])
+	}
+}
+
+// TestAdminLiveInfraSharedUnreachable: the bus is ON but the Valkey backend is gone. The read
+// must NOT panic or block, must still 200, report shared_store reachable=false, and fall back to
+// a self-only count of 1 (never 0 live instances).
+func TestAdminLiveInfraSharedUnreachable(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	mr := miniredis.RunT(t)
+	t.Setenv("ROGERAI_REDIS_URL", "redis://"+mr.Addr())
+	t.Setenv("ROGERAI_MULTI_INSTANCE", "1")
+	_, priv, _ := ed25519.GenerateKey(nil)
+	b := buildBroker(store.NewMem(), priv, 0.30, 100, time.Hour)
+	t.Cleanup(func() { _ = b.shared.Close() })
+	b.adminKey = "k"
+	if !b.multiInstance {
+		t.Fatal("multi-instance must be ON")
+	}
+
+	mr.Close() // backend gone
+
+	infra, _ := liveInfra(t, b)
+	if infra["multi_instance"] != true {
+		t.Errorf("multi_instance = %v, want true", infra["multi_instance"])
+	}
+	if infra["instances_live"] != float64(1) {
+		t.Errorf("instances_live = %v, want 1 (self-only fallback)", infra["instances_live"])
+	}
+	ss := infra["shared_store"].(map[string]any)
+	if ss["reachable"] != false {
+		t.Errorf("shared_store.reachable = %v, want false", ss["reachable"])
+	}
+}

--- a/cmd/rogerai-broker/instance_presence_test.go
+++ b/cmd/rogerai-broker/instance_presence_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+)
+
+// TestValkeyInstancePresence: markInstance records a per-instance presence heartbeat that
+// liveInstances counts as one DISTINCT live instance; a presence key that expires past
+// instanceTTL is no longer counted (a crashed instance ages out of the fleet).
+func TestValkeyInstancePresence(t *testing.T) {
+	mr := miniredis.RunT(t)
+	v, err := newValkeyStore("redis://" + mr.Addr())
+	if err != nil {
+		t.Fatalf("newValkeyStore: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+
+	now := time.Now()
+	// Empty fleet -> 0 live.
+	if n, err := v.liveInstances(); err != nil || n != 0 {
+		t.Fatalf("liveInstances(empty) = %d, %v; want 0, nil", n, err)
+	}
+
+	if err := v.markInstance("a", now); err != nil {
+		t.Fatalf("markInstance a: %v", err)
+	}
+	if err := v.markInstance("b", now); err != nil {
+		t.Fatalf("markInstance b: %v", err)
+	}
+	// Re-marking the same id is idempotent (still one distinct instance).
+	if err := v.markInstance("a", now); err != nil {
+		t.Fatalf("markInstance a (again): %v", err)
+	}
+
+	if n, err := v.liveInstances(); err != nil || n != 2 {
+		t.Fatalf("liveInstances = %d, %v; want 2, nil", n, err)
+	}
+
+	// Age a's presence past instanceTTL: it drops out, b remains (refreshed).
+	mr.FastForward(instanceTTL + time.Second)
+	if err := v.markInstance("b", time.Now()); err != nil {
+		t.Fatalf("markInstance b (refresh): %v", err)
+	}
+	if n, err := v.liveInstances(); err != nil || n != 1 {
+		t.Fatalf("liveInstances(after expiry) = %d, %v; want 1, nil", n, err)
+	}
+}
+
+// TestValkeyInstancePresenceBackendDown: with the backend gone, both presence ops return an
+// error and never panic (the caller degrades to a self-only count).
+func TestValkeyInstancePresenceBackendDown(t *testing.T) {
+	mr := miniredis.RunT(t)
+	v, err := newValkeyStore("redis://" + mr.Addr())
+	if err != nil {
+		t.Fatalf("newValkeyStore: %v", err)
+	}
+	mr.Close()
+
+	if err := v.markInstance("a", time.Now()); err == nil {
+		t.Error("markInstance must error when the backend is down")
+	}
+	if _, err := v.liveInstances(); err == nil {
+		t.Error("liveInstances must error when the backend is down")
+	}
+}
+
+// TestMemStoreInstancePresence: the inert default store no-ops both presence primitives so the
+// in-memory single-instance path never touches a backend.
+func TestMemStoreInstancePresence(t *testing.T) {
+	m := newMemStore()
+	if err := m.markInstance("a", time.Now()); err == nil {
+		t.Error("memStore.markInstance must return the no-shared-store sentinel")
+	}
+	if n, err := m.liveInstances(); err == nil || n != 0 {
+		t.Errorf("memStore.liveInstances = %d, %v; want 0, err", n, err)
+	}
+}

--- a/cmd/rogerai-broker/instance_presence_test.go
+++ b/cmd/rogerai-broker/instance_presence_test.go
@@ -47,6 +47,16 @@ func TestValkeyInstancePresence(t *testing.T) {
 	if n, err := v.liveInstances(); err != nil || n != 1 {
 		t.Fatalf("liveInstances(after expiry) = %d, %v; want 1, nil", n, err)
 	}
+	// The expired id must be PRUNED from the set (not left to accumulate across restarts).
+	members, err := mr.SMembers(instancesSetKey)
+	if err != nil {
+		t.Fatalf("SMembers: %v", err)
+	}
+	for _, m := range members {
+		if m == "a" {
+			t.Errorf("expired instance 'a' still in the set %v; want pruned", members)
+		}
+	}
 }
 
 // TestValkeyInstancePresenceBackendDown: with the backend gone, both presence ops return an

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -562,6 +562,10 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 			b.multiInstance = true
 			b.instanceID = newInstanceID()
 			b.peerInflight = map[string]int{}
+			// Announce this instance's presence immediately so the ops panel counts the full
+			// live fleet from the first read (before the first sync tick refreshes it).
+			// Best-effort: a shared-store hiccup just defers presence to the next tick.
+			_ = b.shared.markInstance(b.instanceID, time.Now())
 			// Tag EVERY log line with this instance's id so logs from the 2+ instances
 			// (interleaved in the aggregated DO log stream) are attributable at a glance -
 			// the team no longer has to guess which instance emitted a relay/bus line. This

--- a/cmd/rogerai-broker/sharedstore.go
+++ b/cmd/rogerai-broker/sharedstore.go
@@ -129,6 +129,19 @@ type sharedStore interface {
 	// caller keeps the last merged peer-sum, degrading to local-only capacity).
 	inflightByNode(selfInstanceID string) (map[string]int, error)
 
+	// markInstance records THIS broker process's presence heartbeat so peers (and the ops
+	// panel's topology block) can count the live instance fleet. It (re)writes a per-instance
+	// presence key under instanceTTL and tracks the id in a prefixed set, refreshed each sync
+	// tick. Best-effort/non-fatal: a non-nil err just means the panel degrades to a self-only
+	// count this round. Only invoked in multi-instance mode (the single-instance count is 1).
+	markInstance(instanceID string, now time.Time) error
+
+	// liveInstances returns the number of DISTINCT broker instances whose presence key is
+	// still live (unexpired) in the shared store - the fleet size the ops panel renders a
+	// redundancy posture from. A non-nil err means the snapshot is unavailable this round, and
+	// the caller falls back to a self-only count of 1 (this instance is always live).
+	liveInstances() (int, error)
+
 	// --- PRE-SCALE Stage 2: the cross-instance job/result/stream RENDEZVOUS bus. ---
 	//
 	// These back the multi-instance relay path (ROGERAI_MULTI_INSTANCE=1). They are a
@@ -301,6 +314,8 @@ func (m *memStore) Close() error  { return nil }
 
 func (m *memStore) markInflight(string, string, int, time.Time) error { return errNoSharedStore }
 func (m *memStore) inflightByNode(string) (map[string]int, error)     { return nil, errNoSharedStore }
+func (m *memStore) markInstance(string, time.Time) error              { return errNoSharedStore }
+func (m *memStore) liveInstances() (int, error)                       { return 0, errNoSharedStore }
 
 // The rendezvous-bus primitives are all "unavailable" no-ops on memStore: the
 // multi-instance flag is only ever ON with a valkeyStore, so the in-memory path never
@@ -878,6 +893,75 @@ func (v *valkeyStore) inflightByNode(selfInstanceID string) (map[string]int, err
 	}
 	v.setUp(true)
 	return out, nil
+}
+
+// --- instance presence: the live broker-fleet heartbeat (ops topology). ---
+//
+// Each instance write-throughs its OWN presence under a per-instance key with instanceTTL and
+// tracks its id in a prefixed set, so any instance (and the admin ops panel) can count the live
+// fleet without an un-prefixed SCAN over the SHARED keyspace. Modeled on the liveness/inflight
+// write-through: forward-only freshness via a TTL, so a crashed instance ages out of the count.
+func instanceKey(id string) string { return keyPrefix + "inst:" + id }
+
+const instancesSetKey = keyPrefix + "instances"
+
+// instanceTTL bounds how long an instance's presence survives without a refresh. Generous
+// relative to the 5s sync tick so a brief GC pause never drops a live instance, while a truly
+// dead instance ages out within a minute (the panel then shows the reduced fleet).
+const instanceTTL = 60 * time.Second
+
+func (v *valkeyStore) markInstance(instanceID string, now time.Time) error {
+	if v == nil || v.rdb == nil {
+		return errNoSharedStore
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sharedOpTimeout)
+	defer cancel()
+	pipe := v.rdb.Pipeline()
+	pipe.Set(ctx, instanceKey(instanceID), now.UnixMilli(), instanceTTL)
+	pipe.SAdd(ctx, instancesSetKey, instanceID)
+	pipe.PExpire(ctx, instancesSetKey, instanceTTL)
+	if _, err := pipe.Exec(ctx); err != nil {
+		v.noteErr("markInstance", err)
+		return err
+	}
+	v.setUp(true)
+	return nil
+}
+
+func (v *valkeyStore) liveInstances() (int, error) {
+	if v == nil || v.rdb == nil {
+		return 0, errNoSharedStore
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sharedOpTimeout)
+	defer cancel()
+	ids, err := v.rdb.SMembers(ctx, instancesSetKey).Result()
+	if err != nil {
+		v.noteErr("liveInstances", err)
+		return 0, err
+	}
+	if len(ids) == 0 {
+		v.setUp(true)
+		return 0, nil
+	}
+	// Batch the per-instance EXISTS into ONE pipeline: an id still in the set whose presence
+	// key has expired is a dead instance - count only the ids whose key is still live.
+	pipe := v.rdb.Pipeline()
+	cmds := make([]*redis.IntCmd, len(ids))
+	for i, id := range ids {
+		cmds[i] = pipe.Exists(ctx, instanceKey(id))
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		v.noteErr("liveInstances", err)
+		return 0, err
+	}
+	live := 0
+	for i := range ids {
+		if n, err := cmds[i].Result(); err == nil && n > 0 {
+			live++
+		}
+	}
+	v.setUp(true)
+	return live, nil
 }
 
 // cacheKeyPrefix namespaces the response cache under the shared keyspace so it never

--- a/cmd/rogerai-broker/sharedstore.go
+++ b/cmd/rogerai-broker/sharedstore.go
@@ -955,10 +955,24 @@ func (v *valkeyStore) liveInstances() (int, error) {
 		return 0, err
 	}
 	live := 0
+	var stale []string
 	for i := range ids {
 		if n, err := cmds[i].Result(); err == nil && n > 0 {
 			live++
+		} else if err == nil {
+			// EXISTS returned 0: the presence key aged out. Prune the dead id so the set does
+			// not accumulate a new random instance id on every restart/deploy (the whole set
+			// only wholesale-expires once EVERY instance stops marking). The count above is
+			// already correct; this just keeps SMembers bounded to the live fleet.
+			stale = append(stale, ids[i])
 		}
+	}
+	if len(stale) > 0 {
+		members := make([]any, len(stale))
+		for i, id := range stale {
+			members[i] = id
+		}
+		_ = v.rdb.SRem(ctx, instancesSetKey, members...).Err() // best-effort; count is unaffected
 	}
 	v.setUp(true)
 	return live, nil

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -2532,6 +2532,12 @@ func (b *broker) mergeSharedInflight() {
 	if b.shared == nil {
 		return
 	}
+	// Refresh this instance's presence heartbeat on the same multi-instance cadence as the
+	// inflight merge, so a live instance keeps its presence key alive (instanceTTL) and the ops
+	// panel's fleet count stays current. Best-effort: a failure just defers to the next tick.
+	if b.multiInstance && b.instanceID != "" {
+		_ = b.shared.markInstance(b.instanceID, time.Now())
+	}
 	snap, err := b.shared.inflightByNode(b.instanceID)
 	if err != nil {
 		return


### PR DESCRIPTION
## What

Adds an `infra` (topology) block to the admin-gated `GET /admin/live` JSON so the ops panel (control.rogerai.fyi) can surface the cross-instance posture now that production runs **2 broker instances with `ROGERAI_MULTI_INSTANCE=1`** (the multi-instance Valkey bus is on).

## Payload shape

`GET /admin/live` (requireAdmin) gains an `infra` block alongside the existing `health`:

```jsonc
{
  "now": 1751500000,
  "health": {
    "version": "v5.0.2",
    "uptime_seconds": 192600,
    "db": "ok",            // reachable: ok | down | nil
    "ready": true,
    "shared": "ok",
    ...
  },
  "infra": {
    "multi_instance": true,          // is the cross-instance bus mode on
    "instances_live": 2,             // distinct live broker instances
    "shared_store": {
      "reachable": true,
      "role": "valkey accelerator+bus"
    }
  },
  "marketplace_live": { ... },
  ...
}
```

- `multi_instance` — `b.multiInstance` (the `ROGERAI_MULTI_INSTANCE` bus mode).
- `instances_live` — distinct live broker instances. In multi-instance mode this counts the live instance-presence heartbeats in the shared store; in single-instance mode it is `1`.
- `shared_store.reachable` / `role` — Valkey reachability + role (`valkey accelerator+bus` when the bus is on, `valkey accelerator` otherwise; `none` when no shared store).
- `db` (reachable), `version`, `uptime_seconds` stay in the existing `health` block (reused, not duplicated).

## How `instances_live` is counted

There was no instance-presence signal in the shared store (the inflight hash is per-node and an idle instance has no entry). This PR adds a minimal presence heartbeat modeled on the existing liveness/inflight write-through:

- `markInstance(id, now)` — (re)writes a per-instance key `rogerai:inst:<id>` under a 60s TTL and tracks the id in the `rogerai:instances` set. Written at startup and refreshed on the existing multi-instance sync tick (`mergeSharedInflight`). `memStore` no-ops it.
- `liveInstances()` — counts the ids whose presence key is still live (`EXISTS`), and prunes (`SREM`) ids whose key has aged out so the set stays bounded to the live fleet. A crashed instance ages out via the TTL.

The read is pure and non-blocking: every shared-store touch is bounded and degrades safely — an unreachable shared store is reported `reachable: false` and `instances_live` falls back to a self-only count of `1` (never `0`, never a panic, never a block).

## Spec-first / tests

Tests written first (RED → GREEN):
- `TestAdminLiveInfraSingleInstance` — bus off → `multi_instance:false`, `instances_live:1`, `shared_store` `reachable:false role:none`; `health` still carries `version`/`uptime_seconds`/`db`.
- `TestAdminLiveInfraMultiInstancePeers` — bus on over a seeded Valkey → `instances_live` reflects the peer count (self + 2 seeded peers = 3), `role: valkey accelerator+bus`.
- `TestAdminLiveInfraSharedUnreachable` — bus on, backend gone → still 200, `reachable:false`, `instances_live:1` (self-only fallback), no panic/block.
- `TestValkeyInstancePresence` (mark/count, TTL expiry, dead-id prune), `TestValkeyInstancePresenceBackendDown`, `TestMemStoreInstancePresence`.

## Gate

`go vet` clean. `make cover-gate` **PASS** — `cmd/rogerai-broker` 90.7%, module total 92.3% (every package ≥ 90%).

## Companion

Consumed by the private `roger-admin` panel (a new Infrastructure section), which degrades gracefully to "not reported" until this ships.
