### PR TITLE
broker: pin the multi-instance discovery UNION on the public surface (specs)

### DIFF
--- a/cmd/rogerai-broker/cross_instance_bdd_test.go
+++ b/cmd/rogerai-broker/cross_instance_bdd_test.go
@@ -283,6 +283,10 @@ type xiState struct {
 
 	node *xiNode
 
+	// duNodes holds the multiple nodes a discovery-union scenario registers (the
+	// single-node harness keeps s.node; the union suite needs a fleet).
+	duNodes []*xiNode
+
 	// consumer
 	consumerPriv   ed25519.PrivateKey
 	consumerWallet string
@@ -311,6 +315,7 @@ func (s *xiState) reset(t *testing.T) {
 	_, s.brokerPr, _ = ed25519.GenerateKey(nil)
 	s.inst = map[string]*xiInst{}
 	s.node = nil
+	s.duNodes = nil
 	s.consumerPriv = nil
 	s.consumerWallet = ""
 	s.startBalance = 0

--- a/cmd/rogerai-broker/discovery_union_bdd_test.go
+++ b/cmd/rogerai-broker/discovery_union_bdd_test.go
@@ -1,0 +1,310 @@
+package main
+
+// discovery_union_bdd_test.go makes features/multinode/discovery_union.feature
+// EXECUTABLE: the PUBLIC marketplace on-air view (/discover, /market, liveMarket) must be
+// the UNION across every instance behind the load balancer, so the TUNE-IN dial never
+// flickers "N online <-> 0 online" as the round-robin LB hits an instance that lacks a
+// given node's affine tunnel. Same real-deps harness as cross_instance_bdd_test.go
+// (real broker instances over real HTTP, one shared store + one real Valkey/miniredis,
+// real signed registrations, the real sync tick). No mocks. It reuses the xiState
+// primitives (twoBrokers/singleBroker, register, sweepAll) and adds the multi-node
+// registration + public-surface assertions this feature needs.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+)
+
+// duModel is the model every discovery-union node offers, so the /market + liveMarket
+// aggregations key on one known model.
+const duModel = "free-m"
+
+// duRegisterOne registers ONE free node (unique id) on inst, heartbeats it there (so the
+// shared liveness carries a fresh last_seen), and records it in s.duNodes. It does NOT
+// sweep - the scenario's When runs the sync tick, exactly as the 5s production tick would.
+func (s *xiState) duRegisterOne(specName, inst string) error {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	n := &xiNode{
+		id:       specName + "-" + s.nonce,
+		specName: specName,
+		pub:      hex.EncodeToString(pub),
+		priv:     priv,
+		token:    "tok-0-" + specName + "-" + s.nonce,
+		model:    duModel,
+		priceOut: 0,
+		hc:       &http.Client{Timeout: 10 * time.Second},
+	}
+	if err := n.register(s.t, s.inst[inst]); err != nil {
+		return err
+	}
+	n.beat(s.t, s.inst[inst])
+	s.duNodes = append(s.duNodes, n)
+	s.node = n // keep the single-node steps (heartbeats instance X, absent-from-discover) usable
+	return nil
+}
+
+func (s *xiState) duRegisterOneHB(name, inst string) error {
+	return s.duRegisterOne(name, inst)
+}
+
+func (s *xiState) duRegisterN(count int, inst string) error {
+	for i := 0; i < count; i++ {
+		if err := s.duRegisterOne(fmt.Sprintf("du-%s-%d", inst, i), inst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// duDiscoverOnline counts the offers instance inst reports ONLINE from computeDiscover -
+// the exact function GET /discover computes on every request (and, crucially, on every
+// shared-cache MISS: the TTL is ~2-3s, so this is what the round-robin dial actually
+// re-derives from THIS instance's own registry moments apart). We assert on computeDiscover
+// rather than the raw HTTP body ON PURPOSE: the shared RESPONSE cache (serveCachedJSON)
+// makes the HTTP body cross-instance-consistent INCIDENTALLY (a peer can serve the affine
+// instance's cached bytes), which MASKS a broken registry mirror. The bug the founder saw
+// live is exactly the per-instance registry disagreeing whenever the cache misses; pinning
+// computeDiscover pins the real fix (the syncRegistry union), not the accelerator that hides
+// it. It is the SAME read path (public, no money mutation), just without the cache veneer.
+func (s *xiState) duDiscoverOnline(inst string) (int, error) {
+	res, ok := s.inst[inst].b.computeDiscover().(map[string]any)
+	if !ok {
+		return 0, fmt.Errorf("computeDiscover on %s returned %T", inst, s.inst[inst].b.computeDiscover())
+	}
+	offers, _ := res["offers"].([]offerView)
+	n := 0
+	for _, o := range offers {
+		if o.Online {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (s *xiState) duDiscoverShows(inst string, want int) error {
+	got, err := s.duDiscoverOnline(inst)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf("instance %s public /discover shows %d online, want %d - the peer disagrees with the affine instance (the flicker)", inst, got, want)
+	}
+	return nil
+}
+
+func (s *xiState) duAgree() error {
+	a, err := s.duDiscoverOnline("A")
+	if err != nil {
+		return err
+	}
+	b, err := s.duDiscoverOnline("B")
+	if err != nil {
+		return err
+	}
+	if a != b {
+		return fmt.Errorf("instances disagree on the online count: A=%d B=%d - the round-robin dial flickers between them", a, b)
+	}
+	return nil
+}
+
+func (s *xiState) duStable(inst string, want int) error {
+	for i := 0; i < 5; i++ {
+		s.sweepAll()
+		time.Sleep(10 * time.Millisecond)
+		got, err := s.duDiscoverOnline(inst)
+		if err != nil {
+			return err
+		}
+		if got != want {
+			return fmt.Errorf("round %d: instance %s shows %d online, want a stable %d (the dial oscillated)", i, inst, got, want)
+		}
+	}
+	return nil
+}
+
+// duAgeOut simulates every registered node going dark: it moves last_seen PAST the on-air
+// TTL on both the LOCAL registries and the SHARED liveness (so a following sync tick, which
+// only merges freshness FORWARD, cannot resurrect them). The nodes stay in b.nodes (only a
+// multi-day prune removes a registration) but must read OFFLINE.
+func (s *xiState) duAgeOut() error {
+	old := time.Now().Add(-2 * nodeTTL)
+	for _, n := range s.duNodes {
+		for _, inst := range s.inst {
+			inst.b.mu.Lock()
+			inst.b.lastSeen[n.id] = old
+			inst.b.mu.Unlock()
+			if inst.b.shared != nil {
+				_ = inst.b.shared.markSeen(n.id, old)
+			}
+		}
+	}
+	return nil
+}
+
+// duReRegisterRotated re-registers the LAST node with a rotated bridge token on inst - the
+// idempotent-by-node-id path: a re-register must overwrite the same registry key, never add
+// a duplicate offer to the peer's dial.
+func (s *xiState) duReRegisterRotated(inst string) error {
+	n := s.duNodes[len(s.duNodes)-1]
+	n.mu.Lock()
+	n.token = "tok-rot-" + xiNonce()
+	n.mu.Unlock()
+	if err := n.register(s.t, s.inst[inst]); err != nil {
+		return err
+	}
+	n.beat(s.t, s.inst[inst])
+	// Steady state: the local-register grace has lapsed so the peer reconciles from shared.
+	for _, i := range s.inst {
+		i.b.mu.Lock()
+		if i.b.localRegAt == nil {
+			i.b.localRegAt = map[string]time.Time{}
+		}
+		i.b.localRegAt[n.id] = time.Now().Add(-2 * syncLocalRegisterGrace)
+		i.b.mu.Unlock()
+	}
+	return nil
+}
+
+// duBreakShared points inst's shared store at a dead address so every shared op errors,
+// exercising the fail-OPEN read: the instance must keep serving its LOCAL registry.
+func (s *xiState) duBreakShared(inst string) error {
+	dead, _ := newValkeyStore("redis://127.0.0.1:1") // connection-refused: returns the store, ping errs
+	s.t.Cleanup(func() { _ = dead.Close() })
+	s.inst[inst].b.shared = dead
+	return nil
+}
+
+// duAbsentFromMarket asserts the private band never surfaces in inst's PUBLIC /market,
+// while (per absentFromDiscover) the instance does hold it internally.
+func (s *xiState) duAbsentFromMarket(inst string) error {
+	resp, err := http.Get(s.inst[inst].url() + "/market")
+	if err != nil {
+		return err
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("/market on %s = %d", inst, resp.StatusCode)
+	}
+	if bytes.Contains(body, []byte(s.node.id)) {
+		return fmt.Errorf("PRIVATE band %s leaked into instance %s's public /market: %s", s.node.id, inst, body)
+	}
+	return nil
+}
+
+// duHoldsBandOffer asserts the peer LEARNED the private band internally with the SAME
+// offer it registered - the "mirrored for routing, hidden from the public surface" split:
+// the metrics are real and identical, only the public listing is suppressed.
+func (s *xiState) duHoldsBandOffer(inst string) error {
+	b := s.inst[inst].b
+	b.mu.Lock()
+	reg, known := b.nodes[s.node.id]
+	priv := b.private[s.node.id]
+	b.mu.Unlock()
+	if !known {
+		return fmt.Errorf("instance %s never learned the band internally - it could not route the freq", inst)
+	}
+	if !priv {
+		return fmt.Errorf("instance %s holds the band but did not flag it private - it would leak into /discover", inst)
+	}
+	if len(reg.Offers) != 1 || reg.Offers[0].Model != s.node.model {
+		return fmt.Errorf("instance %s holds a DIFFERENT offer than registered: got %+v, want model %q", inst, reg.Offers, s.node.model)
+	}
+	return nil
+}
+
+func (s *xiState) duMarketProviders(inst string, want int) error {
+	res, ok := s.inst[inst].b.computeMarket().(map[string]any)
+	if !ok {
+		return fmt.Errorf("computeMarket on %s returned %T", inst, s.inst[inst].b.computeMarket())
+	}
+	rows, _ := res["market"].([]marketView)
+	got := 0
+	for _, m := range rows {
+		if m.Model == duModel {
+			got = m.Providers
+		}
+	}
+	if got != want {
+		return fmt.Errorf("instance %s computeMarket shows %d providers for %q, want the union %d", inst, got, duModel, want)
+	}
+	return nil
+}
+
+func (s *xiState) duLiveMarketOnAir(inst string, want int) error {
+	lm := s.inst[inst].b.liveMarket(time.Now())
+	got, _ := lm["on_air"].(int)
+	if got != want {
+		return fmt.Errorf("instance %s liveMarket on_air = %d, want the union %d", inst, got, want)
+	}
+	return nil
+}
+
+// duInitScenarios wires the discovery-union feature to the xiState harness.
+func duInitScenarios(t *testing.T) func(sc *godog.ScenarioContext) {
+	return func(sc *godog.ScenarioContext) {
+		st := &xiState{}
+		sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+			st.reset(t)
+			return ctx, nil
+		})
+		sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+			st.cleanup()
+			return ctx, nil
+		})
+
+		// topology (reused from the churn harness)
+		sc.Step(`^a single broker with the shared backend wired and the multi-instance flag (ON|OFF)$`, st.singleBrokerAfterPersist)
+		sc.Step(`^two broker (?:processes|instances) A and B with the multi-instance flag (ON|OFF) sharing one Valkey and one store$`, st.twoBrokers)
+
+		// registration
+		sc.Step(`^node "([^"]*)" registers over HTTP on instance ([AB]) and heartbeats$`, st.duRegisterOneHB)
+		sc.Step(`^(\d+) nodes register over HTTP on instance ([AB]) and heartbeats?$`, st.duRegisterN)
+		sc.Step(`^node "([^"]*)" registers over HTTP on instance ([AB]) as a private band$`, st.nodeRegistersPrivateOn)
+		sc.Step(`^the node re-registers with a rotated token on instance ([AB])$`, st.duReRegisterRotated)
+
+		// sync tick / liveness (reused)
+		sc.Step(`^both instances run their liveness sync sweep$`, st.sweepBoth)
+		sc.Step(`^the node heartbeats instance ([AB])$`, st.heartbeatsOn)
+		sc.Step(`^the node stops heartbeating and its last-seen ages past the on-air TTL$`, st.duAgeOut)
+		sc.Step(`^instance ([AB])'s shared store becomes unreachable$`, st.duBreakShared)
+
+		// public-surface assertions
+		sc.Step(`^instance ([AB])'s public discover shows (\d+) nodes? online$`, st.duDiscoverShows)
+		sc.Step(`^instance ([AB])'s public discover still shows (\d+) nodes? online$`, st.duDiscoverShows)
+		sc.Step(`^instance ([AB])'s public discover stays at (\d+) nodes? online across repeated sweeps$`, st.duStable)
+		sc.Step(`^instance A and instance B agree on the online count$`, st.duAgree)
+		sc.Step(`^the node is absent from instance ([AB])'s public discovery$`, st.absentFromDiscover)
+		sc.Step(`^the node is absent from instance ([AB])'s public market$`, st.duAbsentFromMarket)
+		sc.Step(`^instance ([AB]) holds the band internally with the same offer it registered$`, st.duHoldsBandOffer)
+		sc.Step(`^instance ([AB])'s market shows (\d+) providers for the model$`, st.duMarketProviders)
+		sc.Step(`^instance ([AB])'s live-market on-air count is (\d+)$`, st.duLiveMarketOnAir)
+	}
+}
+
+// TestDiscoveryUnionBDD runs features/multinode/discovery_union.feature.
+func TestDiscoveryUnionBDD(t *testing.T) {
+	t.Setenv("ROGERAI_PAYOUT_HOLD_DAYS", "0")
+	t.Setenv("ROGERAI_PAYOUT_RESERVE", "0")
+	suite := godog.TestSuite{
+		ScenarioInitializer: duInitScenarios(t),
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/multinode/discovery_union.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("multinode/discovery_union scenarios failed (see godog output above)")
+	}
+}

--- a/features/multinode/discovery_union.feature
+++ b/features/multinode/discovery_union.feature
@@ -1,0 +1,136 @@
+# Multi-instance DISCOVERY UNION - the public /discover + /market + /admin-live
+# on-air view must be identical on EVERY instance behind the load balancer.
+#
+# THE PROD BUG (2026-07-04, instance_count=2 + a round-robin LB): a node's tunnel is
+# AFFINE to the ONE instance it dialed. The public dial (/discover) is round-robined
+# across instances, so an instance WITHOUT a given node's tunnel used to read its own
+# empty in-memory registry and report that node ABSENT - the TUNE-IN dial alternated
+# "8 online" (the affine instance) <-> "0 online" (the peer) every few seconds.
+#
+# THE FIX (already shipped as task #52's registry+liveness mirror, PINNED here so it can
+# never regress): every instance WRITE-THROUGHs its live registrations to the shared
+# store (putNode, keyed by node id, under a TTL refreshed on every heartbeat) and MIRRORS
+# the shared registry into its own in-memory b.nodes on the same 5s sync tick that already
+# carries liveness (syncRegistry, gated on `shared != nil` - NOT the bus flag). So the
+# UNION of every instance's nodes is what /discover, computeMarket and liveMarket all read
+# from b.nodes - the peer no longer disagrees. Reads are fail-OPEN: a slow/absent shared
+# store degrades each instance to its LOCAL registry (never an empty dial), never blocks
+# the hot path on Valkey.
+#
+# GROUND TRUTH: cmd/rogerai-broker/tunnel.go (register putNode, markSeen, syncRegistry),
+# market.go (computeDiscover/computeMarket read b.nodes, skip private/banned/offline),
+# admin.go (liveMarket reads b.nodes). Enforced end-to-end over REAL HTTP against real
+# broker instances sharing one store + one Valkey (ROGERAI_TEST_REDIS_URL container / CI
+# service / local podman, else an in-process miniredis speaking the real protocol). No
+# mocks. Registrations are real signed registrations; the mirror is the real sync tick.
+
+Feature: The public marketplace on-air view is the union across every instance
+
+  # ---------------------------------------------------------------------------
+  # (1) THE FLICKER: a node registered on A must be ON AIR on the peer B's public
+  # /discover after the sync tick - and both instances must AGREE.
+  # ---------------------------------------------------------------------------
+  Scenario: a node registered on instance A is on air on instance B's public discover
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And node "du-alpha" registers over HTTP on instance A and heartbeats
+    When both instances run their liveness sync sweep
+    Then instance A's public discover shows 1 node online
+    And instance B's public discover shows 1 node online
+    And instance A and instance B agree on the online count
+
+  # ---------------------------------------------------------------------------
+  # (1b) THE 8<->0 DIAL, generalized to a COUNT: many nodes on A -> the peer's
+  # dial reports the SAME count, never 0.
+  # ---------------------------------------------------------------------------
+  Scenario: the peer's dial reports the full online count, not zero
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And 5 nodes register over HTTP on instance A and heartbeat
+    When both instances run their liveness sync sweep
+    Then instance A's public discover shows 5 nodes online
+    And instance B's public discover shows 5 nodes online
+
+  # Nodes SPLIT across instances -> BOTH dials show the UNION of all of them.
+  Scenario: both instances show the union when nodes are split across A and B
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And 2 nodes register over HTTP on instance A and heartbeat
+    And 3 nodes register over HTTP on instance B and heartbeat
+    When both instances run their liveness sync sweep
+    Then instance A's public discover shows 5 nodes online
+    And instance B's public discover shows 5 nodes online
+
+  # The dial must be STABLE under the round-robin, never oscillating back to 0.
+  Scenario: the peer dial stays stable across repeated round-robin sweeps
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And 4 nodes register over HTTP on instance A and heartbeat
+    When both instances run their liveness sync sweep
+    Then instance B's public discover stays at 4 nodes online across repeated sweeps
+
+  # ---------------------------------------------------------------------------
+  # (2) AGE-OUT: a node whose instance stops heart-beating ages out of the peer's
+  # on-air view once its last-seen passes the on-air TTL - and stays out.
+  # ---------------------------------------------------------------------------
+  Scenario: a node that stops heartbeating ages out of the peer's on-air view
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And node "du-alpha" registers over HTTP on instance A and heartbeats
+    And both instances run their liveness sync sweep
+    And instance B's public discover shows 1 node online
+    When the node stops heartbeating and its last-seen ages past the on-air TTL
+    And both instances run their liveness sync sweep
+    Then instance B's public discover shows 0 nodes online
+
+  # ---------------------------------------------------------------------------
+  # (3) IDEMPOTENT: re-registering the SAME node id (even with a rotated token)
+  # never duplicates it in the peer's dial.
+  # ---------------------------------------------------------------------------
+  Scenario: re-registering the same node id does not duplicate it on the peer
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And node "du-alpha" registers over HTTP on instance A and heartbeats
+    And both instances run their liveness sync sweep
+    And the node re-registers with a rotated token on instance A
+    When both instances run their liveness sync sweep
+    Then instance B's public discover shows 1 node online
+
+  # ---------------------------------------------------------------------------
+  # (4) FALL-OPEN: a single instance serves its OWN registry, and an unreachable
+  # shared store degrades an instance to its LOCAL registry - the dial is NEVER
+  # empty and NEVER errors.
+  # ---------------------------------------------------------------------------
+  Scenario: a single instance serves its local registry
+    Given a single broker with the shared backend wired and the multi-instance flag OFF
+    And node "du-alpha" registers over HTTP on instance A and heartbeats
+    Then instance A's public discover shows 1 node online
+
+  Scenario: an unreachable shared store degrades an instance to its local registry
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And node "du-local" registers over HTTP on instance B and heartbeats
+    When instance B's shared store becomes unreachable
+    Then instance B's public discover still shows 1 node online
+
+  # ---------------------------------------------------------------------------
+  # (5) PRIVATE stays private: a band node is mirrored for ROUTING (the peer holds
+  # it with identical metrics) yet NEVER appears in the peer's public /discover or
+  # /market.
+  # ---------------------------------------------------------------------------
+  Scenario: a private band is routable on the peer but never in its public discover or market
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And node "du-priv" registers over HTTP on instance A as a private band
+    And the node heartbeats instance B
+    When both instances run their liveness sync sweep
+    Then the node is absent from instance B's public discovery
+    And the node is absent from instance B's public market
+    And instance B holds the band internally with the same offer it registered
+
+  # ---------------------------------------------------------------------------
+  # (6) computeMarket + liveMarket reflect the SAME union the dial does.
+  # ---------------------------------------------------------------------------
+  Scenario: computeMarket on the peer aggregates the union of providers
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And 3 nodes register over HTTP on instance A and heartbeat
+    When both instances run their liveness sync sweep
+    Then instance B's market shows 3 providers for the model
+
+  Scenario: liveMarket on the peer counts the union on air
+    Given two broker processes A and B with the multi-instance flag OFF sharing one Valkey and one store
+    And 3 nodes register over HTTP on instance A and heartbeat
+    When both instances run their liveness sync sweep
+    Then instance B's live-market on-air count is 3


### PR DESCRIPTION
## The bug (confirmed live)

With `instance_count=2` + `ROGERAI_MULTI_INSTANCE=1` behind the DO round-robin load balancer, the public **TUNE-IN dial flickered "N online <-> 0 online" every few seconds**. A node's tunnel is affine to the ONE instance it dialed; when `/discover` round-robined to the *other* instance, that instance recomputed the market from its own in-memory `b.nodes` and reported the node **absent**.

## Why there is no production code change here

The registry+liveness mirror that fixes this **already shipped** (task #52, on `main` since v5.0.x):

- **Write-through:** on register, each instance publishes the node's full registration via `putNode` (shared store, keyed by node id) under a TTL that every heartbeat refreshes (`markSeen` extends `reg` + `regset` + private `preg`/`pregset`). A dead instance's nodes age out; a re-register overwrites the same key (idempotent, no churn). Gated on `shared != nil` - NOT the bus flag - so registration state travels with liveness under both flag values.
- **Read (union):** `syncRegistry` mirrors the shared registry into each instance's `b.nodes` on the same 5s tick that carries liveness, deduped by node id, freshest-wins (strictly-older mirrors are rejected and healed). `computeDiscover`, `computeMarket`, and `liveMarket` all read that unioned `b.nodes`.
- **Fail-open:** the hot read path (`computeDiscover`/`computeMarket`/`liveMarket`) touches **zero** Valkey - it reads local `b.nodes`. A slow/absent shared store degrades an instance to its LOCAL registry; the dial never empties and never errors.

A live probe of the exact prod scenario (register on A, heartbeat, sync, read `/discover` on B) passes: B reports the node online, stably.

**What was missing was executable proof of the public-surface union**, so re-enabling 2 instances was unpinned. This PR closes that gap.

## What this PR adds (test-only)

`features/multinode/discovery_union.feature` (godog) + step defs reusing the existing real-deps `xiState` harness (real broker instances, one shared store + one real Valkey `ROGERAI_TEST_REDIS_URL` / in-process miniredis, real signed registrations, the real sync tick - **no mocks**). 11 scenarios / 56 steps covering all six requirements:

1. a node on A is on air on peer B; A and B **agree** on the count
2. the peer's dial reports the full **count** (not 0); nodes split across A/B -> both see the **union**; **stable** across repeated round-robin sweeps
3. a node that stops heartbeating **ages out** of the peer's on-air view
4. re-registering the same node id is **idempotent** (no duplicate on the peer)
5. single-instance and a **dead shared store** fall open to the LOCAL registry
6. a **private** band is routable on the peer yet excluded from its `/discover` AND `/market`, held internally with identical metrics
7. `computeMarket` + `liveMarket` reflect the same union the dial does

### Key design note: don't test the incidental cache

The assertions read `computeDiscover`/`computeMarket`/`liveMarket` **directly, not the raw HTTP body** - on purpose. The shared **response cache** (`serveCachedJSON`, ~2-3s TTL) makes the HTTP `/discover` body cross-instance-consistent *incidentally* (a peer can serve the affine instance's cached bytes), which would **mask a broken registry mirror**. The real bug is the per-instance registry disagreeing on every cache miss; the compute functions are what the dial re-derives moments apart, so pinning them pins the real fix, not the accelerator that hides it.

## Shared-registry key/TTL scheme (documented for reviewers)

| key | holds | TTL | refreshed by |
|-----|-------|-----|--------------|
| `rogerai:reg:<node>` | full public registration JSON (incl. bridge token) | `livenessTTL` 10m | `putNode` on register; `markSeen` PEXPIRE on every heartbeat |
| `rogerai:regset` | index set of public node ids `allNodes()` enumerates | 10m | same |
| `rogerai:preg:<node>` / `rogerai:pregset` | PRIVATE band registration + index (separate namespace, never in `allNodes()`) | 10m | same |
| `rogerai:node:<node>` (`ls`) | last_seen unix-ms | 10m | `markSeen` |
| `rogerai:nodes` | index set `liveness()` enumerates | 10m | `markSeen` |

A dead instance's nodes age out after 10m of no heartbeat from any instance; a live node re-registers rarely but its keys are kept warm by the heartbeat PEXPIRE.

## Evidence

- **RED** (mirror deliberately disabled via a temporary `syncRegistry` no-op): 8/11 union scenarios fail with the exact flicker signature - "instance B shows 0 online, want N - the peer disagrees with the affine instance". The 3 non-mirror scenarios (single-instance, dead-store fallback, private lazy-learn) correctly still pass.
- **GREEN** (mirror restored): `11 scenarios (11 passed) / 56 steps (56 passed)`.
- `go vet` clean; full broker suite **+ `-race`** green (`ok cmd/rogerai-broker 152s`).
- **cover-gate PASS**: every package >=90%, `cmd/rogerai-broker 90.7%`, **total 92.3%**.

## Safe to re-enable 2 instances

After this merges and CI is green, it is **safe to re-enable `instance_count: 2` + `ROGERAI_MULTI_INSTANCE=1`**: the discovery union is now pinned by executable specs against a real shared store, so the "N online <-> 0" flicker cannot silently regress. (No `.do/app.yaml` change is in this PR - build-and-hold.)

## Rollback

If the dial misbehaves after re-enabling, set `ROGERAI_MULTI_INSTANCE=0` and `instance_count: 1` in `.do/app.yaml` and redeploy - the broker returns to the single-instance in-memory path (byte-for-byte unchanged; the shared mirror is inert with one instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ny8VyF5BQCpazjDsxqXC6t