### PR TITLE
broker: stop /discover + /voices rate-limiting the public read to EMPTY (429 misread as empty market)

### DIFF
--- a/cmd/rogerai-broker/discover_ratelimit_test.go
+++ b/cmd/rogerai-broker/discover_ratelimit_test.go
@@ -1,0 +1,147 @@
+package main
+
+// discover_ratelimit_test.go pins the RELEASE-DAY root cause of the "dial flickers to
+// empty" incident: GET /discover (and its voice twin GET /voices) must NEVER answer a
+// public READ with HTTP 429. The old redundant per-IP anon-rate-limit gate on these two
+// PUBLIC READ endpoints returned 429 {"error":...} under normal same-IP polling, and every
+// client reads `.offers` / `.voices` off the body - a 429 body has neither, so the market
+// rendered EMPTY (an on-air band blinked to "quiet"). The expensive full-market recompute
+// the gate meant to bound is ALREADY collapsed to <=1 per publicMarketTTL by the shared
+// read-through cache (serveCachedJSON), so the throttle only ever harmed availability.
+//
+// The fix removes the anon-RL gate from /discover + /voices, matching /market's cache-only
+// posture. These tests assert the invariant on the REAL HTTP handlers (no mocks): repeated
+// same-IP reads all return 200 with the full payload, even when the anon bucket is DRAINED.
+// The anon limiter itself stays (relay/audio/tunnel still use it) - it just no longer gates
+// the two public reads.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// rlTestBroker builds a broker with one live, probed public offer on air and a DELIBERATELY
+// TINY anon bucket (rpm 1, burst 1) - so if any public-read handler still consulted the anon
+// limiter, the 2nd same-IP request in the burst would trip 429. The cache-only posture must
+// keep every read at 200 regardless.
+func rlTestBroker(t *testing.T) *broker {
+	t.Helper()
+	now := time.Now()
+	b := routeBroker(now, map[string]protocol.NodeRegistration{
+		"n-live": {NodeID: "n-live", Offers: []protocol.ModelOffer{
+			{Model: "gpt-oss-20b", PriceIn: 0.20, PriceOut: 0.20},
+		}},
+		"n-voice": {NodeID: "n-voice", Station: "bownux", Offers: []protocol.ModelOffer{
+			{Model: "roger-operator-voice", Modality: protocol.ModalityTTS, Name: "Operator", PriceIn: 20},
+		}},
+	})
+	b.db = store.NewMem()
+	b.probeSched = map[string]*probeState{}
+	b.localCache = map[string]localCacheEntry{}
+	b.trust["n-live"] = trustState{probed: true, probeOK: true, ttftMs: 200}
+	b.tps["n-live"] = 120
+	// The smallest possible bucket: one token, then empty. Proves the public reads do NOT
+	// consult it (they would 429 on the 2nd hit if they did).
+	b.anonRL = &rateLimiter{buckets: map[string]*tokenBucket{}, rpm: 1, burst: 1}
+	return b
+}
+
+// getFrom issues a GET against the handler from a single fixed CF-Connecting-IP.
+func getFrom(h func(http.ResponseWriter, *http.Request), path, ip string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	r.Header.Set("CF-Connecting-IP", ip)
+	w := httptest.NewRecorder()
+	h(w, r)
+	return w
+}
+
+// TestDiscoverNeverRateLimitsToEmpty is the primary regression: 60 rapid GET /discover from
+// ONE IP, with a live offer on air and the anon bucket drained to a single token, must ALL
+// return 200 with the offers list present - never a 429 whose body a client would misread as
+// an empty market.
+func TestDiscoverNeverRateLimitsToEmpty(t *testing.T) {
+	b := rlTestBroker(t)
+	const n = 60
+	for i := 0; i < n; i++ {
+		w := getFrom(b.discover, "/discover", "203.0.113.7")
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("GET /discover #%d = 429 (rate-limited); a public read must never 429 - it blanks the market", i+1)
+		}
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET /discover #%d = %d, want 200", i+1, w.Code)
+		}
+		var resp struct {
+			Offers []offerView `json:"offers"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("GET /discover #%d: bad JSON: %v", i+1, err)
+		}
+		if len(resp.Offers) == 0 {
+			t.Fatalf("GET /discover #%d returned an EMPTY market while an offer is on air (the flicker bug)", i+1)
+		}
+	}
+}
+
+// TestVoicesNeverRateLimitsToEmpty is the same regression for the voice twin: repeated
+// same-IP GET /voices with the anon bucket drained must all return 200 with the voices list,
+// never a 429.
+func TestVoicesNeverRateLimitsToEmpty(t *testing.T) {
+	b := rlTestBroker(t)
+	// Bind the voice node's owner so operatorStation lists it (Q2: attributable operators only).
+	bindOwnerNode(t, b, "n-voice", "bownux")
+	const n = 60
+	for i := 0; i < n; i++ {
+		w := getFrom(b.voices, "/voices", "203.0.113.7")
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("GET /voices #%d = 429 (rate-limited); a public read must never 429", i+1)
+		}
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET /voices #%d = %d, want 200", i+1, w.Code)
+		}
+		var resp struct {
+			Voices []voiceView `json:"voices"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("GET /voices #%d: bad JSON: %v", i+1, err)
+		}
+		if len(resp.Voices) == 0 {
+			t.Fatalf("GET /voices #%d returned an EMPTY voice list while a voice is on air", i+1)
+		}
+	}
+}
+
+// TestPublicReadsShareCacheOnlyThrottlePosture pins that /discover and /market carry the
+// SAME throttle posture: neither anon-RL-gates the public read (the shared short-TTL cache is
+// their only guard). With the anon bucket drained to empty, both handlers keep answering 200.
+func TestPublicReadsShareCacheOnlyThrottlePosture(t *testing.T) {
+	b := rlTestBroker(t)
+	// Drain the anon bucket outright for this IP, so any residual gate would 429 immediately.
+	b.anonRL.allow("203.0.113.7")
+
+	for _, tc := range []struct {
+		name string
+		h    func(http.ResponseWriter, *http.Request)
+		path string
+	}{
+		{"discover", b.discover, "/discover"},
+		{"market", b.market, "/market"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 0; i < 5; i++ {
+				w := getFrom(tc.h, tc.path, "203.0.113.7")
+				if w.Code == http.StatusTooManyRequests {
+					t.Fatalf("GET %s #%d = 429; the public reads must share a cache-only (no anon-gate) posture", tc.path, i+1)
+				}
+				if w.Code != http.StatusOK {
+					t.Fatalf("GET %s #%d = %d, want 200", tc.path, i+1, w.Code)
+				}
+			}
+		})
+	}
+}

