### PR TITLE
broker: fix residual multi-instance /discover ONLINE flicker (peer probe-veto)

### DIFF
--- a/cmd/rogerai-broker/discover_liveness_bdd_test.go
+++ b/cmd/rogerai-broker/discover_liveness_bdd_test.go
@@ -1,0 +1,315 @@
+package main
+
+// discover_liveness_bdd_test.go makes features/multinode/discover_liveness.feature EXECUTABLE:
+// the RESIDUAL cross-instance /discover ONLINE flicker that the registry union (task #52 / PR
+// #11) did NOT fix. Two REAL broker instances (A and B) share ONE miniredis + ONE store + ONE
+// broker signing key; a node registers + heartbeats + polls on A; B mirrors it via the shared
+// registry + liveness sync. The scenarios assert on computeDiscover/computeMarket DIRECTLY (not
+// the serveCachedJSON HTTP path, whose shared response cache would mask a per-instance flip).
+// Real signed registrations; no mocks.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+const flModel = "free-m"
+
+type flState struct {
+	mr       *miniredis.Miniredis
+	db       store.Store
+	priv     ed25519.PrivateKey // broker signing key (shared by A + B)
+	a, b     *broker
+	nodePriv ed25519.PrivateKey
+	token    string
+	offersA  []offerView
+	offersB  []offerView
+	marketA  []marketView
+	marketB  []marketView
+}
+
+func (s *flState) reset(t *testing.T) {
+	s.mr = miniredis.RunT(t)
+	_, s.priv, _ = ed25519.GenerateKey(nil)
+	s.db = store.NewMem()
+	s.a = newMIBroker(t, s.priv, s.db, s.mr)
+	s.b = newMIBroker(t, s.priv, s.db, s.mr)
+	s.token = "tok-flick-1"
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func (s *flState) discover(b *broker) []offerView {
+	res := b.computeDiscover().(map[string]any)
+	out, _ := res["offers"].([]offerView)
+	return out
+}
+
+func (s *flState) market(b *broker) []marketView {
+	res := b.computeMarket().(map[string]any)
+	out, _ := res["market"].([]marketView)
+	return out
+}
+
+func onlineOf(offers []offerView, node string) (offerView, bool) {
+	for _, o := range offers {
+		if o.NodeID == node {
+			return o, true
+		}
+	}
+	return offerView{}, false
+}
+
+func providerFor(mkt []marketView, model string) (marketView, bool) {
+	for _, m := range mkt {
+		if m.Model == model {
+			return m, true
+		}
+	}
+	return marketView{}, false
+}
+
+func (s *flState) setProbeFails(b *broker, node string, n int) {
+	b.metricsMu.Lock()
+	tq := b.trust[node]
+	tq.probed = true
+	tq.probeFails = n
+	b.trust[node] = tq
+	b.metricsMu.Unlock()
+}
+
+// hostPoll drives ONE real /agent/poll on the instance with an already-canceled request
+// context, so agentPoll authenticates, marks the node seen, records the LOCAL poll (the fix's
+// poll-host signal), then returns 204 at once instead of long-polling for 25s. This makes the
+// instance the node's authoritative poll host exactly as a live long-poll would.
+func (s *flState) hostPoll(b *broker, node string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // return immediately after the markSeen + poll-host stamp, before the 25s wait
+	r := httptest.NewRequest(http.MethodGet, "/agent/poll?node="+node, nil).WithContext(ctx)
+	r.Header.Set("Authorization", "Bearer "+s.token)
+	w := httptest.NewRecorder()
+	b.agentPoll(w, r)
+}
+
+// --- Background ------------------------------------------------------------
+
+func (s *flState) twoInstances() error { return nil } // pair built in reset()
+
+func (s *flState) registersHeartbeatsPollsOnA(node string) error {
+	_, s.nodePriv, _ = ed25519.GenerateKey(nil)
+	pubHex := hex.EncodeToString(s.nodePriv.Public().(ed25519.PublicKey))
+	reg := protocol.NodeRegistration{
+		NodeID: node, PubKey: pubHex, BridgeToken: s.token, HW: "test-hw",
+		Offers: []protocol.ModelOffer{{Model: flModel, Ctx: 4096}},
+		TS:     time.Now().Unix(),
+	}
+	reg.SignRegistration(s.nodePriv)
+	body, _ := json.Marshal(reg)
+	w := httptest.NewRecorder()
+	s.a.register(w, httptest.NewRequest(http.MethodPost, "/nodes/register", bytes.NewReader(body)))
+	if w.Code != http.StatusOK {
+		return fmt.Errorf("register on A: %d %s", w.Code, w.Body.String())
+	}
+	s.a.markSeen(node)    // heartbeat: write-through to the shared liveness
+	s.hostPoll(s.a, node) // long-poll: A becomes the node's authoritative poll host
+	return nil
+}
+
+func (s *flState) bMirrorsAndSyncs() error {
+	s.b.syncLivenessOnce() // registry union + liveness merge from the shared backend
+	return nil
+}
+
+// --- Scenario steps --------------------------------------------------------
+
+func (s *flState) bStreakNoPoll(node string) error {
+	s.setProbeFails(s.b, node, probeDeadStreak) // B's local probe streak crosses the dead bar
+	// B never polled the node, so it does NOT host the node's poll (b.localPollAt unset).
+	return nil
+}
+
+func (s *flState) getDiscoverB() error { s.offersB = s.discover(s.b); return nil }
+
+func (s *flState) bListsOnline(node string) error {
+	o, ok := onlineOf(s.offersB, node)
+	if !ok {
+		return fmt.Errorf("instance B must LIST node %q on /discover (registry union)", node)
+	}
+	if !o.Online {
+		return fmt.Errorf("instance B must report node %q ONLINE (it heartbeats on A); got Online=false - the residual flicker", node)
+	}
+	return nil
+}
+
+func (s *flState) bAtLeastOneOnline() error {
+	n := 0
+	for _, o := range s.offersB {
+		if o.Online {
+			n++
+		}
+	}
+	if n < 1 {
+		return fmt.Errorf("instance B /discover collapsed to %d online offers (the ~20%% flicker)", n)
+	}
+	return nil
+}
+
+func (s *flState) bRepeatedAcrossThrottleWithProbe(node string) error {
+	// Simulate B browsing /discover repeatedly across the 20s durable-write throttle window,
+	// attempting a probe on B each round. B hosts no poller, so its bus probe finds no
+	// subscriber and skips (errNoPoller) - probeFails stays at the streak we set. B must never
+	// flip the live node to zero-online.
+	for round := 0; round < 6; round++ {
+		s.b.probeNode(s.b.nodes[node], flModel, canaryFingerprints[round%len(canaryFingerprints)])
+		s.b.syncLivenessOnce()
+		offers := s.discover(s.b)
+		o, ok := onlineOf(offers, node)
+		if !ok || !o.Online {
+			return fmt.Errorf("round %d: instance B flipped node %q OFFLINE (listed=%v)", round, node, ok)
+		}
+	}
+	return nil
+}
+
+func (s *flState) aStreak(node string) error {
+	s.setProbeFails(s.a, node, probeDeadStreak) // A is the poll host: its streak IS authoritative
+	return nil
+}
+
+func (s *flState) getDiscoverA() error { s.offersA = s.discover(s.a); return nil }
+
+func (s *flState) aListsOffline(node string) error {
+	o, ok := onlineOf(s.offersA, node)
+	if !ok {
+		return fmt.Errorf("instance A must still LIST node %q on /discover", node)
+	}
+	if o.Online {
+		return fmt.Errorf("the poll-hosting instance A must surface a probe-dead node %q as OFFLINE", node)
+	}
+	return nil
+}
+
+func (s *flState) bLocalStalePastTTL(node string) error {
+	s.b.mu.Lock()
+	s.b.lastSeen[node] = time.Now().Add(-(nodeTTL + 10*time.Second))
+	s.b.mu.Unlock()
+	return nil
+}
+
+func (s *flState) sharedFreshFromA(node string) error {
+	return s.a.shared.markSeen(node, time.Now()) // A's heartbeat write-through keeps shared fresh
+}
+
+func (s *flState) bSyncsThenDiscoverMarket() error {
+	s.b.syncLivenessOnce()
+	s.offersB = s.discover(s.b)
+	s.marketB = s.market(s.b)
+	return nil
+}
+
+func (s *flState) bMarketHasProvider(node string) error {
+	m, ok := providerFor(s.marketB, flModel)
+	if !ok || m.Providers < 1 {
+		return fmt.Errorf("instance B /market must list a provider for %q (live via shared liveness); got ok=%v providers=%d", flModel, ok, m.Providers)
+	}
+	return nil
+}
+
+func (s *flState) staleBothInstances(node string) error {
+	old := time.Now().Add(-2 * nodeTTL)
+	s.a.mu.Lock()
+	s.a.lastSeen[node] = old
+	s.a.mu.Unlock()
+	s.b.mu.Lock()
+	s.b.lastSeen[node] = old
+	s.b.mu.Unlock()
+	// Age the SHARED liveness too, so a sync cannot refresh either instance back to live.
+	_ = s.a.shared.markSeen(node, old)
+	return nil
+}
+
+func (s *flState) getDiscoverMarketBoth() error {
+	s.b.syncLivenessOnce()
+	s.offersA = s.discover(s.a)
+	s.marketA = s.market(s.a)
+	s.offersB = s.discover(s.b)
+	s.marketB = s.market(s.b)
+	return nil
+}
+
+func (s *flState) bListsOfflineOf(node string) error {
+	o, ok := onlineOf(s.offersB, node)
+	if ok && o.Online {
+		return fmt.Errorf("instance B must age node %q OUT (OFFLINE) once heartbeats stop", node)
+	}
+	return nil
+}
+
+func (s *flState) neitherMarketHasProvider(node string) error {
+	if _, ok := providerFor(s.marketA, flModel); ok {
+		return fmt.Errorf("instance A /market must drop a dead node's model %q", flModel)
+	}
+	if _, ok := providerFor(s.marketB, flModel); ok {
+		return fmt.Errorf("instance B /market must drop a dead node's model %q", flModel)
+	}
+	return nil
+}
+
+func TestDiscoverLivenessBDD(t *testing.T) {
+	st := &flState{}
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				st.reset(t)
+				return ctx, nil
+			})
+			sc.Step(`^two broker instances A and B share one store and one shared backend, multi-instance ON$`, st.twoInstances)
+			sc.Step(`^node "([^"]*)" registers on instance A and heartbeats and polls there$`, st.registersHeartbeatsPollsOnA)
+			sc.Step(`^instance B mirrors the registry and syncs liveness from the shared backend$`, st.bMirrorsAndSyncs)
+
+			sc.Step(`^instance B has accumulated a sustained probe-fail streak for "([^"]*)" and does not host its poll$`, st.bStreakNoPoll)
+			sc.Step(`^a consumer GETs /discover on instance B$`, st.getDiscoverB)
+			sc.Step(`^instance B lists "([^"]*)" as ONLINE$`, st.bListsOnline)
+			sc.Step(`^instance B reports at least one online offer$`, st.bAtLeastOneOnline)
+
+			sc.Step(`^instance B computes /discover repeatedly across the shared-write throttle window with a probe attempted each round$`, func() error { return st.bRepeatedAcrossThrottleWithProbe("st-alpha") })
+			sc.Step(`^every /discover on instance B lists "([^"]*)" as ONLINE$`, func(string) error { return nil }) // asserted inside the loop above
+
+			sc.Step(`^instance A has accumulated a sustained probe-fail streak for "([^"]*)"$`, st.aStreak)
+			sc.Step(`^a consumer GETs /discover on instance A$`, st.getDiscoverA)
+			sc.Step(`^instance A lists "([^"]*)" as OFFLINE$`, st.aListsOffline)
+
+			sc.Step(`^instance B's local last-seen for "([^"]*)" has aged past the node TTL$`, st.bLocalStalePastTTL)
+			sc.Step(`^the shared liveness for "([^"]*)" is fresh from instance A$`, st.sharedFreshFromA)
+			sc.Step(`^instance B syncs liveness and a consumer GETs /discover and /market on instance B$`, st.bSyncsThenDiscoverMarket)
+			sc.Step(`^instance B's /market lists a provider for "([^"]*)"'s model$`, st.bMarketHasProvider)
+
+			sc.Step(`^"([^"]*)"'s last-seen has aged past the node TTL on both instances$`, st.staleBothInstances)
+			sc.Step(`^a consumer GETs /discover and /market on instance A and instance B$`, st.getDiscoverMarketBoth)
+			sc.Step(`^instance B lists "([^"]*)" as OFFLINE$`, st.bListsOfflineOf)
+			sc.Step(`^neither instance's /market lists a provider for "([^"]*)"'s model$`, st.neitherMarketHasProvider)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/multinode/discover_liveness.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("discover_liveness.feature scenarios failed")
+	}
+}

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -58,9 +58,17 @@ type broker struct {
 	bandOf       map[string]string    // node id -> band id (the private channel it serves)
 	attestedAt   map[string]time.Time // when each node last passed TEE attestation (for re-attest lapse)
 	localRegAt   map[string]time.Time // when THIS instance last (re)registered a node, so syncRegistry briefly trusts our own fresh bridge token over a possibly-stale shared read (multi-instance token reconvergence)
-	attest       *attestRegistry      // TEE attestation policy + backends + nonce store
-	tps          map[string]float64   // EWMA output tokens/sec per node (measured)
-	quotes       map[string]priceQuote
+	// localPollAt records when THIS instance last served a node's /agent/poll long-poll -
+	// i.e. it currently HOSTS the node's live poll and is its authoritative prober. Only the
+	// poll-host may probe-kill a node to OFFLINE on /discover: a PEER that merely mirrors the
+	// node via the shared registry/liveness must NOT apply its own (cross-instance, non-
+	// authoritative) probe-fail streak, or a live node heartbeating on the host flickers to
+	// OFFLINE on the peer (the residual multi-instance /discover flicker after the registry
+	// union). Guarded by b.mu. See enrichOffersForNode + features/multinode/discover_liveness.
+	localPollAt map[string]time.Time
+	attest      *attestRegistry    // TEE attestation policy + backends + nonce store
+	tps         map[string]float64 // EWMA output tokens/sec per node (measured)
+	quotes      map[string]priceQuote
 	// refPrices is the synced same-model external reference OUT-price ($/1M) by NORMALIZED
 	// model name — the preferred price-tier baseline (see refprices.go / pricetier.go).
 	// Best-effort refreshed; guarded by its own refMu (independent of mu/metricsMu) so a
@@ -472,7 +480,7 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		nodes: map[string]protocol.NodeRegistration{}, tunnels: map[string]*nodeTunnel{},
 		lastSeen: map[string]time.Time{}, confidential: map[string]bool{},
 		private: map[string]bool{}, bandOf: map[string]string{}, tps: map[string]float64{},
-		attestedAt: map[string]time.Time{}, localRegAt: map[string]time.Time{}, attest: loadAttestRegistry(),
+		attestedAt: map[string]time.Time{}, localRegAt: map[string]time.Time{}, localPollAt: map[string]time.Time{}, attest: loadAttestRegistry(),
 		quotes: map[string]priceQuote{}, streams: map[string]*streamSink{}, db: db,
 		pubOfUser: map[string]string{},
 		inflight:  map[string]int{}, success: map[string]float64{}, trust: map[string]trustState{},

--- a/cmd/rogerai-broker/market.go
+++ b/cmd/rogerai-broker/market.go
@@ -96,14 +96,26 @@ type offerView struct {
 func (b *broker) enrichOffersForNode(out []offerView, n protocol.NodeRegistration, now time.Time, deny func(string) bool, probeOnBrowse bool) []offerView {
 	age := time.Since(b.lastSeen[n.NodeID])
 	live := age < nodeTTL // heartbeat-fresh (drives recovery probing below)
+	// The probe-dead veto below is only AUTHORITATIVE on the instance that hosts this node's
+	// live poll (a recent local /agent/poll, stamped in agentPoll) - the one that can actually
+	// probe it. In single-instance mode (no shared store) the poll is always local, so the veto
+	// always applies (behavior unchanged). A MULTI-INSTANCE PEER that merely mirrors the node
+	// via the shared registry/liveness must NOT probe-kill it with its own non-authoritative
+	// streak: a cross-instance probe can time out or never land, so probeFails climbs on the
+	// non-host and a node heartbeating on the host flickers OFFLINE here - the residual
+	// /discover flicker the registry union (task #52) did NOT fix. b.mu is held by the caller,
+	// so b.localPollAt is safe to read. Pinned by features/multinode/discover_liveness.feature.
+	authoritative := b.shared == nil ||
+		(!b.localPollAt[n.NodeID].IsZero() && now.Sub(b.localPollAt[n.NodeID]) < nodeTTL)
 	b.metricsMu.Lock()
 	tq := b.trust[n.NodeID]
 	// A node that heartbeats but has failed a SUSTAINED streak of liveness probes is not
 	// actually serving its model (dead/unloaded upstream) - surface it as OFFLINE so a
 	// consumer never tunes into a dead channel and eats repeated 504s. It still heartbeats,
 	// so the proberLoop keeps probing it (gated on `live` below); one OK probe resets the
-	// streak and it flips back online. See probeDeadStreak.
-	online := live && tq.probeFails < probeDeadStreak
+	// streak and it flips back online. See probeDeadStreak. The veto is applied only by the
+	// node's authoritative poll host (see above); a peer keeps it online on heartbeat liveness.
+	online := live && (!authoritative || tq.probeFails < probeDeadStreak)
 	tps := b.tps[n.NodeID]
 	inflight := b.inflight[n.NodeID]
 	sr, srSeen := b.success[n.NodeID]

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -1192,6 +1192,16 @@ func (b *broker) agentPoll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	b.markSeen(node)
+	// Record that THIS instance now hosts the node's live poll, so it is the node's
+	// AUTHORITATIVE prober: only the poll host applies the probe-dead veto on /discover. A
+	// PEER that merely mirrors the node (shared registry/liveness) must NOT flicker a live
+	// node OFFLINE with its own non-authoritative probe-fail streak. See enrichOffersForNode.
+	b.mu.Lock()
+	if b.localPollAt == nil {
+		b.localPollAt = map[string]time.Time{}
+	}
+	b.localPollAt[node] = time.Now()
+	b.mu.Unlock()
 
 	// MULTI-INSTANCE (Stage 2): a job for this node may have been dispatched on a PEER
 	// instance, so subscribe to the node's bus channel for the life of this long-poll.

--- a/features/multinode/discover_liveness.feature
+++ b/features/multinode/discover_liveness.feature
@@ -1,0 +1,84 @@
+# Cross-instance /discover ONLINE liveness - the RESIDUAL flicker after the registry union.
+#
+# CONTEXT: task #52 / PR #11 pinned the registry UNION - both instances re-hydrate every
+# peer's registration from the shared store, so a node that dialed instance A is VISIBLE +
+# pickable + authenticatable on instance B (features/multinode/liveness_churn.feature). That
+# fixed WHICH nodes appear. It did NOT fix the ONLINE bit each offer carries.
+#
+# THE RESIDUAL BUG (proven live 2026-07-04, 2 instances, MULTI_INSTANCE=1): /discover was
+# ~80% steady at 8 online but ~20% collapsed to 0 - the instance that does NOT host a given
+# node's live poll intermittently showed that node OFFLINE, so its /discover reported 0
+# online even though the node kept heartbeating on the other instance.
+#
+# ROOT CAUSE: enrichOffersForNode computes `online := live && tq.probeFails < probeDeadStreak`
+# using THIS instance's LOCAL probe-fail streak (market.go). probeFails is a per-instance,
+# in-memory counter (recount.go) that is NEVER shared. On the instance that does not host a
+# node's live poll, that streak is NOT an authoritative liveness signal - a cross-instance
+# probe can time out or never land - so a live node accumulates probeFails locally and flips
+# to OFFLINE on that peer's /discover, collapsing the online count. The registry union keeps
+# the node VISIBLE; this keeps it ONLINE.
+#
+# THE FIX: the probe-dead veto is applied only on the instance that authoritatively probes the
+# node - the one that hosts its live poll (a recent LOCAL /agent/poll, tracked in localPollAt)
+# - or in single-instance mode (shared == nil), where the poll is always local (byte-for-byte
+# unchanged). A peer that merely mirrors the node via the shared registry/liveness keeps it
+# ONLINE on heartbeat liveness alone and never probe-kills it. A node that stops heartbeating
+# still ages out as OFFLINE on BOTH instances via nodeTTL.
+#
+# GROUND TRUTH: cmd/rogerai-broker/market.go (enrichOffersForNode / computeDiscover /
+# computeMarket), tunnel.go (agentPoll stamps localPollAt; markSeen / syncLivenessOnce mirror
+# liveness), recount.go (trustState.probeFails), probe.go (probeDeadStreak). Enforced by
+# cmd/rogerai-broker/discover_liveness_bdd_test.go: two real broker instances sharing one
+# miniredis + one store, real signed registrations, asserting on computeDiscover/computeMarket
+# DIRECTLY (not the serveCachedJSON HTTP path, whose shared response cache would mask a
+# per-instance flip). No mocks.
+
+Feature: Cross-instance /discover ONLINE liveness stays steady on every instance
+
+  Background:
+    Given two broker instances A and B share one store and one shared backend, multi-instance ON
+    And node "st-alpha" registers on instance A and heartbeats and polls there
+    And instance B mirrors the registry and syncs liveness from the shared backend
+
+  # THE REPRODUCED FLICKER (RED before the fix): B holds a local probe-fail streak for a node
+  # whose live poll is on A, and wrongly reads it OFFLINE, collapsing /discover to 0 online.
+  Scenario: a peer keeps a live node ONLINE despite its own local probe-fail streak
+    Given instance B has accumulated a sustained probe-fail streak for "st-alpha" and does not host its poll
+    When a consumer GETs /discover on instance B
+    Then instance B lists "st-alpha" as ONLINE
+    And instance B reports at least one online offer
+
+  # The steady-state guarantee across BOTH the 20s durable-write throttle window and a probe
+  # attempted on B each round: B must never flip the live node to zero-online.
+  Scenario: a peer never flips a live node to zero-online across the shared-write throttle and a probe attempt
+    Given instance B has accumulated a sustained probe-fail streak for "st-alpha" and does not host its poll
+    When instance B computes /discover repeatedly across the shared-write throttle window with a probe attempted each round
+    Then every /discover on instance B lists "st-alpha" as ONLINE
+
+  # The veto is NOT removed - the instance that hosts the node's live poll is its authoritative
+  # prober and STILL surfaces a genuinely probe-dead node (heartbeating but upstream dead) as
+  # OFFLINE, so a consumer never tunes into a dead channel.
+  Scenario: the poll-hosting instance still surfaces a probe-dead node OFFLINE
+    Given instance A has accumulated a sustained probe-fail streak for "st-alpha"
+    When a consumer GETs /discover on instance A
+    Then instance A lists "st-alpha" as OFFLINE
+
+  # Liveness derives from the shared write: even when B's LOCAL last-seen has aged past the TTL,
+  # a fresh shared liveness value written by A (heartbeat write-through) restores it on the next
+  # sync, so a node heartbeating on ANY instance is ONLINE everywhere.
+  Scenario: a node heartbeating on A stays ONLINE on B when B's local last-seen has aged past the TTL
+    Given instance B's local last-seen for "st-alpha" has aged past the node TTL
+    And the shared liveness for "st-alpha" is fresh from instance A
+    When instance B syncs liveness and a consumer GETs /discover and /market on instance B
+    Then instance B lists "st-alpha" as ONLINE
+    And instance B's /market lists a provider for "st-alpha"'s model
+
+  # The genuine-death case: a node that stops heartbeating ages out as OFFLINE on BOTH
+  # instances (the shared liveness stops refreshing, so every instance's last-seen crosses the
+  # TTL) - the fix does not keep a dead node alive anywhere.
+  Scenario: a node that stops heartbeating ages OUT as OFFLINE on both instances
+    Given "st-alpha"'s last-seen has aged past the node TTL on both instances
+    When a consumer GETs /discover and /market on instance A and instance B
+    Then instance A lists "st-alpha" as OFFLINE
+    And instance B lists "st-alpha" as OFFLINE
+    And neither instance's /market lists a provider for "st-alpha"'s model


### PR DESCRIPTION
## What still flickered after the registry mirror

Task #52 / PR #11 pinned the **registry UNION**: both instances re-hydrate every peer's
registration from the shared store, so a node that dialed instance A is visible + pickable +
authenticatable on instance B. That fixed **which** nodes appear. It did not fix the **ONLINE
bit** each `/discover` offer carries.

Proven live on 2026-07-04 (2 instances, `MULTI_INSTANCE=1`, 4-min observation): `/discover`
was ~80% steady at 8 online but ~20% collapsed to **0** - the instance **without** a given
node's live poll intermittently showed that node OFFLINE, so its `/discover` reported 0 online
even though the node kept heartbeating on the other instance.

## Which suspect was the real cause

I investigated **both** suspects from the brief. The reproduced cause is **suspect #1
(the recovery/probe path), in its liveness-signal form**:

- `enrichOffersForNode` computed `online := live && tq.probeFails < probeDeadStreak` using
  **this instance's LOCAL, in-memory `probeFails` streak**. That counter is **never shared**
  (confirmed: no `probeFails` in `sharedstore.go`; it lives on the per-process `trust` map).
- On the instance that does **not** host a node's live poll, that streak is not an
  authoritative liveness signal - a cross-instance probe can time out or never land - so
  `probeFails` climbs on the non-host and a node heartbeating on the *other* instance flips to
  OFFLINE, collapsing the online count. Under `MULTI_INSTANCE=1` the probe itself already
  routes over the bus and `errNoPoller` skips without failing (pinned by `c2_mirror_test.go`),
  so the residual leak is the **per-instance streak being trusted on a non-host at all**.

**Suspect #2 (pure liveness staleness) did NOT independently reproduce.** In steady state the
20s durable-write throttle + 5s liveness sync = ~25s worst-case lag, comfortably under
`nodeTTL` (45s) with a ~20s margin, and `syncLiveness` max-merges the shared value forward, so
a node heartbeating on any instance stays live everywhere. This PR pins that property with a
regression scenario (a node whose local last-seen aged past the TTL is restored ONLINE by the
next sync). Note (not fixed here, lower severity follow-up): `sharedFlushDue` advances its
per-node throttle stamp even when the shared write *fails*, which can widen the staleness
window toward the TTL on a Valkey blip - a candidate secondary hardening, out of scope for the
reproduced flicker.

## The fix

Apply the probe-dead OFFLINE veto **only on the instance that authoritatively probes the node**
- the one hosting its live `/agent/poll` - or in single-instance mode:

- New `broker.localPollAt` map, stamped in `agentPoll` right after `markSeen` (the true poll
  host), guarded by `b.mu`.
- `enrichOffersForNode`:
  `authoritative := b.shared == nil || (localPollAt[node] recent within nodeTTL)` and
  `online := live && (!authoritative || tq.probeFails < probeDeadStreak)`.
- **Single-instance is byte-for-byte unchanged** (`shared == nil` → `authoritative` always
  true → original expression).
- A peer that merely mirrors the node keeps it ONLINE on heartbeat liveness alone; the
  poll-host still surfaces a genuinely probe-dead node OFFLINE; a node that stops heartbeating
  still ages OUT as OFFLINE on **both** instances via `nodeTTL`.
- The relay **pick** gate (`probeFails`, `tunnel.go`) is untouched: a peer's pick still routes
  over the bus to the real host, which fails a genuinely dead node cleanly.

Accepted trade-off (documented): a genuinely-dead-but-heartbeating node can read ONLINE on a
non-host peer's `/discover` for up to `nodeTTL` - the brief explicitly blessed this ("a node
that is live-by-shared-liveness must not be probe-killed by an instance that isn't its tunnel
host"). Pick + the host's OFFLINE flag remain the backstops.

## Spec-first (RED then GREEN)

`features/multinode/discover_liveness.feature` (5 scenarios, godog) drives two real broker
instances sharing one miniredis + one store, real signed registrations, asserting on
`computeDiscover`/`computeMarket` **directly** (not the `serveCachedJSON` HTTP path, whose
shared response cache would mask a per-instance flip). No mocks.

**RED before the fix (exact output):**
```
Scenario: a peer keeps a live node ONLINE despite its own local probe-fail streak
  Then instance B lists "st-alpha" as ONLINE
    Error: instance B must report node "st-alpha" ONLINE (it heartbeats on A); got Online=false - the residual flicker
Scenario: a peer never flips a live node to zero-online across the shared-write throttle and a probe attempt
  When instance B computes /discover repeatedly ...
    Error: round 0: instance B flipped node "st-alpha" OFFLINE (listed=true)
5 scenarios (3 passed, 2 failed)
```

**GREEN after the fix:** `5 scenarios (5 passed) / 35 steps (35 passed)`.

## Verification

- `make cover-gate`: **PASS** - every package >= 90% (`cmd/rogerai-broker` 90.5%), **total
  92.2%**.
- `go vet ./cmd/rogerai-broker/`: clean.
- Full broker suite: green (146s). `-race` full package: green (151s).
- `enrichOffersForNode` coverage 100%; new `agentPoll` stamp exercised.
- Pre-push `claude-audit`: VERDICT=PASS (high) - root-cause, non-inert, single-instance
  unchanged, in-scope.

## This is safe to re-enable 2 instances once merged + verified

This was the residual `/discover` ONLINE flicker remaining after the registry mirror. With this
merged and verified, the 2-instance `MULTI_INSTANCE=1` posture no longer flips live nodes to
0-online on the non-poll-host. **Build-and-hold: do NOT merge, do NOT deploy** until reviewed.

## Rollback

Single, self-contained commit touching only `market.go` (online expression), `tunnel.go`
(localPollAt stamp), `main.go` (field + init), plus the feature + BDD test. Revert the commit
to restore the prior behavior exactly; no schema, config, or shared-store format change, so no
migration or coordinated rollout is required.
