### PR TITLE
web: bound the market/roster hold so a dead broker stops painting on-air

### DIFF
--- a/web/src/js/bands.js
+++ b/web/src/js/bands.js
@@ -1105,6 +1105,13 @@
   var inflight = false;
   var lastLiveReal = [];           // last real bands that had >=1 live row (held over a transient error)
   var retryAfterMs = 0;            // a 429's Retry-After hint (ms), applied to the NEXT poll only
+  // BOUNDED HOLD: the transient-error hold is not indefinite. A short blip holds the last-known
+  // live bands, but a broker that stays unreachable would otherwise paint them "on air" forever.
+  // After HOLD_MAX consecutive holds we stop holding and tell the honest truth; any 200-with-data
+  // resets the streak so a recovered broker returns to live and a fresh blip holds again. At the
+  // 30s cadence HOLD_MAX=12 bounds the hold to ~6 min. (Mirrors market.js decideRender / HOLD_MAX.)
+  var HOLD_MAX = 12;
+  var holdStreak = 0;              // consecutive holds so far
 
   // parseRetryAfter reads an integer-seconds Retry-After header and returns it in ms (0 if
   // absent/non-numeric), so a transient 429 can pace the next poll to what the server asked.
@@ -1163,13 +1170,24 @@
       var liveN = merged.filter(function (b) { return b.live; }).length;
 
       // Transient: NEITHER endpoint returned a usable 200 body. Don't blank the live bands - if
-      // we have a last-known live set, HOLD it (re-ingest so the on-air rows stay put).
+      // we have a last-known live set, HOLD it (re-ingest so the on-air rows stay put) - but only
+      // for a BOUNDED number of consecutive polls, so a long-dead broker is not painted on-air
+      // indefinitely. Past HOLD_MAX holds we drop to the honest "couldn't reach" state.
       if (!anyOK && liveN === 0 && lastLiveReal.length) {
-        ingest(lastLiveReal, true);
-        setStatus("holding the last band read · re-tuning…", "live");
+        holdStreak++;
+        if (holdStreak <= HOLD_MAX) {
+          ingest(lastLiveReal, true);
+          setStatus("holding the last band read · re-tuning…", "live");
+          return;
+        }
+        lastLiveReal = [];              // bounded hold expired: stop resurrecting a dead broker
+        ingest([], false);
+        setStatus("couldn't reach the broker just now - retrying", "off");
         return;
       }
 
+      // Any poll that reaches here is live or reachable-but-empty: the failure streak is broken.
+      holdStreak = 0;
       if (liveN > 0) lastLiveReal = merged; // remember the freshest live set for a future hold
       ingest(merged, anyOK);
 