--- a/cmd/rogerai-broker/discovery_market_bdd_test.go
+++ b/cmd/rogerai-broker/discovery_market_bdd_test.go
@@ -14,7 +14,9 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -34,6 +36,8 @@ type dmState struct {
 	market []marketView // last /market payload
 
 	computeCalls int // counts compute() runs for the cache scenario
+
+	codes []int // HTTP status codes from the public-read burst scenarios
 }
 
 func (s *dmState) reset() {
@@ -43,6 +47,11 @@ func (s *dmState) reset() {
 	s.b.probeSched = map[string]*probeState{}
 	s.b.localCache = map[string]localCacheEntry{}
 	s.offers, s.market, s.computeCalls = nil, nil, 0
+	s.codes = nil
+	// A deliberately tiny anon bucket (1 token) so the public-read posture scenarios prove the
+	// gate is GONE: if a public read still consulted it, the 2nd same-IP hit would 429.
+	s.b.anonRL = &rateLimiter{buckets: map[string]*tokenBucket{}, rpm: 1, burst: 1}
+	s.b.probe = probeConfig{}
 }
 
 // addNode registers a public node on air for one model at input price `in`, last seen
@@ -300,6 +309,120 @@ func (s *dmState) offerCarriesModality(want string) error {
 	return nil
 }
 
+// --- Public-read never-rate-limited-to-empty (release-day regression) -------
+
+func (s *dmState) liveOfferOnAir(model string) error {
+	s.addNode("n-live", model, 0.20, 0)
+	return nil
+}
+
+func (s *dmState) boundVoiceOnAir() error {
+	s.b.nodes["n-voice"] = protocol.NodeRegistration{NodeID: "n-voice", Station: "bownux",
+		Offers: []protocol.ModelOffer{{Model: "roger-operator-voice", Modality: protocol.ModalityTTS, Name: "Operator", PriceIn: 20}}}
+	s.b.lastSeen["n-voice"] = s.now
+	if s.b.bannedOwners == nil {
+		s.b.bannedOwners = map[string]bool{}
+	}
+	// Bind the owner so operatorStation lists the voice (Q2: attributable operators only).
+	if s.b.db == nil {
+		s.b.db = store.NewMem()
+	}
+	_ = s.b.db.BindOwner(store.Owner{GitHubID: 1, Login: "bownux", Pubkey: "pub-n-voice"})
+	_ = s.b.db.BindNode("n-voice", "pub-n-voice")
+	return nil
+}
+
+// anonBucketDrained empties the anon per-IP bucket for the test consumer so any residual gate
+// on a public read would 429 on the very next request.
+func (s *dmState) anonBucketDrained() error {
+	s.b.anonRL.allow(dmConsumerIP)
+	return nil
+}
+
+const dmConsumerIP = "203.0.113.7"
+
+func (s *dmState) dmGet(h func(http.ResponseWriter, *http.Request), path string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	r.Header.Set("CF-Connecting-IP", dmConsumerIP)
+	w := httptest.NewRecorder()
+	h(w, r)
+	return w
+}
+
+func (s *dmState) burstDiscover(n int) error {
+	s.codes = s.codes[:0]
+	for i := 0; i < n; i++ {
+		w := s.dmGet(s.b.discover, "/discover")
+		s.codes = append(s.codes, w.Code)
+		if w.Code == http.StatusOK {
+			var resp struct {
+				Offers []offerView `json:"offers"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				return fmt.Errorf("GET /discover #%d: bad JSON: %v", i+1, err)
+			}
+			if len(resp.Offers) == 0 {
+				return fmt.Errorf("GET /discover #%d returned an EMPTY market while an offer is on air", i+1)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *dmState) burstVoices(n int) error {
+	s.codes = s.codes[:0]
+	for i := 0; i < n; i++ {
+		w := s.dmGet(s.b.voices, "/voices")
+		s.codes = append(s.codes, w.Code)
+		if w.Code == http.StatusOK {
+			var resp struct {
+				Voices []voiceView `json:"voices"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				return fmt.Errorf("GET /voices #%d: bad JSON: %v", i+1, err)
+			}
+			if len(resp.Voices) == 0 {
+				return fmt.Errorf("GET /voices #%d returned an EMPTY voice list while a voice is on air", i+1)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *dmState) allResponses200NoEmpty() error {
+	for i, c := range s.codes {
+		if c == http.StatusTooManyRequests {
+			return fmt.Errorf("response #%d = 429; a public read must never rate-limit to empty", i+1)
+		}
+		if c != http.StatusOK {
+			return fmt.Errorf("response #%d = %d, want 200", i+1, c)
+		}
+	}
+	if len(s.codes) == 0 {
+		return fmt.Errorf("no responses recorded")
+	}
+	return nil
+}
+
+func (s *dmState) discoverAndMarketOnce() error {
+	s.codes = s.codes[:0]
+	s.codes = append(s.codes, s.dmGet(s.b.discover, "/discover").Code)
+	s.codes = append(s.codes, s.dmGet(s.b.market, "/market").Code)
+	return nil
+}
+
+func (s *dmState) neitherRateLimited() error {
+	if len(s.codes) != 2 {
+		return fmt.Errorf("want a /discover + /market pair, got %d responses", len(s.codes))
+	}
+	for i, c := range s.codes {
+		if c != http.StatusOK {
+			return fmt.Errorf("public read #%d = %d, want 200 (shared cache-only posture)", i+1, c)
+		}
+	}
+	return nil
+}
+
 func TestDiscoveryMarketBDD(t *testing.T) {
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(sc *godog.ScenarioContext) {
@@ -329,6 +452,15 @@ func TestDiscoveryMarketBDD(t *testing.T) {
 			sc.Step(`^"([^"]*)" carries price_tier (\d+)$`, st.marketTierIs)
 			sc.Step(`^a node on air for "([^"]*)" with modality "([^"]*)"$`, st.nodeOnAirWithModality)
 			sc.Step(`^that offer carries modality "([^"]*)"$`, st.offerCarriesModality)
+			sc.Step(`^a live offer is on air for "([^"]*)"$`, st.liveOfferOnAir)
+			sc.Step(`^a bound voice is on air$`, st.boundVoiceOnAir)
+			sc.Step(`^the anon per-IP bucket for this consumer is already drained$`, st.anonBucketDrained)
+			sc.Step(`^the same consumer GETs /discover (\d+) times in a burst$`, st.burstDiscover)
+			sc.Step(`^the same consumer GETs /voices (\d+) times in a burst$`, st.burstVoices)
+			sc.Step(`^every response is 200 with the offers list \(never a 429, never an empty market\)$`, st.allResponses200NoEmpty)
+			sc.Step(`^every voices response is 200 with the voices list \(never a 429\)$`, st.allResponses200NoEmpty)
+			sc.Step(`^the same consumer GETs /discover and /market$`, st.discoverAndMarketOnce)
+			sc.Step(`^neither is rate-limited \(both 200\) - one cache-only posture across the public reads$`, st.neitherRateLimited)
 		},
 		Options: &godog.Options{
 			Format:   "pretty",

--- a/cmd/rogerai-broker/market.go
+++ b/cmd/rogerai-broker/market.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -195,15 +194,14 @@ func (b *broker) discover(w http.ResponseWriter, r *http.Request) {
 	if !allow(w, r, http.MethodGet) {
 		return
 	}
-	// Per-IP rate limit on this UNAUTHENTICATED public surface (keyed on the validated
-	// CF-Connecting-IP, see clientIP). /discover is no-auth and enumerates the whole
-	// market, so it gets the same per-IP discipline as the concierge and the anon relay
-	// to keep a single source from hammering it.
-	if ok, retry := b.anonRL.allow(clientIP(r)); !ok {
-		w.Header().Set("Retry-After", strconv.Itoa(retry))
-		jsonErr(w, http.StatusTooManyRequests, "rate limit exceeded - slow down")
-		return
-	}
+	// NO per-IP anon rate-limit gate here (deliberately, matching /market). /discover is a
+	// PUBLIC READ: a client reads `.offers` off the body, so a 429 error body (with no offers)
+	// renders as an EMPTY market - the release-day "dial flickers to empty" incident. The one
+	// expensive thing this endpoint does - the full-market recompute - is ALREADY collapsed to
+	// <=1 per publicMarketTTL across all instances by the shared read-through cache below, so
+	// every extra same-IP read is just a cheap cache GET + memcpy and needs no throttle. The
+	// anon limiter still guards the real cost/abuse surfaces (relay/audio/tunnel), just not this
+	// read. Regression: discover_ratelimit_test.go + features/discovery/market.feature.
 	cors(w) // public market data - let the website (rogerai.fyi) fetch it
 
 	// Hot-path cache (flag-gated, behind ROGERAI_REDIS_URL). /discover recomputes every

--- a/cmd/rogerai-broker/now_hardening_test.go
+++ b/cmd/rogerai-broker/now_hardening_test.go
@@ -101,12 +101,15 @@ func TestClientIPPrefersCFConnectingIP(t *testing.T) {
 	}
 }
 
-// TestAnonPerIPRateLimit asserts the unauthenticated public surface (/discover, a
-// no-auth path) is bounded PER CF-IP: a single IP trips the per-IP limit once its
-// bucket drains, while a different source IP keeps its own allowance. The per-IP key is
-// the validated CF-Connecting-IP (clientIP). This is the same bucket discipline applied
-// to the anon relay path and the concierge.
-func TestAnonPerIPRateLimit(t *testing.T) {
+// TestDiscoverNotAnonGated pins the CORRECTED intent (was TestAnonPerIPRateLimit): /discover
+// is a PUBLIC READ and is NO LONGER anon-rate-limited. The old per-IP anon gate here returned
+// 429 under normal same-IP polling, and clients misread that error body as an EMPTY market
+// (the release-day "dial flickers to empty" incident). The shared short-TTL read cache is the
+// only guard the endpoint needs. So even with the anon bucket DRAINED to empty - and regardless
+// of the source IP or a spoofed X-Forwarded-For - every /discover read must stay 200. (The anon
+// LIMITER mechanism itself, still used by the relay/audio/tunnel surfaces, is covered in
+// money/caps.feature; it just no longer gates this read.)
+func TestDiscoverNotAnonGated(t *testing.T) {
 	_, brokerPriv, _ := ed25519.GenerateKey(nil)
 	b := &broker{
 		priv:         brokerPriv,
@@ -122,9 +125,12 @@ func TestAnonPerIPRateLimit(t *testing.T) {
 		trust:        map[string]trustState{},
 		quotes:       map[string]priceQuote{},
 		banned:       map[string]bool{},
-		// Tiny anon bucket so a couple of requests trip it deterministically.
-		anonRL: &rateLimiter{buckets: map[string]*tokenBucket{}, rpm: 1, burst: 2},
+		// A tiny bucket, then DRAINED below: if /discover still consulted it, the next request
+		// would already 429. It must not.
+		anonRL: &rateLimiter{buckets: map[string]*tokenBucket{}, rpm: 1, burst: 1},
 	}
+	// Drain IP A's bucket outright, so any residual gate would 429 immediately.
+	b.anonRL.allow("198.51.100.1")
 
 	doDiscover := func(ip string) int {
 		r := httptest.NewRequest(http.MethodGet, "/discover", nil)
@@ -134,29 +140,24 @@ func TestAnonPerIPRateLimit(t *testing.T) {
 		return w.Code
 	}
 
-	// IP A: burst of 2 passes the per-IP limiter, the 3rd trips it (429).
-	if c := doDiscover("198.51.100.1"); c == http.StatusTooManyRequests {
-		t.Fatalf("discover req 1 from IP A unexpectedly 429")
+	// Hammer the drained IP well past what the old burst-of-2 gate allowed: never a 429.
+	for i := 0; i < 10; i++ {
+		if c := doDiscover("198.51.100.1"); c == http.StatusTooManyRequests {
+			t.Fatalf("discover req %d from one IP = 429; /discover is a public read and must not be anon-gated", i+1)
+		}
 	}
-	if c := doDiscover("198.51.100.1"); c == http.StatusTooManyRequests {
-		t.Fatalf("discover req 2 from IP A unexpectedly 429")
-	}
-	if c := doDiscover("198.51.100.1"); c != http.StatusTooManyRequests {
-		t.Errorf("discover req 3 from IP A = %d, want 429 (per-IP bucket drained)", c)
-	}
-	// IP B has its OWN bucket and is still allowed despite IP A being limited.
+	// A different IP is likewise unaffected.
 	if c := doDiscover("198.51.100.2"); c == http.StatusTooManyRequests {
-		t.Errorf("discover req from a DIFFERENT IP B = 429, want its own per-IP bucket")
+		t.Errorf("discover from a different IP = 429, want 200 (no anon gate)")
 	}
-	// A spoofed X-Forwarded-For must NOT let IP A escape its bucket when CF is present:
-	// clientIP keys on CF-Connecting-IP, so IP A is still limited regardless of XFF.
+	// A spoofed X-Forwarded-For changes nothing - the endpoint never consults the bucket at all.
 	r := httptest.NewRequest(http.MethodGet, "/discover", nil)
 	r.Header.Set("CF-Connecting-IP", "198.51.100.1")
-	r.Header.Set("X-Forwarded-For", "9.9.9.9") // attacker tries to dodge the bucket
+	r.Header.Set("X-Forwarded-For", "9.9.9.9")
 	w := httptest.NewRecorder()
 	b.discover(w, r)
-	if w.Code != http.StatusTooManyRequests {
-		t.Errorf("IP A with a spoofed XFF = %d, want 429 (CF-Connecting-IP keys the bucket, XFF ignored)", w.Code)
+	if w.Code == http.StatusTooManyRequests {
+		t.Errorf("IP A with a spoofed XFF = 429, want 200 (/discover is not anon-gated)")
 	}
 }
 

--- a/cmd/rogerai-broker/voicename_test.go
+++ b/cmd/rogerai-broker/voicename_test.go
@@ -318,21 +318,23 @@ func TestVoicesHTTPHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("rate limit returns 429 with Retry-After", func(t *testing.T) {
+	t.Run("public read is NOT anon-gated (never 429, even drained)", func(t *testing.T) {
+		// CORRECTED intent: /voices is a PUBLIC READ and no longer carries the per-IP anon gate
+		// (it mirrored /discover's release-day "flickers to empty" bug - a 429 body has no
+		// `.voices`, so the picker blanked). Even with the anon bucket drained, every read stays
+		// 200. The anon limiter still guards the relay/audio/tunnel surfaces, just not this read.
 		b := nsUnitBroker(t)
-		b.anonRL = &rateLimiter{buckets: map[string]*tokenBucket{}, rpm: 1, burst: 1} // 1 token, then blocked
-		w1 := httptest.NewRecorder()
-		b.voices(w1, httptest.NewRequest(http.MethodGet, "/voices", nil))
-		if w1.Code != http.StatusOK {
-			t.Fatalf("first GET = %d, want 200", w1.Code)
-		}
-		w2 := httptest.NewRecorder()
-		b.voices(w2, httptest.NewRequest(http.MethodGet, "/voices", nil))
-		if w2.Code != http.StatusTooManyRequests {
-			t.Errorf("second GET = %d, want 429", w2.Code)
-		}
-		if w2.Header().Get("Retry-After") == "" {
-			t.Error("429 must carry a Retry-After header")
+		b.anonRL = &rateLimiter{buckets: map[string]*tokenBucket{}, rpm: 1, burst: 1}
+		b.anonRL.allow(clientIP(httptest.NewRequest(http.MethodGet, "/voices", nil))) // drain it
+		for i := 0; i < 5; i++ {
+			w := httptest.NewRecorder()
+			b.voices(w, httptest.NewRequest(http.MethodGet, "/voices", nil))
+			if w.Code == http.StatusTooManyRequests {
+				t.Fatalf("GET /voices #%d = 429; a public read must not be anon-gated", i+1)
+			}
+			if w.Code != http.StatusOK {
+				t.Fatalf("GET /voices #%d = %d, want 200", i+1, w.Code)
+			}
 		}
 	})
 

--- a/cmd/rogerai-broker/voices.go
+++ b/cmd/rogerai-broker/voices.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net/http"
 	"sort"
-	"strconv"
 	"time"
 
 	"github.com/rogerai-fyi/roger/internal/protocol"
@@ -47,11 +46,12 @@ func (b *broker) voices(w http.ResponseWriter, r *http.Request) {
 	if !allow(w, r, http.MethodGet) {
 		return
 	}
-	if ok, retry := b.anonRL.allow(clientIP(r)); !ok {
-		w.Header().Set("Retry-After", strconv.Itoa(retry))
-		jsonErr(w, http.StatusTooManyRequests, "rate limit exceeded - slow down")
-		return
-	}
+	// NO per-IP anon rate-limit gate here (deliberately, matching /discover + /market). /voices
+	// is a PUBLIC READ: a client reads `.voices` off the body, so a 429 error body (with no
+	// voices) renders as an EMPTY picker. Its only expensive work is collapsed to <=1 per
+	// publicMarketTTL by the shared cache below, so extra same-IP reads are cheap cache hits and
+	// need no throttle. The anon limiter still guards the relay/audio/tunnel cost surfaces.
+	// Regression: discover_ratelimit_test.go + features/discovery/market.feature.
 	cors(w)
 	b.serveCachedJSON(w, "voices", publicMarketTTL, b.computeVoices)
 }

--- a/features/discovery/market.feature
+++ b/features/discovery/market.feature
@@ -82,3 +82,31 @@ Feature: Discovery — the public marketplace
       | whisper-listener    | stt        | stt  |
       | gpt-oss-20b         | chat       | chat |
       | legacy-model        |            | chat |
+
+  # RELEASE-DAY regression ("the dial flickers to empty"). /discover + /voices are PUBLIC READS.
+  # They must NEVER answer with HTTP 429: a client reads `.offers` / `.voices` off the body, and
+  # a 429 error body carries neither, so the whole market renders EMPTY - an on-air band blinks to
+  # "quiet". The expensive full-market recompute is ALREADY collapsed to <=1 per publicMarketTTL by
+  # the shared read-through cache (serveCachedJSON), so the old per-IP anon-rate-limit gate on these
+  # reads only ever harmed availability. It is REMOVED: the public reads adopt /market's cache-only
+  # posture. The anon limiter itself STAYS - it still guards the relay/audio/tunnel cost surfaces.
+  # GROUND TRUTH: market.go discover() + voices.go voices() no longer call b.anonRL; /market never did.
+  Rule: A public read is never rate-limited to empty (cache-only throttle posture)
+
+    Scenario: Repeated same-IP /discover reads stay 200 with offers, even with the anon bucket drained
+      Given a live offer is on air for "gpt-oss-20b"
+      And the anon per-IP bucket for this consumer is already drained
+      When the same consumer GETs /discover 60 times in a burst
+      Then every response is 200 with the offers list (never a 429, never an empty market)
+
+    Scenario: Repeated same-IP /voices reads stay 200 with voices, even with the anon bucket drained
+      Given a bound voice is on air
+      And the anon per-IP bucket for this consumer is already drained
+      When the same consumer GETs /voices 60 times in a burst
+      Then every voices response is 200 with the voices list (never a 429)
+
+    Scenario: /discover and /market share the cache-only throttle posture (neither anon-gates)
+      Given a live offer is on air for "gpt-oss-20b"
+      And the anon per-IP bucket for this consumer is already drained
+      When the same consumer GETs /discover and /market
+      Then neither is rate-limited (both 200) - one cache-only posture across the public reads

--- a/web/src/js/bands.js
+++ b/web/src/js/bands.js
@@ -1103,6 +1103,19 @@
 
   /* ---- fetch + refresh (REAL DATA ONLY) ------------------------- */
   var inflight = false;
+  var lastLiveReal = [];           // last real bands that had >=1 live row (held over a transient error)
+  var retryAfterMs = 0;            // a 429's Retry-After hint (ms), applied to the NEXT poll only
+
+  // parseRetryAfter reads an integer-seconds Retry-After header and returns it in ms (0 if
+  // absent/non-numeric), so a transient 429 can pace the next poll to what the server asked.
+  function parseRetryAfter(res) {
+    if (!res || !res.headers) return 0;
+    var raw = "";
+    try { raw = res.headers.get ? res.headers.get("Retry-After") : ""; } catch (_) { raw = ""; }
+    var secs = parseInt(raw, 10);
+    return isFinite(secs) && secs > 0 ? secs * 1000 : 0;
+  }
+
   function ingest(realBands, broker) {
     reachedBroker = broker;
     var liveModels = realBands.filter(function (b) { return b.live; }).map(function (b) { return b.model; });
@@ -1121,18 +1134,26 @@
     var to = setTimeout(function () { if (ctrl) ctrl.abort(); }, 8000);
     var opt = { signal: ctrl ? ctrl.signal : undefined, cache: "no-store" };
 
-    var mP = fetch(BROKER + "/market", opt).then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; });
-    var dP = fetch(BROKER + "/discover", opt).then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; });
+    // Capture each endpoint's ok separately (not just its body) so a transient non-200 (a 429
+    // "slow down", a 5xx) is distinguishable from a genuine 200-with-empty-body. A non-200
+    // carries no `.market`/`.offers`; reading it as "empty" is exactly the "flickers to empty"
+    // bug. On a transient failure we HOLD the last-known live bands instead of dropping them.
+    var mP = fetch(BROKER + "/market", opt)
+      .then(function (r) { if (!r.ok) { retryAfterMs = retryAfterMs || parseRetryAfter(r); return { ok: false, data: null }; } return r.json().then(function (d) { return { ok: true, data: d }; }); })
+      .catch(function () { return { ok: false, data: null }; });
+    var dP = fetch(BROKER + "/discover", opt)
+      .then(function (r) { if (!r.ok) { retryAfterMs = retryAfterMs || parseRetryAfter(r); return { ok: false, data: null }; } return r.json().then(function (d) { return { ok: true, data: d }; }); })
+      .catch(function () { return { ok: false, data: null }; });
 
     Promise.all([mP, dP]).then(function (res) {
       clearTimeout(to);
       inflight = false;
-      var mData = res[0], dData = res[1];
+      var mData = res[0].data, dData = res[1].data;
+      var anyOK = res[0].ok || res[1].ok; // at least one endpoint answered 200 with a body
       var marketRows = (mData && Array.isArray(mData.market)) ? mData.market : [];
       var offers = (dData && Array.isArray(dData.offers)) ? dData.offers : [];
       var mBands = fromMarket(marketRows);
       var dBands = fromDiscover(offers);
-      var broker = (mData != null) || (dData != null);
 
       var merged;
       if (mBands.length) merged = merge(mBands, dBands);
@@ -1140,11 +1161,21 @@
       else merged = [];
 
       var liveN = merged.filter(function (b) { return b.live; }).length;
-      ingest(merged, broker);
+
+      // Transient: NEITHER endpoint returned a usable 200 body. Don't blank the live bands - if
+      // we have a last-known live set, HOLD it (re-ingest so the on-air rows stay put).
+      if (!anyOK && liveN === 0 && lastLiveReal.length) {
+        ingest(lastLiveReal, true);
+        setStatus("holding the last band read · re-tuning…", "live");
+        return;
+      }
+
+      if (liveN > 0) lastLiveReal = merged; // remember the freshest live set for a future hold
+      ingest(merged, anyOK);
 
       if (liveN > 0) {
         setStatus(liveN + " model" + (liveN === 1 ? "" : "s") + " on air · live from the broker", "live");
-      } else if (broker) {
+      } else if (anyOK) {
         setStatus("the band is quiet - no models on air right now", "quiet");
       } else {
         setStatus("couldn't reach the broker just now - retrying", "off");
@@ -1152,8 +1183,14 @@
     }).catch(function () {
       clearTimeout(to);
       inflight = false;
-      ingest([], false);
-      setStatus("couldn't reach the broker just now - retrying", "off");
+      // Unexpected error: HOLD the last-known live bands rather than blanking, if any.
+      if (lastLiveReal.length) {
+        ingest(lastLiveReal, true);
+        setStatus("holding the last band read · re-tuning…", "live");
+      } else {
+        ingest([], false);
+        setStatus("couldn't reach the broker just now - retrying", "off");
+      }
     });
   }
 
@@ -1197,7 +1234,11 @@
   function schedule() {
     if (REDUCED) return;
     clearTimeout(pollTimer);
-    pollTimer = setTimeout(function () { if (visible) load(); schedule(); }, POLL_MS);
+    // Honor a 429's Retry-After for the NEXT poll only (never faster than the base cadence),
+    // then reset so a one-off throttle doesn't slow the steady state.
+    var wait = Math.max(POLL_MS, retryAfterMs || 0);
+    retryAfterMs = 0;
+    pollTimer = setTimeout(function () { if (visible) load(); schedule(); }, wait);
   }
   document.addEventListener("visibilitychange", function () {
     visible = !document.hidden;

--- a/web/src/js/market.js
+++ b/web/src/js/market.js
@@ -64,11 +64,46 @@
     return { kind: "priced", rate: rate, reply: "~" + usd(mid * REPLY_TOK / 1e6), mid: mid };
   }
 
+  /* ---------- transient-error resilience (defense in depth) ------------
+     RELEASE-DAY root cause: the broker's public reads (/market, /discover)
+     could answer a transient HTTP 429 ("slow down"); a 429 error body carries
+     NO `.market` / `.offers`, so the old code read an empty list and painted
+     the "band is quiet" empty state - an on-air market blinked to EMPTY (the
+     "dial flickers to empty" incident). The broker fix removes that gate, but
+     as defense in depth the client must ALSO never blank on a transient non-200:
+     if neither endpoint returned a usable 200 body this poll AND we have a
+     last-known market, we HOLD it rather than blanking. Only a broker that is
+     REACHABLE and genuinely returns an EMPTY list paints the honest quiet state.
+     A 200-with-live-market always renders fresh. */
+  function decideRender(poll) {
+    poll = poll || {};
+    if ((+poll.liveCount || 0) > 0) return "live";      // fresh live data - always render it
+    // No live market this poll. If BOTH public reads failed to return a usable 200 body
+    // (a transient error - 429, 5xx, a network blip), keep the last-known market on screen
+    // instead of blanking; fall back to an honest "unreachable" only when we have nothing.
+    if (!poll.marketOK && !poll.discoverOK) {
+      return (+poll.prevCount || 0) > 0 ? "hold" : "quiet-unreachable";
+    }
+    // At least one endpoint answered 200 but with an empty/no-live list: an honest quiet market.
+    return "quiet-empty";
+  }
+
+  // parseRetryAfter reads a Retry-After header (integer seconds; a non-numeric/absent value
+  // yields 0) and returns it in MILLISECONDS, so a 429 can pace the next poll to what the
+  // server asked for. HTTP-date form is not emitted by the broker, so only seconds is parsed.
+  function parseRetryAfter(res) {
+    if (!res || typeof res.headers === "undefined" || !res.headers) return 0;
+    var raw = "";
+    try { raw = res.headers.get ? res.headers.get("Retry-After") : ""; } catch (_) { raw = ""; }
+    var secs = parseInt(raw, 10);
+    return isFinite(secs) && secs > 0 ? secs * 1000 : 0;
+  }
+
   // Node test seam (mirrors dashboard.js): in a non-DOM runtime, export the pure
   // bits and skip all DOM/fetch below. The browser path runs exactly as before.
   if (typeof document === "undefined") {
     if (typeof module !== "undefined" && module.exports) {
-      module.exports = { meterReadout: meterReadout, fmtPrice: fmtPrice };
+      module.exports = { meterReadout: meterReadout, fmtPrice: fmtPrice, decideRender: decideRender, parseRetryAfter: parseRetryAfter };
     }
     return;
   }
@@ -97,6 +132,7 @@
   var shimmer = 0;
   var visible = false;
   var inflight = false;
+  var retryAfterMs = 0;            // a 429's Retry-After hint (ms) applied to the NEXT poll only
 
   /* ---------- tiny DOM helpers ----------------------------------- */
   function el(tag, cls, html) {
@@ -424,16 +460,35 @@
   function setFoot(html) { if (footEl) footEl.innerHTML = html; }
 
   /* ---------- fetch + refresh ----------------------------------- */
+  // holdLastKnown keeps the last-known market painted on a TRANSIENT failure (a non-200 such
+  // as 429, or an unreachable broker) instead of blanking it - defense in depth for the
+  // "flickers to empty" incident. It leaves the existing rows on screen (the rAF shimmer keeps
+  // running) and only refreshes the status line.
+  function holdLastKnown() {
+    var live = rendered.filter(function (c) { return c && c.live; }).length;
+    setStatus("holding the last band read · re-tuning…", "live");
+    setFoot('holding the last read from <span class="ember">broker.rogerai.fyi</span> · ' +
+      (live ? live + ' band' + (live === 1 ? '' : 's') + ' shown' : 'retrying') + ' · auto-refresh 30s');
+    startShimmer();
+  }
+
   function load() {
     if (inflight) return;
     inflight = true;
     var ctrl = ("AbortController" in window) ? new AbortController() : null;
     var to = setTimeout(function () { if (ctrl) ctrl.abort(); }, 8000);
 
-    // authoritative /market first (per-band signal 0-100); /discover is the
-    // aggregation fallback; an honest "quiet" empty state is the last resort.
+    // authoritative /market first (per-band signal 0-100); /discover is the aggregation
+    // fallback; a last-known HOLD (transient non-200) or an honest "quiet" empty state is the
+    // last resort. A non-200 is NOT thrown to the blank-the-UI path - it is treated as "no
+    // usable body" and its Retry-After hint is captured to pace the next poll.
+    var marketOK = false, discoverOK = false;
     fetch(MARKET, { signal: ctrl ? ctrl.signal : undefined, cache: "no-store" })
-      .then(function (r) { if (!r.ok) throw new Error("http " + r.status); return r.json(); })
+      .then(function (r) {
+        if (!r.ok) { retryAfterMs = retryAfterMs || parseRetryAfter(r); return null; }
+        marketOK = true;
+        return r.json();
+      })
       .then(function (data) {
         var rows = (data && Array.isArray(data.market)) ? data.market : [];
         var channels = fromMarket(rows);
@@ -447,22 +502,36 @@
           startShimmer();
           return;
         }
-        // /market empty -> try /discover aggregation
-        return fetch(DISCOVER, { cache: "no-store" })
-          .then(function (r) { return r.ok ? r.json() : null; })
+        // /market empty (or a non-200) -> try /discover aggregation
+        return fetch(DISCOVER, { signal: ctrl ? ctrl.signal : undefined, cache: "no-store" })
+          .then(function (r) {
+            if (!r.ok) { retryAfterMs = retryAfterMs || parseRetryAfter(r); return null; }
+            discoverOK = true;
+            return r.json();
+          })
           .then(function (d) {
             clearTimeout(to);
             var offers = (d && Array.isArray(d.offers)) ? d.offers : [];
             var live = offers.length ? offers.filter(function (o) { return o && o.online !== false; }).length : 0;
-            if (offers.length > 0 && live > 0) {
+            var action = decideRender({ liveCount: live, marketOK: marketOK, discoverOK: discoverOK, prevCount: rendered.length });
+            if (action === "live") {
               var ch = aggregate(offers);
               paint(ch, true);
               paintMeter(meterReadout(ch));
               var nOn = ch.filter(function (c) { return c.live; }).length;
               setStatus(nOn + " band" + (nOn === 1 ? "" : "s") + " on air · from /discover", "live");
               setFoot('live from <span class="ember">broker.rogerai.fyi/discover</span> · prices in $ / 1M tokens · auto-refresh 30s');
+              startShimmer();
+            } else if (action === "hold") {
+              // transient non-200 on BOTH reads, but we have a last-known market: KEEP it.
+              holdLastKnown();
+            } else if (action === "quiet-unreachable") {
+              // both reads failed and nothing to hold: honest "couldn't reach" state.
+              paintQuiet();
+              setStatus("couldn't reach the broker just now", "off");
+              setFoot('couldn\'t reach <span class="ember">broker.rogerai.fyi</span> · no live band to show');
             } else {
-              // broker reachable but empty: honest quiet state, no fake rows
+              // broker reachable but genuinely empty: honest quiet state, no fake rows
               paintQuiet();
               setStatus("the band is quiet right now - no stations on air yet", "demo");
               setFoot('broker reachable · <span class="ember">no stations on air yet</span> · this is a preview, not a live band');
@@ -471,10 +540,15 @@
       })
       .catch(function () {
         clearTimeout(to);
-        // unreachable -> honest quiet state, never a fabricated band
-        paintQuiet();
-        setStatus("couldn't reach the broker just now", "off");
-        setFoot('couldn\'t reach <span class="ember">broker.rogerai.fyi</span> · no live band to show');
+        // network error / abort: HOLD the last-known market rather than blanking; only fall to
+        // the honest "unreachable" state when there is nothing to hold.
+        if (decideRender({ liveCount: 0, marketOK: false, discoverOK: false, prevCount: rendered.length }) === "hold") {
+          holdLastKnown();
+        } else {
+          paintQuiet();
+          setStatus("couldn't reach the broker just now", "off");
+          setFoot('couldn\'t reach <span class="ember">broker.rogerai.fyi</span> · no live band to show');
+        }
       })
       .then(function () { inflight = false; });
   }
@@ -482,7 +556,11 @@
   function schedule() {
     if (REDUCED) return;          // no background polling under reduced-motion
     clearTimeout(pollTimer);
-    pollTimer = setTimeout(function () { if (visible) load(); schedule(); }, POLL_MS);
+    // Honor a 429's Retry-After for the NEXT poll only (never faster than the base cadence),
+    // then reset so a one-off throttle doesn't slow the steady state.
+    var wait = Math.max(POLL_MS, retryAfterMs || 0);
+    retryAfterMs = 0;
+    pollTimer = setTimeout(function () { if (visible) load(); schedule(); }, wait);
   }
 
   if (refreshBtn) {

--- a/web/src/js/voices.js
+++ b/web/src/js/voices.js
@@ -41,6 +41,18 @@
   var visible = false;
   var inflight = false;
   var loadedOnce = false;
+  var lastCount = 0;               // rows in the last successfully-painted roster
+  var retryAfterMs = 0;            // a 429's Retry-After hint (ms), applied to the NEXT poll only
+
+  // parseRetryAfter reads an integer-seconds Retry-After header and returns it in ms (0 if
+  // absent/non-numeric), so a transient 429 can pace the next poll to what the server asked.
+  function parseRetryAfter(res) {
+    if (!res || !res.headers) return 0;
+    var raw = "";
+    try { raw = res.headers.get ? res.headers.get("Retry-After") : ""; } catch (_) { raw = ""; }
+    var secs = parseInt(raw, 10);
+    return isFinite(secs) && secs > 0 ? secs * 1000 : 0;
+  }
 
   /* ---------- tiny DOM helpers ----------------------------------- */
   function el(tag, cls, html) {
@@ -173,30 +185,54 @@
     var to = setTimeout(function () { if (ctrl) ctrl.abort(); }, 8000);
 
     fetch(VOICES, { signal: ctrl ? ctrl.signal : undefined, cache: "no-store" })
-      .then(function (r) { if (!r.ok) throw new Error("http " + r.status); return r.json(); })
-      .then(function (data) {
+      .then(function (r) {
         clearTimeout(to);
         loadedOnce = true;
+        // A transient non-200 (e.g. a 429 "slow down") carries NO `.voices` - reading it as an
+        // empty roster is exactly the "flickers to empty" bug. Do NOT blank: if we have a
+        // last-known roster, HOLD it; capture Retry-After to pace the next poll.
+        if (!r.ok) {
+          retryAfterMs = parseRetryAfter(r);
+          if (lastCount > 0) {
+            setStatus("holding the last roster · re-reading…", "live");
+          } else {
+            paintQuiet();
+            setStatus("couldn't reach the broker just now", "off");
+            setFoot('couldn\'t reach <span class="ember">broker.rogerai.fyi</span> · no live roster to show');
+          }
+          return null;
+        }
+        return r.json();
+      })
+      .then(function (data) {
+        if (data === null) return; // handled above (transient non-200 hold / quiet)
         var rows = (data && Array.isArray(data.voices)) ? data.voices : [];
         var voices = normalize(rows);
         if (voices.length) {
           paint(voices);
+          lastCount = voices.length;
           var n = voices.length;
           setStatus(n + " voice" + (n === 1 ? "" : "s") + " on air · live from /voices", "live");
           setFoot('live from <span class="ember">broker.rogerai.fyi/voices</span> · metered by the character · prices in $ / 1k chars · auto-refresh 30s');
         } else {
-          // broker reachable but empty: honest quiet roster, no fake voices
+          // broker reachable but genuinely empty: honest quiet roster, no fake voices
           paintQuiet();
+          lastCount = 0;
           setStatus("the band is quiet right now - no voices on air yet", "quiet");
           setFoot('broker reachable · <span class="ember">no voices on air yet</span> · put your TTS rig on air with <code class="mono">roger share</code>');
         }
       })
       .catch(function () {
         clearTimeout(to);
-        // unreachable -> honest quiet roster, never a fabricated voice
-        paintQuiet();
-        setStatus("couldn't reach the broker just now", "off");
-        setFoot('couldn\'t reach <span class="ember">broker.rogerai.fyi</span> · no live roster to show');
+        // network error / abort: HOLD the last-known roster rather than blanking; fall to the
+        // honest "unreachable" state only when there is nothing to hold.
+        if (lastCount > 0) {
+          setStatus("holding the last roster · re-reading…", "live");
+        } else {
+          paintQuiet();
+          setStatus("couldn't reach the broker just now", "off");
+          setFoot('couldn\'t reach <span class="ember">broker.rogerai.fyi</span> · no live roster to show');
+        }
       })
       .then(function () { inflight = false; });
   }
@@ -204,7 +240,11 @@
   function schedule() {
     if (REDUCED) return;          // no background polling under reduced-motion
     clearTimeout(pollTimer);
-    pollTimer = setTimeout(function () { if (visible) load(); schedule(); }, POLL_MS);
+    // Honor a 429's Retry-After for the NEXT poll only (never faster than the base cadence),
+    // then reset so a one-off throttle doesn't slow the steady state.
+    var wait = Math.max(POLL_MS, retryAfterMs || 0);
+    retryAfterMs = 0;
+    pollTimer = setTimeout(function () { if (visible) load(); schedule(); }, wait);
   }
 
   if (refreshBtn) {

--- a/web/test/market-meter.test.mjs
+++ b/web/test/market-meter.test.mjs
@@ -89,3 +89,41 @@ test("fmtPrice: the shared price renderer the meter range reuses stays free-awar
   assert.equal(R.fmtPrice(0), "free");
   assert.equal(R.fmtPrice(0.3), "$0.30");
 });
+
+// --- transient-error resilience: never blank the market on a non-200 (the "flickers to
+// empty" incident). decideRender is the pure decision the fetch path uses. -----------------
+
+test("decideRender: fresh live data always renders", () => {
+  assert.equal(R.decideRender({ liveCount: 3, marketOK: true, discoverOK: true, prevCount: 0 }), "live");
+  // even a transient non-200 alongside live offers (shouldn't happen, but) renders the live data
+  assert.equal(R.decideRender({ liveCount: 1, marketOK: false, discoverOK: false, prevCount: 5 }), "live");
+});
+
+test("decideRender: a transient non-200 on BOTH reads HOLDS a last-known market (never blanks)", () => {
+  // This is the release-day bug: a 429 body has no offers -> liveCount 0, neither read OK.
+  // With a previous market on screen we HOLD it rather than paint the empty state.
+  assert.equal(R.decideRender({ liveCount: 0, marketOK: false, discoverOK: false, prevCount: 6 }), "hold");
+});
+
+test("decideRender: a transient failure with NOTHING to hold falls to the honest unreachable state", () => {
+  assert.equal(R.decideRender({ liveCount: 0, marketOK: false, discoverOK: false, prevCount: 0 }), "quiet-unreachable");
+});
+
+test("decideRender: a REACHABLE broker that genuinely returns empty shows the honest quiet state", () => {
+  // A 200 with an empty list is NOT transient - it is an honest empty market, even if we had a
+  // last-known one (the market really did go quiet).
+  assert.equal(R.decideRender({ liveCount: 0, marketOK: true, discoverOK: false, prevCount: 6 }), "quiet-empty");
+  assert.equal(R.decideRender({ liveCount: 0, marketOK: false, discoverOK: true, prevCount: 6 }), "quiet-empty");
+  assert.equal(R.decideRender({}), "quiet-unreachable"); // defensive: no info == treat as unreachable, nothing held
+});
+
+test("parseRetryAfter: integer seconds -> ms; absent/garbage -> 0", () => {
+  const mk = (v) => ({ headers: { get: (k) => (k === "Retry-After" ? v : null) } });
+  assert.equal(R.parseRetryAfter(mk("5")), 5000);
+  assert.equal(R.parseRetryAfter(mk("1")), 1000);
+  assert.equal(R.parseRetryAfter(mk("0")), 0);      // 0/negative is not a useful delay
+  assert.equal(R.parseRetryAfter(mk("nope")), 0);
+  assert.equal(R.parseRetryAfter(mk(null)), 0);
+  assert.equal(R.parseRetryAfter({}), 0);           // no headers
+  assert.equal(R.parseRetryAfter(null), 0);         // no response at all
+});


### PR DESCRIPTION
## The incident: "the dial flickers to empty"

`GET /discover` returned **HTTP 429** `{"error":{"message":"rate limit exceeded - slow down"}}` under normal-to-heavy same-IP polling. Every client (website `market.js`, the bands + voices pages, the iOS/CLI feeds) reads `.offers` off the response body. A 429 body has **no** `.offers`, so the client saw an empty list and painted the "honest empty" market state - an on-air band blinked to **quiet**.

## Root cause (verified with live HTTP evidence)

`/discover` had a redundant **per-IP anon rate-limit gate** that ran **before** the shared read-through cache:

```go
// market.go (old)
if ok, retry := b.anonRL.allow(clientIP(r)); !ok {
    w.Header().Set("Retry-After", strconv.Itoa(retry))
    jsonErr(w, http.StatusTooManyRequests, "rate limit exceeded - slow down")
    return
}
```

The bucket is tight (`ROGERAI_ANON_RATE_RPM=30`, `BURST=15`). The functionally-identical `/market` has **no** such gate and stayed stable under identical hammering. `/voices` carried the **same** gate and the same latent bug.

The one expensive thing these endpoints do - the full-market recompute - is **already** collapsed to `<=1 per publicMarketTTL (3s)` across all instances by the shared `serveCachedJSON` cache. So every extra `/discover` read is just a cheap Valkey/local cache GET + memcpy. The throttle bought nothing and only ever harmed availability.

## The fix

**Broker (primary):** delete the anon-RL gate on `/discover` (`market.go`) and `/voices` (`voices.go`), adopting `/market`'s cache-only posture. The shared short-TTL cache is their guard. The anon limiter itself **stays** - it still protects the real cost/abuse surfaces (`audio.go`, `tunnel.go` relay); only the two PUBLIC READ endpoints lose the gate. The now-unused `strconv` import is dropped from both files; no other logic depended on the early return.

**Client hardening (defense in depth):** `market.js` / `bands.js` / `voices.js` no longer render the empty state off a transient error body. On a non-200 (especially 429), a 5xx, or a network blip they **HOLD the last-known market** and **honor `Retry-After`** to pace the next poll. Only a broker that is *reachable and genuinely returns an empty list* paints the quiet state. A transient non-200 can never blank the UI again.

## Test evidence (spec-first, RED then GREEN)

RED against the old code (the gate 429s the 2nd request):

```
--- FAIL: TestDiscoverNeverRateLimitsToEmpty
    GET /discover #2 = 429 (rate-limited); a public read must never 429 - it blanks the market
--- FAIL: TestVoicesNeverRateLimitsToEmpty
    GET /voices #2 = 429 (rate-limited); a public read must never 429
--- FAIL: TestPublicReadsShareCacheOnlyThrottlePosture/discover
    GET /discover #1 = 429; the public reads must share a cache-only (no anon-gate) posture
```

GREEN after removing the gate. New / updated coverage:

- **`cmd/rogerai-broker/discover_ratelimit_test.go`** (new): 60 rapid same-IP `GET /discover` (and `/voices`) with the anon bucket drained all return 200 with the full payload, never 429; a test pinning that `/discover` and `/market` share the cache-only throttle posture.
- **`features/discovery/market.feature`** (+ step defs): executable godog scenarios for the same invariant (a public read is never rate-limited to empty).
- **`now_hardening_test.go` / `voicename_test.go`**: the two existing tests that pinned the OLD "public read rate-limits" behavior are updated to the corrected intent (the gate is intentionally removed; do not re-add it).
- **`web/test/market-meter.test.mjs`**: unit tests for the new pure `decideRender` (hold vs quiet-empty vs quiet-unreachable) and `parseRetryAfter` helpers.

Verification:
- `make cover-gate` **PASS** - total **92.3%**, every package `>=90%` (broker 90.7%). No `COVER_GATE_SKIP`.
- `go vet ./...` clean; `go build ./...` clean.
- Full broker suite green; broker package green under `-race` (154s).
- Web: `npm test` 59/59 green; `node web/build.mjs` builds 22 pages.

Note: `internal/update` has a pre-existing data race (`TestCachedNoticeStaleSpawnsRefresh`, a background-refresh goroutine) present on `origin/main` and untouched by this change.

## Build-and-hold

Opened for review; **not merged**, and the DO app is untouched (coordinator verifies in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ny8VyF5BQCpazjDsxqXC6t
