### PR TITLE
broker: fix the /discover 8-online<->0-online flicker (evidence-qualified probe veto + retry-on-failed-shared-write)

### DIFF
--- a/cmd/rogerai-broker/flicker_soak_test.go
+++ b/cmd/rogerai-broker/flicker_soak_test.go
@@ -1,0 +1,459 @@
+package main
+
+// Real-time /discover FLICKER soak against a REAL Valkey (podman), the acceptance test
+// for the "8-online <-> 0-online" prod flicker. It is DELIBERATELY not fake-clock: it
+// stands up real broker instance(s) on a real redis, drives a node that heartbeats +
+// long-polls + serves (or fails) canary probes at a realistic cadence, and samples
+// /discover in a tight loop, counting how often the market momentarily reads 0-online
+// while the node is provably heartbeat-live.
+//
+// Gated on ROGERAI_TEST_REDIS_URL (the podman Valkey). It is skipped in the normal
+// cover-gate run (no real redis wired) so it never slows CI; run it explicitly:
+//
+//	ROGERAI_TEST_REDIS_URL=redis://127.0.0.1:6399 go test ./cmd/rogerai-broker \
+//	  -run TestDiscoverFlicker -count=1 -v
+//
+// Timings are scaled DOWN from prod by 10x but keep the ratios (TTL 4.5s : throttle 2s :
+// sync 0.5s == prod 45s : 20s : 5s), so a ~20s soak reproduces what a ~3m prod window does.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// flickCfg configures one soak run.
+type flickCfg struct {
+	instances       int           // 1 (single-instance + shared) or 2 (cross-instance)
+	nodes           int           // number of nodes registered
+	probe           bool          // run the canary prober
+	canaryFailRate  float64       // 0..1 fraction of canary probes the node fails (empty body)
+	sharedWriteFail float64       // 0..1 fraction of durable shared markSeen writes that error
+	soak            time.Duration // total sample window
+}
+
+// faultyStore wraps a real valkeyStore and makes markSeen's durable write FAIL a
+// configurable fraction of the time, reproducing the prod condition (a shared cluster
+// with latency / intermittent write failures) that miniredis never exhibits. Every other
+// method delegates unchanged (embedded interface).
+type faultyStore struct {
+	sharedStore
+	failRate float64
+	mu       sync.Mutex
+	rnd      *rand.Rand
+	fails    atomic.Int64
+	oks      atomic.Int64
+}
+
+func (f *faultyStore) markSeen(node string, now time.Time) error {
+	f.mu.Lock()
+	drop := f.rnd.Float64() < f.failRate
+	f.mu.Unlock()
+	if drop {
+		f.fails.Add(1)
+		return fmt.Errorf("injected: shared markSeen write failed")
+	}
+	f.oks.Add(1)
+	return f.sharedStore.markSeen(node, now)
+}
+
+// flickInstance is one fully-wired broker instance on the shared redis, running the same
+// background loops production runs when shared != nil (syncLiveness, and the prober when
+// enabled), behind a real HTTP server.
+type flickInst struct {
+	b    *broker
+	srv  *httptest.Server
+	stop chan struct{}
+}
+
+func flickBuild(t *testing.T, db store.Store, priv ed25519.PrivateKey, redisURL string, cfg flickCfg) *flickInst {
+	t.Helper()
+	b := relayBroker(db)
+	b.priv = priv
+	b.seedFunds = 100
+	b.anonRL = loadAnonRateLimiter()
+	b.localRegAt = map[string]time.Time{}
+	b.attestedAt = map[string]time.Time{}
+	b.lastPersist = map[string]time.Time{}
+	b.lastSharedSeen = map[string]time.Time{}
+	vs, err := newValkeyStore(redisURL)
+	if err != nil {
+		t.Fatalf("valkey connect: %v", err)
+	}
+	t.Cleanup(func() { _ = vs.Close() })
+	var sh sharedStore = vs
+	if cfg.sharedWriteFail > 0 {
+		sh = &faultyStore{sharedStore: vs, failRate: cfg.sharedWriteFail, rnd: rand.New(rand.NewSource(time.Now().UnixNano()))}
+	}
+	b.shared = sh
+	if cfg.instances > 1 {
+		b.multiInstance = true
+		b.instanceID = newInstanceID()
+		b.peerInflight = map[string]int{}
+	}
+	if cfg.probe {
+		// Fast, non-backing-off probe so failures accumulate on the scaled clock.
+		b.probe = probeConfig{interval: 150 * time.Millisecond, ceiling: 150 * time.Millisecond}
+	}
+	stop := make(chan struct{})
+	go b.syncLiveness(stop)
+	if cfg.probe {
+		go b.proberLoop(stop)
+	}
+	inst := &flickInst{b: b, srv: httptest.NewServer(streamSafeHandler(b.routes())), stop: stop}
+	t.Cleanup(func() { close(stop); inst.srv.Close() })
+	return inst
+}
+
+// flickNode drives one node over real HTTP: register, heartbeat loop, and a poll+serve
+// loop that answers canary jobs (failing a configurable fraction with an empty body).
+type flickNode struct {
+	id    string
+	pub   string
+	priv  ed25519.PrivateKey
+	token string
+	model string
+	hc    *http.Client
+}
+
+func (n *flickNode) register(t *testing.T, base string) {
+	t.Helper()
+	reg := protocol.NodeRegistration{
+		NodeID: n.id, PubKey: n.pub, BridgeToken: n.token, TS: time.Now().Unix(),
+		Offers: []protocol.ModelOffer{{Model: n.model, PriceOut: 0, Ctx: 4096}},
+	}
+	reg.SignRegistration(n.priv)
+	body, _ := json.Marshal(reg)
+	req, _ := http.NewRequest(http.MethodPost, base+"/nodes/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.hc.Do(req)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("register status %d", resp.StatusCode)
+	}
+}
+
+func (n *flickNode) heartbeatLoop(stop <-chan struct{}, base string, every time.Duration) {
+	tk := time.NewTicker(every)
+	defer tk.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-tk.C:
+			body, _ := json.Marshal(map[string]string{"node_id": n.id})
+			req, _ := http.NewRequest(http.MethodPost, base+"/nodes/heartbeat", bytes.NewReader(body))
+			req.Header.Set("Authorization", "Bearer "+n.token)
+			if resp, err := n.hc.Do(req); err == nil {
+				io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+			}
+		}
+	}
+}
+
+// pollLoop long-polls the instance and serves any canary job. failRate controls how many
+// canaries get an empty (probe-FAIL) body vs a good ("ok") body.
+func (n *flickNode) pollLoop(stop <-chan struct{}, base string, failRate float64) {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano() ^ int64(len(n.id))))
+	hc := &http.Client{Timeout: 30 * time.Second}
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		req, _ := http.NewRequest(http.MethodGet, base+"/agent/poll?node="+n.id, nil)
+		req.Header.Set("Authorization", "Bearer "+n.token)
+		resp, err := hc.Do(req)
+		if err != nil {
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK || len(body) == 0 {
+			continue // 204 re-poll
+		}
+		var job protocol.Job
+		if json.Unmarshal(body, &job) != nil {
+			continue
+		}
+		completion := "ok"
+		if rnd.Float64() < failRate {
+			completion = "" // empty body => probeDead => probeFails++
+		}
+		res := miSignedResult(job.ID, n.id, n.model, completion, n.priv, 200)
+		rb, _ := json.Marshal(res)
+		rreq, _ := http.NewRequest(http.MethodPost, base+"/agent/result?node="+n.id, bytes.NewReader(rb))
+		rreq.Header.Set("Authorization", "Bearer "+n.token)
+		if rresp, rerr := hc.Do(rreq); rerr == nil {
+			io.Copy(io.Discard, rresp.Body)
+			rresp.Body.Close()
+		}
+	}
+}
+
+// onlineCount returns how many offers the given broker's /discover reports ONLINE right
+// now (direct compute, bypassing the HTTP cache to read the raw liveness decision).
+func onlineCount(b *broker) (online, total int) {
+	res := b.computeDiscover().(map[string]any)
+	offers := res["offers"].([]offerView)
+	for _, o := range offers {
+		total++
+		if o.Online {
+			online++
+		}
+	}
+	return online, total
+}
+
+// flickResult is the measured soak outcome.
+type flickResult struct {
+	reads        int
+	zeroReads    int // reads where online==0 while node(s) heartbeat-live
+	minOnline    int
+	transitions  int // online<->0 flips
+	sharedFails  int64
+	sharedOKs    int64
+}
+
+func runFlickSoak(t *testing.T, redisURL string, cfg flickCfg) flickResult {
+	t.Helper()
+	db := store.NewMem()
+	_, priv, _ := ed25519.GenerateKey(nil)
+
+	insts := make([]*flickInst, cfg.instances)
+	for i := range insts {
+		insts[i] = flickBuild(t, db, priv, redisURL, cfg)
+	}
+	// The node registers + heartbeats + polls on instance 0; /discover is read from the
+	// LAST instance (instance 1 in the 2-instance case, instance 0 in the single case).
+	homeBase := insts[0].srv.URL
+	readInst := insts[len(insts)-1].b
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	nodes := make([]*flickNode, cfg.nodes)
+	for i := range nodes {
+		pub, npriv, _ := ed25519.GenerateKey(nil)
+		n := &flickNode{
+			id:    fmt.Sprintf("flick-node-%d", i),
+			pub:   hex.EncodeToString(pub),
+			priv:  npriv,
+			token: fmt.Sprintf("tok-%d", i),
+			model: "free-m",
+			hc:    &http.Client{Timeout: 10 * time.Second},
+		}
+		nodes[i] = n
+		n.register(t, homeBase)
+		wg.Add(2)
+		go func() { defer wg.Done(); n.heartbeatLoop(stop, homeBase, 200*time.Millisecond) }()
+		go func() { defer wg.Done(); n.pollLoop(stop, homeBase, cfg.canaryFailRate) }()
+	}
+
+	// Let registration + the first sync land so the read instance has mirrored the node
+	// and computeDiscover has a stable non-empty offer set before sampling begins.
+	time.Sleep(2 * time.Second)
+
+	res := flickResult{minOnline: 1 << 30}
+	prevZero := false
+	deadline := time.Now().Add(cfg.soak)
+	for time.Now().Before(deadline) {
+		online, total := onlineCount(readInst)
+		if total == 0 {
+			time.Sleep(50 * time.Millisecond)
+			continue // node not yet mirrored on this instance; not a flicker sample
+		}
+		res.reads++
+		if online < res.minOnline {
+			res.minOnline = online
+		}
+		isZero := online == 0
+		if isZero {
+			res.zeroReads++
+		}
+		if isZero != prevZero {
+			res.transitions++
+			prevZero = isZero
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	close(stop)
+	wg.Wait()
+
+	for _, in := range insts {
+		if fs, ok := in.b.shared.(*faultyStore); ok {
+			res.sharedFails += fs.fails.Load()
+			res.sharedOKs += fs.oks.Load()
+		}
+	}
+	return res
+}
+
+func flickRedisURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("ROGERAI_TEST_REDIS_URL")
+	if url == "" {
+		t.Skip("set ROGERAI_TEST_REDIS_URL (a real Valkey/redis) to run the flicker soak")
+	}
+	opt, err := redis.ParseURL(url)
+	if err != nil {
+		t.Fatalf("bad ROGERAI_TEST_REDIS_URL: %v", err)
+	}
+	rdb := redis.NewClient(opt)
+	defer rdb.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	keys, _ := rdb.Keys(ctx, keyPrefix+"*").Result()
+	if len(keys) > 0 {
+		rdb.Del(ctx, keys...)
+	}
+	return url
+}
+
+// scaleFlickTimings shrinks the liveness clock 10x for the soak (keeping the prod
+// ratios) and restores it after.
+func scaleFlickTimings(t *testing.T) {
+	t.Helper()
+	pTTL, pThrottle, pSync := nodeTTL, persistThrottle, syncTickInterval
+	nodeTTL = 4500 * time.Millisecond
+	persistThrottle = 2000 * time.Millisecond
+	syncTickInterval = 500 * time.Millisecond
+	t.Cleanup(func() {
+		nodeTTL, persistThrottle, syncTickInterval = pTTL, pThrottle, pSync
+	})
+}
+
+// TestProbeVetoTimeQualified locks the flicker fix at the unit level (no Valkey): the
+// /discover dead-upstream veto is qualified by RECENT positive serving evidence, so an
+// intermittently-failing but recently-serving node stays ONLINE, while a node with NO
+// recent evidence and a dead streak is still hidden (the approved dead-node contract).
+func TestProbeVetoTimeQualified(t *testing.T) {
+	pTTL := nodeTTL
+	nodeTTL = 45 * time.Second
+	defer func() { nodeTTL = pTTL }()
+
+	pub, _, _ := ed25519.GenerateKey(nil)
+	hexPub := hex.EncodeToString(pub)
+	reg := protocol.NodeRegistration{NodeID: "n", PubKey: hexPub, Offers: []protocol.ModelOffer{{Model: "m"}}}
+	now := time.Now()
+
+	newB := func(fails int, lastMeasured time.Time) *broker {
+		b := deadProbeBroker()
+		b.probeSched = map[string]*probeState{}
+		b.lastSeen["n"] = now // heartbeat-fresh
+		b.trust["n"] = trustState{probed: true, probeFails: fails}
+		if !lastMeasured.IsZero() {
+			b.probeSched["n"] = &probeState{lastMeasured: lastMeasured}
+		}
+		return b
+	}
+	online := func(b *broker) bool {
+		offers := b.enrichOffersForNode(nil, reg, now, nil, false)
+		if len(offers) != 1 {
+			t.Fatalf("want 1 offer, got %d", len(offers))
+		}
+		return offers[0].Online
+	}
+
+	// Dead streak BUT a passing probe within nodeTTL: FLICKERING/recovering -> stays ONLINE.
+	if !online(newB(probeDeadStreak+2, now.Add(-nodeTTL/3))) {
+		t.Fatal("a heartbeat-live node with a recent passing probe must stay ONLINE despite a dead streak (flicker fix)")
+	}
+	// Dead streak and NO positive evidence for a full nodeTTL: genuinely dead -> OFFLINE.
+	if online(newB(probeDeadStreak, now.Add(-2*nodeTTL))) {
+		t.Fatal("a node with a dead streak and no recent serving evidence must be OFFLINE (dead-node contract)")
+	}
+	// Dead streak and NEVER measured (zero lastMeasured): OFFLINE (approved contract).
+	if online(newB(probeDeadStreak, time.Time{})) {
+		t.Fatal("a never-served node with a dead streak must be OFFLINE")
+	}
+	// Below the streak: ONLINE regardless of evidence age.
+	if !online(newB(probeDeadStreak-1, time.Time{})) {
+		t.Fatal("a node below the dead streak must be ONLINE")
+	}
+}
+
+// TestDiscoverFlicker_SingleInstance_ProbeFailing is the PRIMARY repro: ONE instance +
+// real Valkey, a node that heartbeats continuously (so it is provably live) but whose
+// canary probe fails intermittently. A heartbeat-live node must NEVER read 0-online.
+func TestDiscoverFlicker_SingleInstance_ProbeFailing(t *testing.T) {
+	url := flickRedisURL(t)
+	scaleFlickTimings(t)
+	res := runFlickSoak(t, url, flickCfg{
+		instances:      1,
+		nodes:          1,
+		probe:          true,
+		canaryFailRate: 0.5,
+		soak:           20 * time.Second,
+	})
+	t.Logf("single-instance probe-failing: reads=%d zero-online=%d minOnline=%d transitions=%d",
+		res.reads, res.zeroReads, res.minOnline, res.transitions)
+	if res.zeroReads > 0 {
+		t.Fatalf("FLICKER: %d/%d reads showed 0-online for a heartbeat-live node (transitions=%d)",
+			res.zeroReads, res.reads, res.transitions)
+	}
+}
+
+// TestDiscoverFlicker_TwoInstance_SharedWriteFailing is the cross-instance repro: a peer
+// reads /discover while instance A's durable shared last_seen writes fail intermittently.
+// The peer must keep the node online (its liveness must not age past TTL from a missed write).
+func TestDiscoverFlicker_TwoInstance_SharedWriteFailing(t *testing.T) {
+	url := flickRedisURL(t)
+	scaleFlickTimings(t)
+	res := runFlickSoak(t, url, flickCfg{
+		instances:       2,
+		nodes:           1,
+		probe:           false,
+		sharedWriteFail: 0.5,
+		soak:            25 * time.Second,
+	})
+	t.Logf("two-instance shared-write-failing: reads=%d zero-online=%d minOnline=%d transitions=%d sharedFails=%d sharedOKs=%d",
+		res.reads, res.zeroReads, res.minOnline, res.transitions, res.sharedFails, res.sharedOKs)
+	if res.zeroReads > 0 {
+		t.Fatalf("FLICKER: %d/%d reads showed 0-online on the peer (transitions=%d, injected shared-write fails=%d)",
+			res.zeroReads, res.reads, res.transitions, res.sharedFails)
+	}
+}
+
+// TestDiscoverFlicker_CleanBaseline is the control: no injected faults, healthy canaries.
+// It must be flat-zero flicker both single- and two-instance.
+func TestDiscoverFlicker_CleanBaseline(t *testing.T) {
+	url := flickRedisURL(t)
+	scaleFlickTimings(t)
+	for _, n := range []int{1, 2} {
+		t.Run(fmt.Sprintf("instances=%d", n), func(t *testing.T) {
+			res := runFlickSoak(t, url, flickCfg{
+				instances:      n,
+				nodes:          2,
+				probe:          true,
+				canaryFailRate: 0,
+				soak:           15 * time.Second,
+			})
+			t.Logf("clean instances=%d: reads=%d zero-online=%d minOnline=%d", n, res.reads, res.zeroReads, res.minOnline)
+			if res.zeroReads > 0 {
+				t.Fatalf("clean baseline flickered: %d/%d reads 0-online", res.zeroReads, res.reads)
+			}
+		})
+	}
+}

--- a/cmd/rogerai-broker/market.go
+++ b/cmd/rogerai-broker/market.go
@@ -113,9 +113,30 @@ func (b *broker) enrichOffersForNode(out []offerView, n protocol.NodeRegistratio
 	// actually serving its model (dead/unloaded upstream) - surface it as OFFLINE so a
 	// consumer never tunes into a dead channel and eats repeated 504s. It still heartbeats,
 	// so the proberLoop keeps probing it (gated on `live` below); one OK probe resets the
-	// streak and it flips back online. See probeDeadStreak. The veto is applied only by the
-	// node's authoritative poll host (see above); a peer keeps it online on heartbeat liveness.
-	online := live && (!authoritative || tq.probeFails < probeDeadStreak)
+	// streak and it flips back online. See probeDeadStreak.
+	//
+	// The probe-dead veto is gated by TWO independent liveness signals, so a heartbeat-live
+	// node is hidden only when it is genuinely dead by BOTH - this is the COMBINED fix for
+	// the "8-online <-> 0-online" /discover flicker (PR #12 + PR #13):
+	//
+	//   1. AUTHORITATIVE (PR #12): only the instance HOSTING the node's live poll can
+	//      authoritatively probe it. A multi-instance PEER that merely mirrors the node must
+	//      NOT probe-kill it with its own non-authoritative streak (a cross-instance probe can
+	//      time out or never land), so on a peer the veto never applies. Single-instance
+	//      (shared == nil) is always authoritative -> behavior unchanged.
+	//   2. RECENT SERVING EVIDENCE (PR #13): even on the poll host, a node with a PASSED probe
+	//      or real traffic (probeState.lastMeasured) within nodeTTL is FLICKERING, not dead -
+	//      its canary fails only intermittently. probeEvidenceRecentLocked keeps it ONLINE so a
+	//      transient streak can't yank a heartbeat-live node out of /discover (and, frozen into
+	//      the shared /discover cache for its TTL, present a market-wide 0-online).
+	//
+	// So a node is vetoed OFFLINE only if it is the poll host's own node AND has a dead streak
+	// AND has shown NO positive serving evidence for a full nodeTTL (the approved dead-node
+	// contract: a node that never served, or stopped serving for nodeTTL, shows OFFLINE). The
+	// pick path (pickFor) still excludes any probe-dead node from ROUTING regardless, so no
+	// relay is ever dispatched into a 504 while such a node lingers on the display.
+	probeDead := authoritative && tq.probeFails >= probeDeadStreak && !b.probeEvidenceRecentLocked(n.NodeID, now)
+	online := live && !probeDead
 	tps := b.tps[n.NodeID]
 	inflight := b.inflight[n.NodeID]
 	sr, srSeen := b.success[n.NodeID]

--- a/cmd/rogerai-broker/probe.go
+++ b/cmd/rogerai-broker/probe.go
@@ -279,6 +279,23 @@ func (b *broker) measurementStalenessLocked(nodeID string, now time.Time) float6
 	return b.probe.stalenessFactor(now.Sub(st.lastMeasured))
 }
 
+// probeEvidenceRecentLocked reports whether the node has POSITIVE serving evidence - a
+// PASSED probe or a real served request, both stamped on probeState.lastMeasured - within
+// the last nodeTTL. It is the FLICKER guard on the /discover online veto (market.go): a
+// node whose canary fails only intermittently still passes/serves inside the window, so it
+// keeps this true and is NOT yanked offline by a transient probe streak; a node with no
+// positive evidence for a full nodeTTL returns false and, if it is also at a dead streak,
+// is treated as genuinely dead-upstream. A never-measured node (nil/zero lastMeasured) has
+// no recent evidence -> false, so the approved dead-node contract (a node that has never
+// served shows OFFLINE) is preserved. Caller holds metricsMu.
+func (b *broker) probeEvidenceRecentLocked(nodeID string, now time.Time) bool {
+	st := b.probeSched[nodeID]
+	if st == nil || st.lastMeasured.IsZero() {
+		return false
+	}
+	return now.Sub(st.lastMeasured) < nodeTTL
+}
+
 // proberLoop ticks at the FLOOR interval - the scheduling resolution - and probes the
 // nodes whose adaptive next-due has arrived. Started from main when the probe is
 // enabled. Each round is jittered (see probeOnce) so a fleet that all came on air

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -26,7 +26,10 @@ import (
 // so it re-confirms liveness against the re-hydrated registration within seconds of
 // the broker coming back, WITHOUT re-registering. 45s tolerates ~4 missed beats /
 // the redeploy gap while staying truthful (a genuinely dead node still ages out).
-const nodeTTL = 45 * time.Second
+// nodeTTL is a package var (not a const) ONLY so a test can shrink it to drive the
+// liveness/flicker soaks fast (same test seam as syncTickInterval); production reads
+// the 45s default unchanged.
+var nodeTTL = 45 * time.Second
 
 // defaultMaxNodesPerOwner is the HARD per-owner on-air cap: how many nodes a single
 // owner account may have SIMULTANEOUSLY on air (live within nodeTTL) across all of
@@ -624,7 +627,9 @@ func (b *broker) expireStaleAttestations(now time.Time, ttl time.Duration) {
 // hot heartbeat/poll path. The in-memory lastSeen is updated EVERY beat (liveness is
 // always exact in memory); the durable copy only needs to be recent enough that a
 // re-hydrate after a restart lands within the TTL grace, so we coalesce DB writes.
-const persistThrottle = 20 * time.Second
+// persistThrottle is a package var (not a const) ONLY so a test can shrink it alongside
+// nodeTTL for the flicker soaks; production reads the 20s default unchanged.
+var persistThrottle = 20 * time.Second
 
 // markSeen refreshes a node's liveness on a heartbeat/poll. The in-memory lastSeen
 // is bumped every call (so pick/discover are always exact); the durable last_seen is
@@ -637,13 +642,19 @@ func (b *broker) markSeen(node string) {
 	b.lastSeen[node] = now
 	b.mu.Unlock()
 	// Shared-state write-through (PRE-SCALE Stage 1): mirror the heartbeat to Valkey so
-	// PEER broker instances can observe this node's freshness. Coalesced on the SAME
-	// throttle gate as the durable DB touch below, so the shared write rate stays low.
-	// Best-effort: a failure is logged+swallowed inside markSeen on the store and never
-	// affects in-memory liveness (which remains exact + authoritative on this instance).
-	flushShared := b.shared != nil && b.sharedFlushDue(node, now)
-	if flushShared {
-		_ = b.shared.markSeen(node, now)
+	// PEER broker instances can observe this node's freshness. Coalesced on its own
+	// throttle (sharedFlushThrottle, kept well UNDER nodeTTL so a peer's mirrored last_seen
+	// cannot age past TTL from a single missed write). CRITICAL (the cross-instance
+	// /discover flicker fix): the throttle stamp is advanced ONLY on a SUCCESSFUL durable
+	// write (commitSharedFlush). A FAILED write leaves it unadvanced so the very NEXT
+	// heartbeat retries at once instead of waiting a full throttle window - a transient
+	// Valkey blip that used to freeze the shared last_seen (aging it past nodeTTL on the
+	// peer and flipping the node offline there) now self-heals on the next beat. Best-effort:
+	// a failure never affects in-memory liveness (exact + authoritative on this instance).
+	if b.shared != nil && b.sharedFlushDue(node, now) {
+		if err := b.shared.markSeen(node, now); err == nil {
+			b.commitSharedFlush(node, now)
+		}
 	}
 	if b.db == nil {
 		return // no durable store (e.g. a minimal test broker): in-memory liveness is enough
@@ -664,21 +675,40 @@ func (b *broker) markSeen(node string) {
 	}
 }
 
-// sharedFlushDue coalesces the shared-state liveness write-through on its own
-// per-node throttle (separate from lastPersist so it works even when b.db is nil,
-// e.g. the in-memory store). It returns true at most once per persistThrottle per
-// node, keeping the Valkey HSET rate low while still refreshing well inside nodeTTL.
+// sharedFlushThrottle bounds the shared (Valkey) last_seen write-through rate. It is kept
+// well UNDER nodeTTL (a third) so that even a missed or FAILED write cannot age a peer's
+// mirrored last_seen past nodeTTL before the next refresh lands - the margin half of the
+// cross-instance /discover flicker fix (the other half is retry-on-failure in markSeen). It
+// is SEPARATE from persistThrottle (the DB TouchNode coalesce) so tightening the shared
+// cadence never changes the single-instance DB write rate - single-instance never reaches
+// this path (b.shared is nil). Derived from nodeTTL so a test that scales nodeTTL scales it too.
+func sharedFlushThrottle() time.Duration { return nodeTTL / 3 }
+
+// sharedFlushDue reports whether node's shared last_seen is due for a write-through, on its
+// own per-node throttle (separate from lastPersist so it works even when b.db is nil, e.g.
+// the in-memory store). It is a PURE predicate: it does NOT advance the stamp. The stamp is
+// advanced by commitSharedFlush ONLY after a SUCCESSFUL durable write, so a FAILED write is
+// retried on the very next heartbeat instead of being suppressed for a full throttle window
+// (the throttle-advance-on-failed-write bug that froze a peer's liveness -> the flicker).
 func (b *broker) sharedFlushDue(node string, now time.Time) bool {
 	b.metricsMu.Lock()
 	defer b.metricsMu.Unlock()
 	if b.lastSharedSeen == nil {
 		b.lastSharedSeen = map[string]time.Time{}
 	}
-	if now.Sub(b.lastSharedSeen[node]) < persistThrottle {
-		return false
+	return now.Sub(b.lastSharedSeen[node]) >= sharedFlushThrottle()
+}
+
+// commitSharedFlush records that node's shared last_seen was durably written at now,
+// opening a fresh throttle window. Called ONLY after a successful shared.markSeen so a
+// failed write leaves the previous (earlier) stamp in place and the next heartbeat retries.
+func (b *broker) commitSharedFlush(node string, now time.Time) {
+	b.metricsMu.Lock()
+	defer b.metricsMu.Unlock()
+	if b.lastSharedSeen == nil {
+		b.lastSharedSeen = map[string]time.Time{}
 	}
 	b.lastSharedSeen[node] = now
-	return true
 }
 
 // syncTickInterval is the cross-instance liveness/inflight sync cadence. It is a package


### PR DESCRIPTION
## The bug
The market `/discover` feed flickered ~20-23% of reads between **8-online** and **0-online** in prod (3 separate 2-instance runs), but the miniredis test suite never caught it. Reproduced against a **real Valkey** (podman) with a real-time soak and found **two independent root causes**.

## Root cause 1 - single-instance probe veto (the dominant one)
Confirmed at a **single** instance (shared store connected, `MULTI_INSTANCE=0`): a heartbeating node's in-memory `lastSeen` is always fresh, so `live` is always true - the only thing that can flip `online` false is the probe veto `online = live && probeFails < probeDeadStreak`.

Prod's canary is genuinely flaky (real `probe ... FAIL (consecutive=N)` logs). When a heartbeat-live node's canary hits a `probeDeadStreak` (6) streak, `computeDiscover` marks it offline **for that instant** - and because `/discover` is cached in the shared store for its TTL (`publicMarketTTL` = 3s), that sub-second all-offline snapshot is **frozen and served market-wide**, amplifying a probe blip into a multi-second, all-nodes-to-0 flicker (a single node with N model offers reads as "N online <-> 0").

**Fix:** time-qualify the veto. A node with **positive serving evidence** (a passed probe or real traffic, `probeState.lastMeasured`) within `nodeTTL` stays **online** across a transient streak (`probeEvidenceRecentLocked`). Only a node with **no** evidence for a full `nodeTTL` **and** a dead streak is still hidden. The pick path (`pickFor`) still excludes probe-dead nodes from routing, so no relay is ever dispatched into a 504. The approved dead-node contract (`TestProbeDeadExcludedFromPickAndOffline`: a never-served node shows OFFLINE) stays green - that node has zero evidence.

Real-Valkey soak: **4/398 reads 0-online (RED) -> 0/399 (GREEN)**.

## Root cause 2 - two-instance throttle-advance-on-failed-write
`sharedFlushDue` advanced its per-node throttle stamp **even when the durable Valkey `markSeen` write FAILED**, so one transient failure suppressed the retry for a full throttle window; the peer's mirrored `last_seen` then aged past `nodeTTL` and flipped the node offline. Real Valkey exhibits the intermittent write failures miniredis never does.

**Fix (a):** advance the stamp **only on a successful write** (`commitSharedFlush`); a failed write retries on the very next heartbeat. **Fix (b):** give the shared write its own throttle `sharedFlushThrottle = nodeTTL/3`, decoupled from the DB `persistThrottle`, so it stays well under `nodeTTL` with margin. Single-instance is byte-for-byte unchanged (`b.shared` is nil -> this path never runs).

Real-Valkey soak: **68/499 reads 0-online with 7 injected write fails (RED) -> 0/499 with 16 injected fails (GREEN)**.

## Real-Valkey soak results (podman `valkey:8`, timings scaled 10x, prod ratios kept)
| scenario | before (RED) | after (GREEN) |
|---|---|---|
| single-instance, canary failing 50% | 4/398 zero-online | **0/399** |
| two-instance, shared write failing (injected) | 68/499 (7 fails) | **0/499 (16 fails)** |
| clean baseline, no faults, 1 + 2 instances | 0 | **0** |

## Tests
- `flicker_soak_test.go` - real-time soaks against real Valkey, gated on `ROGERAI_TEST_REDIS_URL` (skip in CI so they never slow the gate); the acceptance test.
- `TestProbeVetoTimeQualified` - fast unit test (no Valkey) locking all four veto branches.
- `nodeTTL`/`persistThrottle` are now package vars (same test seam as `syncTickInterval`) so the soak can scale the clock; prod defaults 45s/20s unchanged.

`go vet` clean; full suite + `-race` green; new production funcs covered by always-on tests. claude-audit verdict: PASS.

## Build-and-hold
Do **not** merge / do **not** touch the DO app - the coordinator runs prod validation. Module-wide `cover-gate` is RED by pre-existing design (~59%); this change does not regress it (pushed with `COVER_GATE_SKIP=1`, claude-audit ran and passed).

Two minor audit notes (both accepted as documented, non-blocking): (1) a probe-dead-but-recently-serving node now shows ONLINE on `/discover` yet `pickFor` still excludes it from routing - transient, self-heals within `nodeTTL`, and prevents 504s regardless; (2) during a *persistent* Valkey outage the retry-on-failure removes throttling (bounded by heartbeat cadence, best-effort/swallowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)