@@ -1183,11 +1201,14 @@
     }).catch(function () {
       clearTimeout(to);
       inflight = false;
-      // Unexpected error: HOLD the last-known live bands rather than blanking, if any.
-      if (lastLiveReal.length) {
+      // Unexpected error: HOLD the last-known live bands rather than blanking, if any - but
+      // bounded, exactly like the transient path above, so a dead broker stops being held.
+      if (lastLiveReal.length && holdStreak < HOLD_MAX) {
+        holdStreak++;
         ingest(lastLiveReal, true);
         setStatus("holding the last band read · re-tuning…", "live");
       } else {
+        if (lastLiveReal.length) lastLiveReal = [];   // bounded hold expired
         ingest([], false);
         setStatus("couldn't reach the broker just now - retrying", "off");
       }

--- a/web/src/js/market.js
+++ b/web/src/js/market.js
@@ -74,7 +74,16 @@
      if neither endpoint returned a usable 200 body this poll AND we have a
      last-known market, we HOLD it rather than blanking. Only a broker that is
      REACHABLE and genuinely returns an EMPTY list paints the honest quiet state.
-     A 200-with-live-market always renders fresh. */
+     A 200-with-live-market always renders fresh.
+
+     BOUNDED HOLD: the hold is not indefinite. A short blip holds, but a broker
+     that stays unreachable would otherwise paint the last-known stations "on air"
+     forever. After HOLD_MAX consecutive holds we DEGRADE from `hold` to the honest
+     `quiet-unreachable` so a long-dead broker is not painted on-air indefinitely.
+     The caller threads the consecutive-hold count in as poll.holdStreak (reset to 0
+     on any 200-with-data poll), keeping decideRender pure - no timers, no clock. At
+     the 30s poll cadence HOLD_MAX=12 bounds the hold to ~6 min before it goes honest. */
+  var HOLD_MAX = 12;
   function decideRender(poll) {
     poll = poll || {};
     if ((+poll.liveCount || 0) > 0) return "live";      // fresh live data - always render it
@@ -82,7 +91,10 @@
     // (a transient error - 429, 5xx, a network blip), keep the last-known market on screen
     // instead of blanking; fall back to an honest "unreachable" only when we have nothing.
     if (!poll.marketOK && !poll.discoverOK) {
-      return (+poll.prevCount || 0) > 0 ? "hold" : "quiet-unreachable";
+      if ((+poll.prevCount || 0) <= 0) return "quiet-unreachable";   // nothing to hold
+      // bounded: once the held state has persisted HOLD_MAX consecutive polls, stop
+      // painting a dead broker on-air and tell the honest truth.
+      return (+poll.holdStreak || 0) >= HOLD_MAX ? "quiet-unreachable" : "hold";
     }
     // At least one endpoint answered 200 but with an empty/no-live list: an honest quiet market.
     return "quiet-empty";
@@ -103,7 +115,7 @@
   // bits and skip all DOM/fetch below. The browser path runs exactly as before.
   if (typeof document === "undefined") {
     if (typeof module !== "undefined" && module.exports) {
-      module.exports = { meterReadout: meterReadout, fmtPrice: fmtPrice, decideRender: decideRender, parseRetryAfter: parseRetryAfter };
+      module.exports = { meterReadout: meterReadout, fmtPrice: fmtPrice, decideRender: decideRender, parseRetryAfter: parseRetryAfter, HOLD_MAX: HOLD_MAX };
     }
     return;
   }
@@ -133,6 +145,7 @@
   var visible = false;
   var inflight = false;
   var retryAfterMs = 0;            // a 429's Retry-After hint (ms) applied to the NEXT poll only
+  var holdStreak = 0;              // consecutive holds so far; a 200-with-data resets it. Bounds the hold (see decideRender / HOLD_MAX)
 
   /* ---------- tiny DOM helpers ----------------------------------- */
   function el(tag, cls, html) {
@@ -495,6 +508,7 @@
         var nOnline = channels.filter(function (c) { return c.live; }).length;
         if (channels.length && nOnline > 0) {
           clearTimeout(to);
+          holdStreak = 0;                        // 200-with-data: a recovered broker returns to live
           paint(channels, true);
           paintMeter(meterReadout(channels));   // ALL on-air bands, not just the 6 painted rows
           setStatus(nOnline + " band" + (nOnline === 1 ? "" : "s") + " on air · live from /market", "live");
@@ -513,7 +527,8 @@
             clearTimeout(to);
             var offers = (d && Array.isArray(d.offers)) ? d.offers : [];
             var live = offers.length ? offers.filter(function (o) { return o && o.online !== false; }).length : 0;
-            var action = decideRender({ liveCount: live, marketOK: marketOK, discoverOK: discoverOK, prevCount: rendered.length });
+            var action = decideRender({ liveCount: live, marketOK: marketOK, discoverOK: discoverOK, prevCount: rendered.length, holdStreak: holdStreak });
+            holdStreak = action === "hold" ? holdStreak + 1 : 0;   // count consecutive holds; any other outcome resets
             if (action === "live") {
               var ch = aggregate(offers);
               paint(ch, true);
@@ -523,7 +538,7 @@
               setFoot('live from <span class="ember">broker.rogerai.fyi/discover</span> · prices in $ / 1M tokens · auto-refresh 30s');
               startShimmer();
             } else if (action === "hold") {
-              // transient non-200 on BOTH reads, but we have a last-known market: KEEP it.
+              // transient non-200 on BOTH reads, but we have a last-known market: KEEP it (bounded).
               holdLastKnown();
             } else if (action === "quiet-unreachable") {
               // both reads failed and nothing to hold: honest "couldn't reach" state.
@@ -541,8 +556,10 @@
       .catch(function () {
         clearTimeout(to);
         // network error / abort: HOLD the last-known market rather than blanking; only fall to
-        // the honest "unreachable" state when there is nothing to hold.
-        if (decideRender({ liveCount: 0, marketOK: false, discoverOK: false, prevCount: rendered.length }) === "hold") {
+        // the honest "unreachable" state when there is nothing to hold OR the bounded hold expired.
+        var action = decideRender({ liveCount: 0, marketOK: false, discoverOK: false, prevCount: rendered.length, holdStreak: holdStreak });
+        holdStreak = action === "hold" ? holdStreak + 1 : 0;
+        if (action === "hold") {
           holdLastKnown();
         } else {
           paintQuiet();

--- a/web/src/js/voices.js
+++ b/web/src/js/voices.js
@@ -43,6 +43,12 @@
   var loadedOnce = false;
   var lastCount = 0;               // rows in the last successfully-painted roster
   var retryAfterMs = 0;            // a 429's Retry-After hint (ms), applied to the NEXT poll only
+  // BOUNDED HOLD: the transient-error hold is not indefinite. A short blip holds the last-known
+  // roster, but a broker that stays unreachable would otherwise paint it "on air" forever. After
+  // HOLD_MAX consecutive holds we drop to the honest unreachable state; any 200 (reachable) resets
+  // the streak. At the 30s cadence HOLD_MAX=12 bounds the hold to ~6 min. (Mirrors market.js.)
+  var HOLD_MAX = 12;
+  var holdStreak = 0;              // consecutive holds so far
 
   // parseRetryAfter reads an integer-seconds Retry-After header and returns it in ms (0 if
   // absent/non-numeric), so a transient 429 can pace the next poll to what the server asked.
@@ -193,9 +199,11 @@
         // last-known roster, HOLD it; capture Retry-After to pace the next poll.
         if (!r.ok) {
           retryAfterMs = parseRetryAfter(r);
-          if (lastCount > 0) {
+          if (lastCount > 0 && holdStreak < HOLD_MAX) {
+            holdStreak++;                       // bounded: keep the last roster for a while
             setStatus("holding the last roster · re-reading…", "live");
           } else {
+            if (lastCount > 0) lastCount = 0;   // bounded hold expired: stop holding a dead roster
             paintQuiet();
             setStatus("couldn't reach the broker just now", "off");
             setFoot('couldn\'t reach <span class="ember">broker.rogerai.fyi</span> · no live roster to show');
@@ -206,6 +214,7 @@
       })
       .then(function (data) {
         if (data === null) return; // handled above (transient non-200 hold / quiet)
+        holdStreak = 0;            // a 200 (reachable) breaks the failure streak
         var rows = (data && Array.isArray(data.voices)) ? data.voices : [];
         var voices = normalize(rows);
         if (voices.length) {
@@ -225,10 +234,12 @@
       .catch(function () {
         clearTimeout(to);
         // network error / abort: HOLD the last-known roster rather than blanking; fall to the
-        // honest "unreachable" state only when there is nothing to hold.
-        if (lastCount > 0) {
+        // honest "unreachable" state when there is nothing to hold OR the bounded hold expired.
+        if (lastCount > 0 && holdStreak < HOLD_MAX) {
+          holdStreak++;
           setStatus("holding the last roster · re-reading…", "live");
         } else {
+          if (lastCount > 0) lastCount = 0;   // bounded hold expired
           paintQuiet();
           setStatus("couldn't reach the broker just now", "off");
           setFoot('couldn\'t reach <span class="ember">broker.rogerai.fyi</span> · no live roster to show');

--- a/web/test/market-meter.test.mjs
+++ b/web/test/market-meter.test.mjs
@@ -117,6 +117,66 @@ test("decideRender: a REACHABLE broker that genuinely returns empty shows the ho
   assert.equal(R.decideRender({}), "quiet-unreachable"); // defensive: no info == treat as unreachable, nothing held
 });
 
+// --- bounded hold: a genuinely dead broker must NOT paint the last-known market on-air
+// forever. After HOLD_MAX consecutive holds the held state DEGRADES to the honest
+// quiet-unreachable; a single 200-with-data resets the streak so a recovered broker returns
+// to live and a fresh blip holds again. The streak is threaded in as poll.holdStreak so
+// decideRender stays a pure function (no timers, no wall clock). --------------------------
+
+// drive() runs decideRender across a poll sequence exactly as the page's poll loop maintains
+// the consecutive-hold streak: reset to 0 on a live (200-with-data) poll, increment on each
+// hold, leave it otherwise (a degraded/quiet poll clears the held rows so prevCount -> 0).
+function drive(steps) {
+  let streak = 0;
+  return steps.map((s) => {
+    const action = R.decideRender({ ...s, holdStreak: streak });
+    if (action === "live") streak = 0;
+    else if (action === "hold") streak += 1;
+    return action;
+  });
+}
+
+const blip = { liveCount: 0, marketOK: false, discoverOK: false, prevCount: 6 };
+const good = { liveCount: 4, marketOK: true, discoverOK: true, prevCount: 6 };
+
+test("bounded hold: a single non-200 after a good read still HOLDS (no regression)", () => {
+  assert.deepEqual(drive([good, blip]), ["live", "hold"]);
+  // a short streak of blips keeps holding, well under the threshold
+  assert.deepEqual(drive([good, blip, blip, blip]), ["live", "hold", "hold", "hold"]);
+});
+
+test("bounded hold: HOLD_MAX consecutive non-200 polls DEGRADE hold -> quiet-unreachable", () => {
+  const K = R.HOLD_MAX;
+  assert.ok(Number.isFinite(K) && K >= 2, "HOLD_MAX is a finite threshold");
+  // K holds, then the (K+1)-th consecutive failure degrades to the honest unreachable state.
+  const steps = [good];
+  for (let i = 0; i < K + 1; i++) steps.push(blip);
+  const out = drive(steps);
+  for (let i = 1; i <= K; i++) assert.equal(out[i], "hold", `blip #${i} still holds`);
+  // one past the threshold: a long-dead broker is no longer painted on-air.
+  assert.equal(out[K + 1], "quiet-unreachable");
+});
+
+test("bounded hold: a 200-with-data before the threshold RESETS the streak (holds again on the next blip)", () => {
+  const K = R.HOLD_MAX;
+  // Drive right UP TO the threshold (K holds), then recover, then blip once more. Without the
+  // reset the streak would be K and the next blip would DEGRADE - so a passing "hold" here proves
+  // the 200-with-data cleared the streak.
+  const steps = [good];
+  for (let i = 0; i < K; i++) steps.push(blip);     // K holds: at the threshold, not past it
+  steps.push(good);                                 // recovered: 200-with-data resets the streak
+  steps.push(blip);                                 // a fresh blip
+  const out = drive(steps);
+  for (let i = 1; i <= K; i++) assert.equal(out[i], "hold", `pre-recovery blip #${i} holds`);
+  assert.equal(out[out.length - 2], "live");
+  assert.equal(out[out.length - 1], "hold", "post-recovery blip holds again - streak was reset");
+});
+
+test("bounded hold: a REACHABLE-but-empty broker still shows quiet-empty (never over-corrected to unreachable)", () => {
+  // even deep into a hold streak, a genuine 200-with-empty is an honest quiet market, not a degrade.
+  assert.equal(R.decideRender({ liveCount: 0, marketOK: true, discoverOK: false, prevCount: 6, holdStreak: 99 }), "quiet-empty");
+});
+
 test("parseRetryAfter: integer seconds -> ms; absent/garbage -> 0", () => {
   const mk = (v) => ({ headers: { get: (k) => (k === "Retry-After" ? v : null) } });
   assert.equal(R.parseRetryAfter(mk("5")), 5000);


### PR DESCRIPTION
## What

Follow-up to PR #14, which made the web market/voices widgets **HOLD** the last-known market on a transient non-200 (429 / 5xx / network) instead of blanking - so a broker blip never empties the dial. That hold was **indefinite**: a genuinely dead broker keeps showing the last-known stations "on air" forever.

This PR **bounds** the hold. After `HOLD_MAX` (12) consecutive holds the held state **degrades** from `hold` to the honest `quiet-unreachable`, so a long-dead broker is not painted on-air indefinitely. Any 200-with-data poll **resets** the consecutive-hold counter, so a recovered broker immediately returns to live and a fresh single blip still holds (no regression). A reachable-but-empty broker still shows `quiet-empty` (not over-corrected to unreachable).

## Threshold chosen

A **consecutive-hold counter**, not a wall-clock timestamp:
- cleaner to unit-test (no fake timers) and keeps the decision **pure**;
- at the 30s poll cadence, **12 consecutive holds bounds a dead broker's on-air paint to ~6 min** before it goes honest.

`market.js` threads the streak into the pure `decideRender` as `poll.holdStreak` (with `HOLD_MAX` exported for the tests). `bands.js` and `voices.js` carry the same bounded counter inline across their transient-error and catch paths, resetting on any reachable (200) poll. All three files use identical 12-holds-then-degrade semantics.

## Spec-first (RED then GREEN)

`web/test/market-meter.test.mjs` extends the `decideRender` suite with a small state-machine driver and pins:
1. a single non-200 after a good read still **holds** (unchanged - no regression);
2. `HOLD_MAX` consecutive non-200 polls **degrade** `hold` -> `quiet-unreachable`;
3. a 200-with-data before the threshold **resets** the streak (drives right up to the threshold, recovers, then a fresh blip must hold again - so the assertion only passes if the streak was cleared);
4. a reachable-but-empty broker still shows `quiet-empty`.

RED first against the current indefinite-hold code (the degrade test failed: `HOLD_MAX` did not exist), then GREEN.

## Verification

- `npm test` (web/): **63 pass, 0 fail** (incl. all existing `decideRender` / `parseRetryAfter` / meter cases).
- `node build.mjs`: **built 22 page(s)**.

Files: `web/src/js/market.js`, `web/src/js/bands.js`, `web/src/js/voices.js`, `web/test/market-meter.test.mjs`.

Build-and-hold: not merged; DO app untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ny8VyF5BQCpazjDsxqXC6t