### PR TITLE
operator: Guest Operators Phase 2 - detection + /operator + handoff + RC interlock

### DIFF
--- a/features/operator/config_aider.feature
+++ b/features/operator/config_aider.feature
@@ -1,0 +1,56 @@
+# GUEST OPERATORS — Phase 2: aider wiring (pure env + flags, ZERO generated files).
+#
+# aider is the one MVP guest whose wiring is honestly env-based (§4): OPENAI_API_BASE +
+# OPENAI_API_KEY plus `--model openai/<m>`. Minimization rung: since no file is generated,
+# NO scratch dir is created for aider at all — the cleanup path is a no-op by construction
+# and there is nothing to leak on crash.
+#
+# The flag set is pinned from §4 verbatim:
+#   --no-show-model-warnings  (an unknown model name otherwise produces a scary wall)
+#   --no-auto-commits         (a guest must NEVER commit to the user's repo on its own —
+#                              this is a safety flag, not a convenience; it stays even if
+#                              some future aider makes it the default)
+#
+# NOTE for the founder: aider is NOT installed on the dev box, so unlike opencode/hermes
+# its wiring is doc-proven (§4) but not re-verified today. The GREEN-stage live E2E needs
+# an aider install; no known-good version is pinned in the registry yet — ruling requested.
+
+Feature: aider per-session wiring
+  Handing the mic to aider composes env and flags only: proxy base URL and session
+  key in the environment, model and safety flags on the argv, no file anywhere.
+
+  Background:
+    Given a live proxy session at "http://127.0.0.1:44017/v1" with session key "sk-test-0123" and band model "qwen3-32b-fp8"
+
+  Scenario: The launch argv is exact and carries the safety flags
+    When the aider launch is materialized
+    Then the argv is exactly "aider --model openai/qwen3-32b-fp8 --no-show-model-warnings --no-auto-commits"
+
+  Scenario: The launch env composes the OpenAI-compatible pair from the live options
+    When the aider launch is materialized
+    Then the env additions are exactly:
+      | OPENAI_API_BASE | http://127.0.0.1:44017/v1 |
+      | OPENAI_API_KEY  | sk-test-0123              |
+    And the parent environment is otherwise inherited unmodified
+
+  Scenario: No file and no scratch dir are created for aider
+    When the aider launch is materialized
+    Then no scratch dir exists for the session
+    And no file was written anywhere
+
+  Scenario: --no-auto-commits is present on every composed argv (permanent safety pin)
+    When the aider launch is materialized for any band model
+    Then the argv contains "--no-auto-commits"
+
+  Scenario: Wiring reads the LIVE proxy options at materialize time
+    Given the band is re-tuned to model "llama-3.3-70b" before the handoff
+    When the aider launch is materialized
+    Then the argv pins "--model openai/llama-3.3-70b"
+
+  Scenario: A stale OPENAI_API_KEY in the parent environment is overridden, not merged
+    # The user may already export a real OpenAI key. The child must get OUR session key,
+    # or aider bills the user's real OpenAI account instead of the tuned band.
+    Given the parent environment already sets OPENAI_API_KEY to "sk-users-real-openai-key"
+    When the aider launch is materialized
+    Then the child env sets OPENAI_API_KEY to "sk-test-0123"
+    And the child env sets OPENAI_API_BASE to "http://127.0.0.1:44017/v1"

--- a/features/operator/config_hermes.feature
+++ b/features/operator/config_hermes.feature
@@ -1,0 +1,98 @@
+# GUEST OPERATORS — Phase 2: hermes config generation (per-session, scratch HERMES_HOME).
+#
+# THE CONFIG-ISOLATION INVESTIGATION (task-mandated; result: hermes STAYS in the MVP):
+#   ~/.hermes/config.yaml is the USER'S REAL FILE and is never written. hermes 0.16.0 reads
+#   the `HERMES_HOME` env var as a full home override (hermes_constants.py:56 "Reads
+#   HERMES_HOME env var, falls back to the platform-native default" — verified in the
+#   installed source on 2026-07-06). Setting HERMES_HOME to a scratch dir isolates
+#   config.yaml, sessions, checkpoints — everything.
+#
+# THE KEY-DELIVERY CORRECTION (supersedes the §4 model_aliases-only route): the doc's
+# empirical run predated Phase 1 auth. A bare `model_aliases:` DirectAlias carries NO
+# api_key field (model_switch.py:165 NamedTuple: model/provider/base_url) and its runtime
+# resolution ends at "no-key-required" for a loopback base_url (runtime_provider.py:919
+# — OPENAI_API_KEY is host-gated to api.openai.com and the host-derived <VENDOR>_API_KEY
+# path rejects IPs/loopback). Against the Phase 1 bearer-enforcing proxy that is a
+# guaranteed 401. The 0.16 path that DOES deliver a key to a custom base_url is the keyed
+# `providers.<name>` schema: model_switch.py:900-931 resolves providers.roger.base_url and
+# expands api_key "${VAR}" from the environment (:914-916; key_env also supported :918-920).
+# So the golden config uses `providers:` + `model:` and the argv pins `-m roger/<model>`.
+# GREEN-stage live E2E must confirm `hermes -m roger/<model> -z "ping"` end-to-end (memory:
+# live E2E catches what tests miss); if 0.16 refuses, hermes drops from MVP per §6.
+#
+# FOUNDER DECISIONS REQUESTED:
+#   - Confirm hermes stays IN the MVP on the HERMES_HOME isolation evidence above.
+#   - A fresh HERMES_HOME may trigger hermes' first-run setup; the launch env is specced
+#     with HERMES_INTERACTIVE-safe defaults only if the live E2E shows a wizard block
+#     (flagged, not specced — no invented flags).
+
+Feature: hermes per-session config generation
+  Handing the mic to hermes materializes a throwaway config.yaml inside a scratch
+  HERMES_HOME, so hermes runs on the tuned band through the authenticated proxy and
+  the user's real ~/.hermes is never opened for writing.
+
+  Background:
+    Given a live proxy session at "http://127.0.0.1:44017/v1" with session key "sk-test-0123" and band model "qwen3-32b-fp8"
+    And a session scratch dir
+
+  Scenario: The generated config.yaml is byte-exact (golden artifact)
+    When the hermes launch is materialized
+    Then the scratch dir contains "hermes-home/config.yaml"
+    And "hermes-home/config.yaml" equals the golden artifact:
+      """
+      providers:
+        roger:
+          base_url: http://127.0.0.1:44017/v1
+          api_key: ${ROGER_SESSION_KEY}
+      model:
+        provider: roger
+        default: qwen3-32b-fp8
+      """
+
+  Scenario: The launch env points hermes at the scratch home
+    When the hermes launch is materialized
+    Then the env additions are exactly:
+      | HERMES_HOME       | <scratch>/hermes-home |
+      | ROGER_SESSION_KEY | sk-test-0123          |
+    And the parent environment is otherwise inherited unmodified
+
+  Scenario: The launch argv pins the roger provider and model
+    When the hermes launch is materialized
+    Then the argv is exactly "hermes -m roger/qwen3-32b-fp8"
+
+  Scenario: The session key never appears inside any generated file
+    # api_key is the literal string "${ROGER_SESSION_KEY}" on disk; hermes expands it
+    # from the env at runtime (model_switch.py:914-916).
+    When the hermes launch is materialized
+    Then no file under the scratch dir contains the string "sk-test-0123"
+
+  Scenario: The user's real ~/.hermes/config.yaml is never opened for writing
+    Given the user has a real "~/.hermes/config.yaml"
+    When the hermes launch is materialized and the guest exits
+    Then "~/.hermes/config.yaml" is byte-identical to before
+    And nothing was written under "~/.hermes"
+
+  Scenario: Config generation reads the LIVE proxy options at materialize time
+    Given the band is re-tuned to model "llama-3.3-70b" before the handoff
+    When the hermes launch is materialized
+    Then "hermes-home/config.yaml" wires default model "llama-3.3-70b"
+    And the argv pins "-m roger/llama-3.3-70b"
+
+  Scenario: The scratch HERMES_HOME is removed after a clean exit
+    When the hermes launch is materialized
+    And the guest exits cleanly
+    Then the session scratch dir no longer exists
+
+  Scenario: A crashed hermes still gets its scratch home cleaned up
+    # hermes writes sessions/checkpoints into HERMES_HOME while running; the sweep
+    # removes the whole scratch dir regardless of what the guest left inside it.
+    When the hermes launch is materialized
+    And the guest crashes with exit 1
+    Then the session scratch dir no longer exists
+
+  Scenario: A model_aliases-only config is a specified regression, not a wiring option
+    # Permanent regression pin for the key-delivery correction above: materialization
+    # must NEVER emit a bare model_aliases entry as the sole wiring (it resolves to
+    # api_key "no-key-required" on loopback and 401s against the Phase 1 proxy).
+    When the hermes launch is materialized
+    Then "hermes-home/config.yaml" contains a "providers:" section with an api_key reference

--- a/features/operator/config_isolation.feature
+++ b/features/operator/config_isolation.feature
@@ -1,0 +1,109 @@
+# GUEST OPERATORS — Phase 2: config isolation invariants (cross-guest, security-adjacent).
+#
+# THE INVARIANT (design doc §4, "avoided by construction"): a handoff NEVER touches the
+# user's real agent configs, the user's cwd, or anything outside the one session scratch
+# dir. This file is the explicit, adversarial pin of that construction for EVERY guest —
+# the scariest failure ("RogerAI clobbered my ~/.config/opencode") must be impossible by
+# spec, not by care.
+#
+# Scratch discipline:
+#   - one dir per handoff under os.TempDir(): rogerai-operator-<random>, mode 0700
+#     (it holds a file whose CONTENT references the session key env var; 0700 keeps other
+#      local users from even enumerating it)
+#   - removed on return, clean or crashed exit alike (the cleanup runs in the ExecProcess
+#     return callback, which bubbletea delivers for every child outcome)
+#   - a crash of ROGER ITSELF mid-handoff leaks the dir; a best-effort sweep of stale
+#     rogerai-operator-* dirs (older than 24h) runs at the next desk scan
+#   - the SESSION KEY NEVER TOUCHES DISK: config files reference it by env-var name only
+#     ({env:ROGER_SESSION_KEY} / ${ROGER_SESSION_KEY}); aider gets it purely via env
+
+Feature: Never touch the user's config — the scratch-dir invariant
+  Every byte a handoff writes lands inside one throwaway session scratch dir,
+  the session secret never lands on disk at all, and the dir is gone when the
+  guest leaves the desk — however the guest left.
+
+  Background:
+    Given a live proxy session at "http://127.0.0.1:44017/v1" with session key "sk-test-0123" and band model "qwen3-32b-fp8"
+
+  Scenario Outline: Materializing <guest> writes nothing outside the session scratch dir
+    Given a sentinel snapshot of the user's home and the launch workdir
+    When the <guest> launch is materialized
+    Then every written path is under the session scratch dir
+    And the user's home matches the sentinel snapshot
+    And the launch workdir matches the sentinel snapshot
+
+    Examples:
+      | guest    |
+      | opencode |
+      | hermes   |
+      | aider    |
+
+  Scenario Outline: The session key is never written to disk for <guest>
+    When the <guest> launch is materialized
+    Then no file on the entire scratch path contains "sk-test-0123"
+
+    Examples:
+      | guest    |
+      | opencode |
+      | hermes   |
+      | aider    |
+
+  Scenario: The scratch dir is private (0700)
+    When the opencode launch is materialized
+    Then the session scratch dir has mode 0700
+
+  Scenario: The launch workdir is the user's confirmed workdir, never the scratch dir
+    # The guest edits the user's project; only its CONFIG lives in scratch. Mixing the
+    # two would make the guest edit throwaway files and then delete its own work.
+    When the opencode launch is materialized
+    Then the child working directory is the launch workdir
+    And the child working directory is not the session scratch dir
+
+  Scenario Outline: Cleanup after a clean exit removes the whole scratch dir for <guest>
+    When the <guest> launch is materialized
+    And the guest exits cleanly
+    Then no rogerai-operator scratch dir remains for this session
+
+    Examples:
+      | guest    |
+      | opencode |
+      | hermes   |
+
+  Scenario Outline: Cleanup after a crash removes the whole scratch dir for <guest>
+    When the <guest> launch is materialized
+    And the guest crashes with exit 1
+    Then no rogerai-operator scratch dir remains for this session
+
+    Examples:
+      | guest    |
+      | opencode |
+      | hermes   |
+
+  Scenario: Cleanup tolerates a guest that deleted its own config
+    When the opencode launch is materialized
+    And the guest removed files inside the scratch dir before exiting
+    Then cleanup still succeeds
+    And no rogerai-operator scratch dir remains for this session
+
+  Scenario: A stale scratch dir from a crashed roger is swept at the next desk scan
+    Given a leftover "rogerai-operator-dead1" scratch dir older than 24 hours
+    And a fresh "rogerai-operator-live2" scratch dir from a running session
+    When the desk is scanned
+    Then "rogerai-operator-dead1" is removed
+    And "rogerai-operator-live2" is untouched
+
+  Scenario: Two rapid handoffs never share a scratch dir
+    When the opencode launch is materialized
+    And the guest exits cleanly
+    And the opencode launch is materialized again
+    Then the second session scratch dir differs from the first
+    And only the second scratch dir exists
+
+  Scenario: Key exfil by the guest itself is out of scope and bounded by the budget
+    # §8 residual: the guest CAN read ROGER_SESSION_KEY from its own env — that is the
+    # wire. What bounds the blast radius is the $2 session budget (Phase 1) and the key
+    # dying with the session. Pinned here so nobody "fixes" it by writing the key to a
+    # file with tighter modes (which would be strictly worse).
+    When the opencode launch is materialized
+    Then the child env contains ROGER_SESSION_KEY
+    And the session budget is capped at the default session budget

--- a/features/operator/config_opencode.feature
+++ b/features/operator/config_opencode.feature
@@ -1,0 +1,107 @@
+# GUEST OPERATORS — Phase 2: opencode config generation (per-session, scratch-scoped).
+#
+# GROUND TRUTH (verified against the installed opencode 1.17.11 binary on 2026-07-06 by
+# inspecting its bundled config loader — not guessed from docs):
+#   - `OPENCODE_CONFIG=/path/to/file.json` IS honored: "load an additional explicit config",
+#     loaded AFTER the global ~/.config/opencode config and BEFORE project opencode.json
+#     files found upward from cwd. OPENCODE_CONFIG_CONTENT (inline JSON env) also exists and
+#     loads AFTER project configs.
+#   - PRECEDENCE HAZARD: because project config loads after OPENCODE_CONFIG, a user project
+#     carrying its own opencode.json { "model": ... } would silently override a model set
+#     only in our scratch config — the exact "guest silently runs on the wrong backend"
+#     failure class that got claude excluded. The launch argv therefore ALWAYS pins the
+#     model too: `opencode -m roger/<model>` (global -m flag, verified in 1.17.11 --help),
+#     which beats every config layer. The wiring is provable from argv+env alone (the
+#     hermes env-ignored lesson: never trust a config file the CLI might not read).
+#   - Config supports `{env:VAR}` substitution (verified in the binary), so the session
+#     bearer key is passed by ENV REFERENCE and NEVER written to disk.
+#
+# The generated provider entry is the §4 empirically-proven shape: a custom provider
+# "roger" on @ai-sdk/openai-compatible with baseURL + apiKey + the tuned model.
+#
+# FOUNDER DECISION REQUESTED (this spec proposes option 1):
+#   1. scratch file + OPENCODE_CONFIG + argv -m pin   (debuggable artifact, shown on the
+#      Phase 3 plate; recommended)
+#   2. OPENCODE_CONFIG_CONTENT inline env             (zero files, highest file precedence,
+#      but no on-disk artifact to show and the whole config lands in /proc/<pid>/environ)
+
+Feature: opencode per-session config generation
+  Handing the mic to opencode materializes a throwaway opencode.json in the session
+  scratch dir, points opencode at it via OPENCODE_CONFIG, and pins the model on the
+  argv, so the guest provably runs on the tuned band and the user's own opencode
+  setup is never touched.
+
+  Background:
+    Given a live proxy session at "http://127.0.0.1:44017/v1" with session key "sk-test-0123" and band model "qwen3-32b-fp8"
+    And a session scratch dir
+
+  Scenario: The generated opencode.json is byte-exact (golden artifact)
+    When the opencode launch is materialized
+    Then the scratch dir contains exactly one file "opencode.json"
+    And "opencode.json" equals the golden artifact:
+      """
+      {
+        "$schema": "https://opencode.ai/config.json",
+        "provider": {
+          "roger": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "RogerAI",
+            "options": {
+              "baseURL": "http://127.0.0.1:44017/v1",
+              "apiKey": "{env:ROGER_SESSION_KEY}"
+            },
+            "models": {
+              "qwen3-32b-fp8": { "name": "qwen3-32b-fp8" }
+            }
+          }
+        },
+        "model": "roger/qwen3-32b-fp8"
+      }
+      """
+
+  Scenario: The launch argv pins the model so no config layer can override it
+    When the opencode launch is materialized
+    Then the argv is exactly "opencode -m roger/qwen3-32b-fp8"
+
+  Scenario: The launch env composes OPENCODE_CONFIG and the key by reference
+    When the opencode launch is materialized
+    Then the env additions are exactly:
+      | OPENCODE_CONFIG   | <scratch>/opencode.json |
+      | ROGER_SESSION_KEY | sk-test-0123            |
+    And the parent environment is otherwise inherited unmodified
+
+  Scenario: The session key never appears inside any generated file
+    When the opencode launch is materialized
+    Then no file under the scratch dir contains the string "sk-test-0123"
+
+  Scenario: A user project already carrying opencode.json cannot re-route the guest
+    # Regression guard for the precedence hazard: project config loads AFTER
+    # OPENCODE_CONFIG in 1.17.11, so only the argv -m pin makes the wiring provable.
+    Given the launch workdir contains a project "opencode.json" selecting model "anthropic/claude-opus-4"
+    When the opencode launch is materialized
+    Then the argv still pins "-m roger/qwen3-32b-fp8"
+    And the project "opencode.json" is not modified
+
+  Scenario: Config generation reads the LIVE proxy options at materialize time
+    # ProxyOptionsHolder.Get() at exec time — never the options frozen at first bind
+    # (features/proxy/live_options.feature is the Phase 1 ground for this).
+    Given the band is re-tuned to model "llama-3.3-70b" before the handoff
+    When the opencode launch is materialized
+    Then "opencode.json" wires model "llama-3.3-70b"
+    And the argv pins "-m roger/llama-3.3-70b"
+
+  Scenario: The generated config is removed after a clean exit
+    When the opencode launch is materialized
+    And the guest exits cleanly
+    Then the session scratch dir no longer exists
+
+  Scenario: A crashed guest still gets its scratch config cleaned up
+    When the opencode launch is materialized
+    And the guest crashes with exit 1
+    Then the session scratch dir no longer exists
+
+  Scenario: The user's real opencode config is never touched
+    Given the user has a real "~/.config/opencode/opencode.json"
+    When the opencode launch is materialized and the guest exits
+    Then "~/.config/opencode/opencode.json" is byte-identical to before
+    And nothing was written under "~/.config/opencode"

--- a/features/operator/detection.feature
+++ b/features/operator/detection.feature
@@ -1,0 +1,135 @@
+# GUEST OPERATORS — Phase 2: agent-CLI detection (THE DESK roster source).
+#
+# A static REGISTRY of guest operators (design doc §4 empirical table) is the ONE source of
+# who can ever appear at the desk. MVP set: opencode, hermes, aider. claude and codex are
+# EXCLUDED in v1 (Anthropic /v1/messages + Responses-API wire; naive launch silently falls
+# back to the user's REAL Anthropic account — the exact failure §4 measured). Detection is a
+# pure function over an injectable Env seam (the internal/audio/audio.go:35 Env pattern:
+# LookPath + a bounded version Probe), so every PATH/version permutation is table-testable
+# with no real binary and the TUI can deliver results async like onSharesDetected
+# (tui.go:2341).
+#
+# GROUND TRUTH (empirical, dev box 2026-07-06):
+#   - `opencode --version`  -> "1.17.11"                                  (bare semver)
+#   - `hermes --version`    -> "Hermes Agent v0.16.0 (2026.6.5) · upstream 9688c1a9"
+#   - `aider --version`     -> "aider X.Y.Z" (not installed on the dev box; format per docs)
+#   - exec.LookPath already rejects a file on PATH without the execute bit (ErrNotFound),
+#     so "exists but not executable" is NOT detected — pinned here as a permanent scenario.
+#
+# Version policy (§8 "version skew"): a failed/garbled/below-floor version probe NEVER hides
+# a guest — it marks the detection UNVERIFIED so the picker can degrade gracefully (warn +
+# fall back to the /connect snippet) instead of lying that the desk is empty.
+#
+# Placement (minimization rung): new pure package internal/operator — registry + detection +
+# config materialization have zero bubbletea dependencies; internal/tui keeps only the
+# command/picker/exec glue. Mirrors the internal/audio precedent.
+
+Feature: Guest operator detection registry
+  The desk roster is derived from a static registry of known guest operators,
+  detected via an injectable LookPath seam and an optional bounded version probe,
+  so the TUI only ever offers a handoff to a CLI that is really on this machine.
+
+  Background:
+    Given the guest operator registry
+
+  Scenario: The MVP registry is exactly opencode, hermes, aider — claude and codex excluded
+    Then the registry lists exactly "opencode", "hermes", "aider" in that order
+    And no registry entry is named "claude" or "codex"
+    And every entry carries a name, a PATH binary, a provider tag, an install hint, and a known-good version
+
+  Scenario: Registry entries carry the empirically-proven wiring strategy
+    Then the "opencode" entry uses the scratch-config strategy with known-good version "1.17.11"
+    And the "hermes" entry uses the scratch-home strategy with known-good version "0.16.0"
+    And the "aider" entry uses the env-and-flags strategy with no config file at all
+
+  Scenario: All three guests on PATH are detected in registry order
+    Given LookPath resolves "opencode" to "/home/u/.opencode/bin/opencode"
+    And LookPath resolves "hermes" to "/home/u/.local/bin/hermes"
+    And LookPath resolves "aider" to "/home/u/.local/bin/aider"
+    When the desk is scanned
+    Then the detections are "opencode", "hermes", "aider" in that order
+    And each detection records the resolved path
+
+  Scenario: A guest missing from PATH is simply absent — never an error
+    Given LookPath resolves "opencode" to "/home/u/.opencode/bin/opencode"
+    And LookPath fails for "hermes" with "executable file not found in $PATH"
+    And LookPath fails for "aider" with "executable file not found in $PATH"
+    When the desk is scanned
+    Then the detections are exactly "opencode"
+
+  Scenario: An empty PATH detects nothing and the scan still succeeds
+    Given LookPath fails for every binary
+    When the desk is scanned
+    Then the detections are empty
+    And no error is surfaced
+
+  Scenario: A file on PATH without the execute bit is NOT at the desk
+    # exec.LookPath excludes non-executable files; the seam preserves that contract.
+    Given LookPath fails for "opencode" with "permission denied"
+    When the desk is scanned
+    Then the detections do not include "opencode"
+
+  Scenario: The version probe pins the proven versions
+    Given LookPath resolves every registry binary
+    And the version probe answers "opencode" with "1.17.11"
+    And the version probe answers "hermes" with "Hermes Agent v0.16.0 (2026.6.5) · upstream 9688c1a9"
+    When the desk is scanned
+    Then the "opencode" detection has version "1.17.11" and is verified
+    And the "hermes" detection has version "0.16.0" and is verified
+
+  Scenario Outline: Version strings parse across the real formats
+    When the raw version output "<raw>" for "<guest>" is parsed
+    Then the parsed version is "<version>"
+
+    Examples:
+      | guest    | raw                                                    | version |
+      | opencode | 1.17.11                                                | 1.17.11 |
+      | opencode | 1.17.11\n                                              | 1.17.11 |
+      | hermes   | Hermes Agent v0.16.0 (2026.6.5) · upstream 9688c1a9    | 0.16.0  |
+      | aider    | aider 0.86.1                                           | 0.86.1  |
+
+  Scenario: A failed version probe degrades to UNVERIFIED, never to hidden
+    Given LookPath resolves "opencode" to "/home/u/.opencode/bin/opencode"
+    And the version probe fails for "opencode" with "exit status 1"
+    When the desk is scanned
+    Then the detections include "opencode"
+    And the "opencode" detection is unverified with an empty version
+
+  Scenario: Garbage version output degrades to UNVERIFIED, never to hidden
+    Given LookPath resolves "hermes" to "/home/u/.local/bin/hermes"
+    And the version probe answers "hermes" with "Traceback (most recent call last): ..."
+    When the desk is scanned
+    Then the detections include "hermes"
+    And the "hermes" detection is unverified
+
+  Scenario: A version below the known-good floor is detected but flagged unverified
+    # §8 version skew: degrade gracefully to the /connect snippet, don't refuse outright.
+    Given LookPath resolves "opencode" to "/usr/bin/opencode"
+    And the version probe answers "opencode" with "0.9.0"
+    When the desk is scanned
+    Then the "opencode" detection is unverified with version "0.9.0"
+
+  Scenario: A wedged version probe cannot hang the scan
+    # The Probe seam is BOUNDED (the audio.PlayTimeout discipline): a hung `--version`
+    # returns an error at the deadline and the guest degrades to unverified.
+    Given LookPath resolves "hermes" to "/home/u/.local/bin/hermes"
+    And the version probe for "hermes" blocks past its deadline
+    When the desk is scanned
+    Then the scan completes
+    And the "hermes" detection is unverified
+
+  Scenario: Re-scan reflects a changed PATH — detection holds no cached state
+    Given LookPath fails for every binary
+    When the desk is scanned
+    Then the detections are empty
+    When LookPath resolves "aider" to "/home/u/.local/bin/aider"
+    And the desk is scanned again
+    Then the detections are exactly "aider"
+
+  Scenario: Detection never launches, writes, or bills anything
+    # Scanning the desk is read-only: LookPath + `--version` only. No config is generated,
+    # no scratch dir is created, no proxy call is made, no budget is touched.
+    Given LookPath resolves every registry binary
+    When the desk is scanned
+    Then no file was written anywhere
+    And no request hit the local proxy

--- a/features/operator/handoff_lifecycle.feature
+++ b/features/operator/handoff_lifecycle.feature
@@ -1,0 +1,193 @@
+# GUEST OPERATORS — Phase 2: the tea.ExecProcess handoff lifecycle (money-adjacent).
+#
+# The handoff is suspend-and-exec (§2: "whenever the TUI is painting, the DJ has the mic" —
+# there is no persistent mode to track). Mechanics specced here; THE DESK view, capability
+# gating, and the pre-launch plate are Phase 3.
+#
+# GROUND TRUTH seams:
+#   - preconditions read the LIVE ProxyOptionsHolder (client.go:454): Connected() must be
+#     true — Phase 1 ruling 5 already makes a disconnected proxy REFUSE to spend
+#     (features/proxy/live_options.feature "disconnected proxy refuses"), so launching
+#     while not tuned would only hand the guest a wall of 502s; block it at the desk.
+#   - must not be mid-agent-turn: m.agentBusy || m.agent.running (the dequeue guard,
+#     agent.go:561) — the DJ's in-flight turn owns the completer and the terminal.
+#   - PATCHING YOU THROUGH is staged like connectingView (connectStep, tui.go:4590-4676):
+#     ONE staged paint (mic to / on band / wire lines, §3 mockup) is rendered BEFORE the
+#     tea.ExecProcess cmd is returned, so the exec never cuts from a stale screen to a
+#     foreign TUI ("anti-blank").
+#   - budget: SetBudget(client.DefaultSessionBudget) ($2.00, client.go:411, founder ruling
+#     2026-07-06) + ResetSpend() + a reset call counter, applied per handoff so the summary
+#     and the 402 ceiling are THIS guest's numbers, never a previous session's.
+#   - session key: STABLE for the whole TUI session (SetBand keeps it, client.go:488);
+#     handoffs rotate budgets and spend, never the bearer.
+#   - return: bubbletea delivers the ExecProcess callback for every child outcome; the
+#     callback restores the terminal, refreshes the balance, prints the one-line summary,
+#     and cleans the scratch config.
+#   - exit-code semantics: 0 clean; 130 (SIGINT) and any *exec.ExitError = "the guest
+#     dropped off (exit N)" — a guest quitting is NORMAL radio traffic, never a scary
+#     red stack; only a SPAWN failure (exec never started) is an error note.
+#
+# Terminal restore (defensive preamble, empirically needed — a guest TUI can leave any
+# combination of modes on): pop the kitty keyboard protocol, disable all mouse reporting
+# modes, exit bracketed paste — THEN re-enable what the radio itself uses: mouse cell
+# motion only when the user has it on (respect m.mouseOff, tui.go:646/1740-1746).
+
+Feature: Handing the mic — suspend, exec, and the return to the desk
+  A handoff only starts when the channel can actually carry it, shows one staged
+  PATCHING YOU THROUGH paint, runs the guest on the live band with a fresh $2
+  budget, and always returns to a working desk with an honest one-line summary.
+
+  Background:
+    Given an AGENT session with a tuned band "qwen3-32b-fp8" and a live proxy holder
+    And a detected guest "opencode"
+
+  # ── preconditions ────────────────────────────────────────────────────────────────
+
+  Scenario: No band tuned — the handoff is refused with the tune-in note
+    Given the proxy holder is disconnected
+    When the user runs "/operator opencode"
+    Then no child process is launched
+    And the transcript notes "no channel to patch into"
+    And the transcript points at tuning in first
+
+  Scenario: Mid-agent-turn — the handoff is refused while the DJ is talking
+    Given a DJ turn is in flight
+    When the user runs "/operator opencode"
+    Then no child process is launched
+    And the transcript notes the DJ is mid-turn
+
+  Scenario: A queued prompt also blocks the handoff
+    # agentQueued drains into a new turn the moment the current one ends (agent.go:558);
+    # execing between them would orphan the queue into a suspended TUI.
+    Given a DJ turn is in flight and a prompt is queued
+    When the user runs "/operator opencode"
+    Then no child process is launched
+
+  # ── the staged transition ────────────────────────────────────────────────────────
+
+  Scenario: One staged PATCHING YOU THROUGH paint precedes the exec
+    When the user runs "/operator opencode"
+    Then the next paint shows "PATCHING YOU THROUGH"
+    And it shows the mic-to line for "opencode"
+    And it shows the on-band line for "qwen3-32b-fp8"
+    And it shows the wire line "config generated in a scratch dir"
+    And only after that paint is the exec command issued
+
+  Scenario: The staged paint shows the real endpoint and model
+    When the user runs "/operator opencode"
+    Then the staged paint shows the live proxy BASE URL
+    And the staged paint shows MODEL "qwen3-32b-fp8"
+
+  # ── the live wiring at exec time ─────────────────────────────────────────────────
+
+  Scenario: The child is composed from the LIVE proxy options at exec time
+    Given the band was re-tuned since the proxy first bound
+    When the user runs "/operator opencode"
+    Then the child wiring carries the CURRENT band model and endpoint
+    And never the options frozen at first bind
+
+  Scenario: Each handoff starts with the default $2 budget and zero spend
+    Given the previous session spent "$1.37" of its budget
+    When the user runs "/operator opencode"
+    Then the holder budget is the default session budget
+    And the holder spend reads $0.00
+    And the holder call counter reads 0
+
+  Scenario: The session bearer key is stable across the handoff
+    When the user runs "/operator opencode"
+    Then the child env carries the SAME session key the proxy enforces
+    And the key was not rotated by the handoff
+
+  # ── the return to the desk ───────────────────────────────────────────────────────
+
+  Scenario: Clean exit — terminal restored, balance refreshed, one-line summary
+    When the guest returns after 14 minutes, 42 calls, and $0.19 spend with exit 0
+    Then the terminal reset preamble ran: kitty keyboard popped, mouse modes off, bracketed paste exited
+    And mouse cell motion is re-enabled because the user has the mouse on
+    And a balance refresh is requested
+    And the transcript shows "back at the desk · opencode had the mic for 14m · 42 calls · $0.19"
+
+  Scenario: The summary numbers come from the proxy accumulator, not the child
+    # The child's own claims are untrusted; duration is measured by the TUI, calls and
+    # spend are read from the holder the proxy billed through.
+    When the guest returns with exit 0
+    Then the summary calls figure equals the holder call counter
+    And the summary spend figure equals the holder Spent()
+
+  Scenario: The user had the mouse off — the return respects m.mouseOff
+    Given the user disabled the mouse before the handoff
+    When the guest returns with exit 0
+    Then the defensive reset still disabled the guest's mouse modes
+    And mouse reporting is NOT re-enabled
+
+  Scenario: Exit 130 is a clean close, not an error
+    When the guest returns with exit 130
+    Then the transcript shows "the guest dropped off (exit 130) - back at the desk"
+    And the note is calm, with no error styling escalation beyond the house red ✕
+    And the terminal restore and summary still run
+
+  Scenario: A non-zero guest exit is a drop-off, same restore path
+    When the guest returns with exit 1
+    Then the transcript shows "the guest dropped off (exit 1) - back at the desk"
+    And the terminal reset preamble ran
+    And the scratch config was cleaned up
+
+  Scenario: A guest that crashed (killed by signal) still restores the desk
+    When the guest is killed mid-session
+    Then the terminal reset preamble ran
+    And the summary line still renders with the accumulated calls and spend
+    And the scratch config was cleaned up
+
+  Scenario: A spawn failure never leaves the TUI suspended
+    Given the guest binary vanishes between detection and exec
+    When the user runs "/operator opencode"
+    Then the TUI is painting again
+    And the transcript shows an error note naming the launch failure
+    And no scratch dir remains
+
+  Scenario: The scratch config is cleaned up on every return path
+    When the guest returns with any exit
+    Then no rogerai-operator scratch dir remains for this session
+
+  # ── money mid-session ────────────────────────────────────────────────────────────
+
+  Scenario: Budget reached mid-session — clean 402s inside, honest summary outside
+    # The proxy side is Phase 1 (features/proxy/budget.feature: OpenAI-shaped 402 at the
+    # ceiling). Phase 2 owns the RETURN: the summary must say the budget was reached so
+    # "the guest went quiet" is never a mystery.
+    Given the guest spends up to the session budget during the handoff
+    When the guest returns
+    Then the summary notes the session budget was reached
+    And the summary spend figure is at or just past the default session budget
+
+  Scenario: Band goes off-air mid-handoff — the guest saw 502s, the summary stays honest
+    # Phase 1 already shapes relay failures as OpenAI JSON errors. The return summary
+    # reports the spend that actually settled; it does not invent an error state.
+    Given the band goes off-air while the guest has the mic
+    When the guest returns with exit 1
+    Then the summary shows the spend accumulated before the drop
+    And the desk is fully usable for a re-tune
+
+  # ── sequencing ───────────────────────────────────────────────────────────────────
+
+  Scenario: Re-tune during a handoff is impossible by construction
+    # tea.ExecProcess suspends the whole event loop: no key reaches the TUI while the
+    # guest has the terminal, so there is no code path that could re-tune mid-handoff.
+    # Pinned so nobody adds a background re-tune that breaks the assumption.
+    When the guest has the mic
+    Then no TUI key handling runs until the exec callback returns
+
+  Scenario: Two rapid handoffs are independent sessions
+    When the guest returns after spending "$0.50"
+    And the user immediately runs "/operator opencode" again
+    Then the second handoff gets a fresh scratch dir
+    And the holder spend reads $0.00 again
+    And the holder call counter reads 0 again
+    And the session key is unchanged
+
+  Scenario: A second handoff to a different guest reuses nothing from the first
+    Given a detected guest "aider" as well
+    When the guest "opencode" returns
+    And the user runs "/operator aider"
+    Then the aider wiring carries no opencode artifacts
+    And the first session's scratch dir is already gone

--- a/features/operator/operator_command.feature
+++ b/features/operator/operator_command.feature
@@ -1,0 +1,147 @@
+# GUEST OPERATORS — Phase 2: the /operator command + picker (THE DESK entry points).
+#
+# /operator joins the ONE canonical agentCommands registry (internal/tui/agent.go:585) so
+# the slash-strip, /commands, and TestAgentCommandRegistrySeam (agent_slash_complete_test.go
+# :264 — sorted, lowercase, every entry dispatches) pick it up for free. Aliases /mic /guest
+# /op follow the /dj /y pattern (agent.go:583): typable, dispatched by runAgentCommand,
+# NEVER suggested by the strip and NEVER in the registry.
+#
+# The picker mirrors the /model modal exactly (open state owns every key — agent.go:307-334;
+# render — agent.go:1101-1116; footer case — tui.go:7797-7801): cursor rows, enter picks,
+# esc keeps the DJ. §3 rules: bare /operator only opens with >=1 DETECTED guest (zero
+# guests = a transcript note, never a one-row picker); rows are detected guests plus AT
+# MOST ONE dim not-installed suggestion at the bottom that the cursor SKIPS;
+# installed-but-not-configured rows are selectable but print a setup note instead of
+# execing (reserved in v1 for the future claude row — every MVP guest is config-generated,
+# so none of the three can be "not configured"); the DJ row keeps the current session.
+#
+# Phase boundary: THIS file specs command dispatch + picker state. What happens after a
+# valid pick (preconditions, staging, exec) is handoff_lifecycle.feature. THE DESK roster
+# VIEW and the desk strip are Phase 3 — not specced here.
+
+Feature: The /operator command and the hand-the-mic picker
+  /operator is a first-class AGENT command with the house registry guarantees,
+  and its picker only ever offers a handoff that can actually happen.
+
+  Background:
+    Given an AGENT session at the ask prompt
+
+  Scenario: /operator is in the canonical command registry
+    Then the agent command registry contains "/operator"
+    And the registry stays sorted, lowercase, and duplicate-free
+
+  Scenario: /operator dispatches — never "unknown:"
+    When the user runs "/operator"
+    Then the transcript does not show "unknown: /operator"
+
+  Scenario Outline: The aliases dispatch but are never suggested
+    When the user runs "<alias>"
+    Then the transcript does not show "unknown: <alias>"
+    And the agent command registry does not contain "<alias>"
+
+    Examples:
+      | alias  |
+      | /mic   |
+      | /guest |
+      | /op    |
+
+  Scenario: The slash strip suggests /operator, not the aliases
+    When the user has typed "/o"
+    Then the suggestion strip includes "/operator"
+    And the suggestion strip never includes "/mic" or "/guest"
+
+  Scenario: Bare /operator with zero guests detected prints the desk note, no picker
+    Given no guest operators are detected
+    When the user runs "/operator"
+    Then no picker opens
+    And the transcript notes "no guests at the desk"
+
+  Scenario: Bare /operator with guests detected opens the picker
+    Given detected guests "opencode" and "aider"
+    When the user runs "/operator"
+    Then the operator picker is open
+    And the picker rows are "DJ", "opencode", "aider"
+
+  Scenario: At most ONE not-installed suggestion row, dim, at the bottom
+    Given detected guests "opencode"
+    And undetected registry guests "hermes" and "aider"
+    When the user runs "/operator"
+    Then the picker rows are "DJ", "opencode" and one suggestion row
+    And the suggestion row shows an install hint
+
+  Scenario: The cursor skips the not-installed suggestion row
+    Given detected guests "opencode"
+    And an undetected registry guest "hermes"
+    When the user runs "/operator"
+    And the user presses down past the last selectable row
+    Then the cursor stays on "opencode"
+    And the cursor is never on the suggestion row
+
+  Scenario: Enter on a detected, configured guest starts the handoff path
+    Given detected guests "opencode"
+    When the user runs "/operator"
+    And the user picks "opencode"
+    Then the picker closes
+    And the handoff to "opencode" begins
+
+  Scenario: Enter on an installed-but-not-configured guest prints the setup note, no exec
+    Given a detected guest "claudeish" that requires setup
+    When the user runs "/operator"
+    And the user picks "claudeish"
+    Then the picker closes
+    And the transcript shows the setup note for "claudeish"
+    And no child process is launched
+
+  Scenario: Picking the DJ keeps the current session
+    Given detected guests "opencode"
+    When the user runs "/operator"
+    And the user picks "DJ"
+    Then the picker closes
+    And the transcript notes the DJ keeps the mic
+    And no child process is launched
+
+  Scenario: Esc keeps the DJ
+    Given detected guests "opencode"
+    When the user runs "/operator"
+    And the user presses esc
+    Then the picker closes
+    And no child process is launched
+
+  Scenario: The open picker owns every key
+    # Mirrors the /model modal contract (agent.go:307-334): digits, presets, left/right
+    # are swallowed, never stolen by presetForKey or the prompt.
+    Given detected guests "opencode"
+    When the user runs "/operator"
+    And the user presses "1"
+    Then the picker is still open
+    And the TUI did not switch modes
+
+  Scenario: r re-scans the desk from inside the picker
+    Given detected guests "opencode"
+    When the user runs "/operator"
+    And "aider" appears on PATH
+    And the user presses "r"
+    Then the picker rows include "aider"
+
+  Scenario: /operator <name> direct-jumps to a detected guest
+    Given detected guests "opencode" and "aider"
+    When the user runs "/operator aider"
+    Then no picker opens
+    And the handoff to "aider" begins
+
+  Scenario: /operator <name> for a registry guest not on PATH prints its install hint
+    Given no guest operators are detected
+    When the user runs "/operator hermes"
+    Then no picker opens
+    And the transcript shows the install hint for "hermes"
+
+  Scenario: /operator <name> for an unknown name is a note, never a turn
+    When the user runs "/operator warez9000"
+    Then no picker opens
+    And no chat turn is submitted
+    And the transcript notes the name is not a known operator
+
+  Scenario: /operator name matching is case-insensitive
+    Given detected guests "opencode"
+    When the user runs "/operator OpenCode"
+    Then the handoff to "opencode" begins

--- a/features/operator/rc_interlock.feature
+++ b/features/operator/rc_interlock.feature
@@ -1,0 +1,114 @@
+# GUEST OPERATORS — Phase 2: the remote-control interlock (iOS parity review, REQUIRED).
+#
+# THE HAZARD: tea.ExecProcess suspends the TUI event loop, but the RCBridge poll loop
+# (internal/client/rc.go:329) keeps pumping inbound messages into the program's channel.
+# Without an interlock, a viewer's turns during a handoff (a) go silently deaf, then
+# (b) REPLAY AS A BURST into the DJ the moment the exec callback lands — remote turns the
+# sender believes were dropped suddenly fire minutes later. Both are unacceptable on a
+# money path (a replayed turn bills).
+#
+# THE CHOSEN BEHAVIOR (recommended: PARK + DROP with a status frame; founder confirm
+# requested — the alternative "queue and replay on return" is explicitly rejected as the
+# blind-replay hazard):
+#   - the interlock lives at the BRIDGE level (the bridge goroutines run through the
+#     suspend; the TUI's Update loop does not): parked BEFORE the exec cmd is issued,
+#     unparked in the return callback
+#   - while parked: inbound "turn" messages are DROPPED at the bridge and answered with a
+#     status frame ("guest has the mic") so the sender knows immediately; nothing is
+#     queued, nothing replays on return
+#   - while parked: inbound "confirm" answers are dropped (no DJ confirm can be pending —
+#     the DJ loop is idle by the handoff preconditions)
+#   - while parked: backfill requests are still answered (transcript snapshot + a status
+#     frame) so a viewer attaching mid-handoff sees a live, honest session, not a blank
+#     stream
+#   - handoff start and end each emit ONE status frame (kind "status") carrying operator
+#     metadata, additively — existing viewers render or ignore it (unknown fields are
+#     ignored by the wire contract)
+#
+# RESERVED NAMES (constants documented in internal/protocol/rc.go, NO behavior in v1):
+#   frame kind    "operator_status"   — future dedicated operator-state frame
+#   inbound kind  "operator_handoff"  — future remote-initiated handoff
+#   inbound kind  "operator_recall"   — future remote "give the DJ the mic back"
+# Reserving the strings NOW keeps old hosts and new surfaces from colliding on the names
+# later (persistent-state lesson: additive, idempotent wire evolution).
+
+Feature: While a guest has the mic, remote control parks — never deaf, never a replay burst
+  A live BASE STATION session stays honest through a handoff: viewers are told the
+  guest has the mic, their turns are parked-and-dropped with a status frame instead
+  of vanishing or replaying, and the desk announces the handoff start and end.
+
+  Background:
+    Given a HOST agent session with an attached remote-control bridge
+    And a tuned band and a detected guest "opencode"
+
+  Scenario: Handoff start emits a status frame with operator metadata
+    When the handoff to "opencode" begins
+    Then a frame of kind "status" is emitted before the exec
+    And the frame names the operator "opencode"
+
+  Scenario: The bridge is parked before the exec command is issued
+    When the handoff to "opencode" begins
+    Then the bridge is parked
+    And parking happened before the exec command was returned
+
+  Scenario: A remote turn during the handoff is dropped with a status frame
+    Given the guest has the mic
+    When a viewer sends a turn "refactor the parser"
+    Then the turn is not queued for the DJ
+    And the viewers receive a status frame saying the guest has the mic
+    And no agent turn ever fires for "refactor the parser"
+
+  Scenario: Parked turns do NOT burst-replay when the guest returns
+    Given the guest has the mic
+    And viewers sent 3 turns during the handoff
+    When the guest returns and the bridge unparks
+    Then no queued turn fires
+    And the DJ receives zero injected turns from the parked window
+
+  Scenario: A remote confirm answer during the handoff is dropped
+    # No DJ confirm can be pending (handoff preconditions), so any confirm arriving
+    # parked is stale by definition — dropping it mirrors the stale-confirm guard
+    # (internal/tui/rc.go:191).
+    Given the guest has the mic
+    When a viewer sends a confirm approval
+    Then it is dropped
+    And no tool runs
+
+  Scenario: A viewer attaching mid-handoff gets a status frame, not a blank stream
+    Given the guest has the mic
+    When a new viewer attaches and requests backfill
+    Then the viewer receives the transcript snapshot
+    And the viewer receives a status frame saying the guest has the mic
+
+  Scenario: Handoff end emits a status frame and normal service resumes
+    Given the guest has the mic
+    When the guest returns and the bridge unparks
+    Then a frame of kind "status" is emitted announcing the DJ is back
+    And a subsequent viewer turn injects into the DJ exactly like local typing
+
+  Scenario: Handoff with NO bridge attached emits nothing and parks nothing
+    Given the remote-control bridge is not enabled
+    When the handoff to "opencode" begins
+    Then no frame is emitted
+    And the handoff proceeds normally
+
+  Scenario: The bridge ending mid-handoff leaves the return path safe
+    # A revoke-all can 401 the poll while the guest has the mic (onRemoteHostEnd,
+    # internal/tui/rc.go:155). Unparking a dead bridge must be a no-op, not a panic.
+    Given the guest has the mic
+    And the remote session is revoked during the handoff
+    When the guest returns
+    Then the unpark is a no-op
+    And the desk summary still renders
+
+  Scenario: The reserved operator wire names are pinned constants
+    Then the protocol reserves frame kind "operator_status"
+    And the protocol reserves inbound kind "operator_handoff"
+    And the protocol reserves inbound kind "operator_recall"
+    And v1 attaches no behavior to any of them
+
+  Scenario: Frames emitted around the handoff are content-blind about the guest's work
+    # The guest's terminal I/O NEVER tees to viewers (the broker relay stays content-blind
+    # and the guest session is not the DJ loop). Only the status transitions are visible.
+    When the handoff to "opencode" begins and the guest works for a while
+    Then no frame carries any guest terminal output

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rogerai-fyi/roger/internal/glyphs"
@@ -459,6 +460,11 @@ type ProxyOptionsHolder struct {
 
 	budgetMu sync.Mutex
 	spent    float64
+
+	// calls counts completion requests dispatched to the relay this session (Guest
+	// Operators ruling 4, additive): the honest source for the return summary's
+	// "N calls" figure - the child's own claims are never trusted.
+	calls atomic.Int64
 }
 
 // NewProxyOptionsHolder wraps a fixed ProxyOptions as a live source (starts connected).
@@ -512,6 +518,12 @@ func (h *ProxyOptionsHolder) ResetSpend() {
 	h.spent = 0
 	h.budgetMu.Unlock()
 }
+
+// Calls returns how many completion requests this session dispatched to the relay.
+func (h *ProxyOptionsHolder) Calls() int64 { return h.calls.Load() }
+
+// ResetCalls zeroes the session call counter (a fresh guest-operator handoff).
+func (h *ProxyOptionsHolder) ResetCalls() { h.calls.Store(0) }
 
 // Spent returns the accumulated session spend in dollars.
 func (h *ProxyOptionsHolder) Spent() float64 {
@@ -713,6 +725,10 @@ func ProxyHandlerLive(h *ProxyOptionsHolder) http.Handler {
 			defer release(0)
 			onServed = release
 		}
+		// Count the dispatched call (ruling 4): admitted requests only, so the summary's
+		// "N calls" matches what actually reached the relay - a 401/402/400 refusal is not
+		// a call the guest made on the band.
+		h.calls.Add(1)
 		// h.addSpend as onStreamCost: a streamed response carries no cost header - its billed
 		// cost arrives as the `: rogerai-cost=` SSE comment at stream END, accumulated after
 		// the budget slot was already released (the ceiling's crossing stream completes; the

--- a/internal/client/rc.go
+++ b/internal/client/rc.go
@@ -72,15 +72,7 @@ func EnableRC(broker, name string) (*RCBridge, RCEnableResult, error) {
 	if err := json.Unmarshal(raw, &res); err != nil {
 		return nil, RCEnableResult{}, err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	rb := &RCBridge{
-		broker: broker, sessionID: res.SessionID, hostToken: res.HostToken,
-		out:     make(chan protocol.RCFrame, 256),
-		inbound: make(chan protocol.RCInbound, 64),
-		stop:    make(chan struct{}),
-		ctx:     ctx, cancel: cancel,
-	}
-	return rb, res, nil
+	return NewRCBridge(broker, res.SessionID, res.HostToken), res, nil
 }
 
 // ListRC fetches the owner's remote-control roster (signed).
@@ -274,6 +266,104 @@ type RCBridge struct {
 	cancel                       context.CancelFunc
 	stopOnce                     sync.Once
 	stopped                      atomic.Bool
+
+	// The guest-operator PARK interlock (Guest Operators Phase 2, rc_interlock.feature).
+	// tea.ExecProcess suspends the TUI event loop but THESE goroutines keep pumping, so
+	// the interlock lives here: while parked, inbound turns/confirms are DROPPED at the
+	// bridge (a status auto-frame tells the sender the guest has the mic) and backfill is
+	// answered from the park-time transcript snapshot. NOTHING is queued - a parked turn
+	// must never burst-replay into the DJ on return (a replayed turn bills).
+	parkMu       sync.Mutex
+	parkOperator string // "" = not parked; otherwise the guest at the desk
+	parkSnapshot string // the transcript snapshot backfill is answered with while parked
+}
+
+// NewRCBridge builds a host bridge over an already-enabled session (its id + one-time
+// HOST TOKEN). EnableRC wraps this after /rc/enable; it is exported so any host surface
+// holding a token can run the same bridge. The caller starts it with Run().
+func NewRCBridge(broker, sessionID, hostToken string) *RCBridge {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &RCBridge{
+		broker: broker, sessionID: sessionID, hostToken: hostToken,
+		out:     make(chan protocol.RCFrame, 256),
+		inbound: make(chan protocol.RCInbound, 64),
+		stop:    make(chan struct{}),
+		ctx:     ctx, cancel: cancel,
+	}
+}
+
+// Park engages the guest-operator interlock: called by the host BEFORE the exec command
+// is issued. operator names the guest for the status auto-frames; snapshot is the
+// transcript a mid-handoff backfill is answered with (the host cannot serve it itself -
+// its event loop is suspended). Nil-safe.
+func (rb *RCBridge) Park(operator, snapshot string) {
+	if rb == nil {
+		return
+	}
+	rb.parkMu.Lock()
+	rb.parkOperator, rb.parkSnapshot = operator, snapshot
+	rb.parkMu.Unlock()
+}
+
+// Unpark releases the interlock in the exec return callback. Nothing parked replays -
+// dropped inbound is gone for good (the sender was told immediately). A no-op on an
+// unparked, stopped, or nil bridge (a revoke-all can kill the bridge mid-handoff).
+func (rb *RCBridge) Unpark() {
+	if rb == nil {
+		return
+	}
+	rb.parkMu.Lock()
+	rb.parkOperator, rb.parkSnapshot = "", ""
+	rb.parkMu.Unlock()
+}
+
+// Parked reports whether the guest-operator interlock is engaged (and for whom).
+func (rb *RCBridge) Parked() (operator string, parked bool) {
+	if rb == nil {
+		return "", false
+	}
+	rb.parkMu.Lock()
+	defer rb.parkMu.Unlock()
+	return rb.parkOperator, rb.parkOperator != ""
+}
+
+// parkIntercept handles one inbound while parked, AT THE BRIDGE (the TUI's Update loop is
+// suspended under tea.ExecProcess). Returns true when the inbound was consumed here:
+//   - turn:     DROPPED + a status auto-frame ("guest has the mic") so the sender knows
+//     immediately; never queued, never replayed on return.
+//   - confirm:  DROPPED silently - no DJ confirm can be pending (the handoff preconditions
+//     require an idle DJ loop), so any confirm arriving parked is stale by definition.
+//   - interrupt: DROPPED - there is no in-flight DJ turn to cancel.
+//   - backfill: answered with the park-time transcript snapshot + the status frame, so a
+//     viewer attaching mid-handoff sees a live, honest session, not a blank stream.
+func (rb *RCBridge) parkIntercept(in protocol.RCInbound) bool {
+	op, parked := rb.Parked()
+	if !parked {
+		return false
+	}
+	switch in.Kind {
+	case protocol.RCInBackfill:
+		rb.parkMu.Lock()
+		snap := rb.parkSnapshot
+		rb.parkMu.Unlock()
+		rb.Emit(protocol.RCFrame{Kind: protocol.RCKindBackfill, Viewer: in.Viewer, Text: snap})
+		rb.Emit(OperatorStatusFrame(op))
+	case protocol.RCInTurn:
+		rb.Emit(OperatorStatusFrame(op))
+	}
+	return true // confirm/interrupt (and anything else) drop silently while parked
+}
+
+// OperatorStatusFrame is the ONE constructor for the "guest has the mic" status frame:
+// plain RCKindStatus carrying the operator name additively (RCFrame.Operator) - old
+// viewers render or ignore it; the reserved operator_* kinds stay behavior-free in v1
+// (ruling 7). Exported so the TUI's handoff-start announcement and the bridge's parked
+// auto-frames can never drift apart.
+func OperatorStatusFrame(operator string) protocol.RCFrame {
+	return protocol.RCFrame{
+		Kind: protocol.RCKindStatus, Operator: operator,
+		Text: "guest has the mic: " + operator + " - the DJ answers when the handoff ends",
+	}
 }
 
 // SessionID reports the bridge's session id (for the roster / disable).
@@ -362,6 +452,11 @@ func (rb *RCBridge) pollLoop() {
 		resp.Body.Close()
 		var in protocol.RCInbound
 		if json.Unmarshal(raw, &in) == nil && in.Kind != "" {
+			// Guest-operator interlock: while parked, the inbound is consumed AT THE
+			// BRIDGE (dropped/answered) and never reaches the suspended host loop.
+			if rb.parkIntercept(in) {
+				continue
+			}
 			select {
 			case rb.inbound <- in:
 			case <-rb.stop:

--- a/internal/client/rc_park_test.go
+++ b/internal/client/rc_park_test.go
@@ -1,0 +1,194 @@
+package client
+
+// rc_park_test.go - unit tables for the Guest Operators Phase 2 client seams
+// (rc_interlock.feature at the bridge level + the ruling-4 call counter): the RCBridge
+// PARK interlock (turns dropped with a status auto-frame, confirms dropped silently,
+// backfill answered from the park-time snapshot, nothing ever queued) and the
+// ProxyOptionsHolder call counter accumulating through the REAL hardened handler over a
+// stub billing broker. Stdlib testing, real HTTP, no mocks.
+
+import (
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// TestBridgeParkStateMachine: Park engages, Unpark releases, both nil-safe (a revoke-all
+// can kill the bridge mid-handoff; the return path must never panic).
+func TestBridgeParkStateMachine(t *testing.T) {
+	rb := NewRCBridge("http://127.0.0.1:1", "s1", "tok")
+	if op, parked := rb.Parked(); parked || op != "" {
+		t.Fatalf("a fresh bridge must be unparked, got (%q, %v)", op, parked)
+	}
+	rb.Park("opencode", "transcript snapshot")
+	if op, parked := rb.Parked(); !parked || op != "opencode" {
+		t.Fatalf("Parked = (%q, %v), want (opencode, true)", op, parked)
+	}
+	rb.Unpark()
+	if _, parked := rb.Parked(); parked {
+		t.Fatalf("Unpark must release the interlock")
+	}
+	// Nil-safety: the exec return callback may race a dead/never-enabled bridge.
+	var nilRB *RCBridge
+	nilRB.Park("x", "y")
+	nilRB.Unpark()
+	if op, parked := nilRB.Parked(); parked || op != "" {
+		t.Fatalf("nil bridge Parked = (%q, %v), want unparked", op, parked)
+	}
+	// Unpark on a STOPPED bridge is a no-op, not a panic (rc_interlock.feature).
+	rb.Park("opencode", "snap")
+	rb.Stop()
+	rb.Unpark()
+}
+
+// drainOut pops every frame currently queued on the bridge's outbound channel.
+func drainOut(rb *RCBridge) []protocol.RCFrame {
+	var out []protocol.RCFrame
+	for {
+		select {
+		case f := <-rb.out:
+			out = append(out, f)
+		default:
+			return out
+		}
+	}
+}
+
+// TestParkIntercept is the bridge-level interlock table: what each inbound kind does
+// while parked, and that NOTHING is ever queued for the suspended host.
+func TestParkIntercept(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         protocol.RCInbound
+		wantFrames []string // frame kinds emitted by the intercept, in order
+	}{
+		{"turn is dropped with a status auto-frame",
+			protocol.RCInbound{Kind: protocol.RCInTurn, Text: "refactor the parser"},
+			[]string{protocol.RCKindStatus}},
+		{"confirm is dropped silently (stale by definition)",
+			protocol.RCInbound{Kind: protocol.RCInConfirm, Approve: true, ConfirmID: "c1"},
+			nil},
+		{"interrupt is dropped silently (no DJ turn in flight)",
+			protocol.RCInbound{Kind: protocol.RCInInterrupt},
+			nil},
+		{"backfill is answered with the snapshot + the status frame",
+			protocol.RCInbound{Kind: protocol.RCInBackfill, Viewer: "v2"},
+			[]string{protocol.RCKindBackfill, protocol.RCKindStatus}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rb := NewRCBridge("http://127.0.0.1:1", "s1", "tok")
+			rb.Park("opencode", "the transcript so far")
+			if !rb.parkIntercept(tc.in) {
+				t.Fatalf("a parked bridge must consume every inbound")
+			}
+			frames := drainOut(rb)
+			var kinds []string
+			for _, f := range frames {
+				kinds = append(kinds, f.Kind)
+			}
+			if strings.Join(kinds, ",") != strings.Join(tc.wantFrames, ",") {
+				t.Fatalf("frames = %v, want %v", kinds, tc.wantFrames)
+			}
+			for _, f := range frames {
+				switch f.Kind {
+				case protocol.RCKindStatus:
+					if f.Operator != "opencode" || !strings.Contains(f.Text, "guest has the mic") {
+						t.Fatalf("status frame must name the guest: %+v", f)
+					}
+				case protocol.RCKindBackfill:
+					if f.Viewer != "v2" || f.Text != "the transcript so far" {
+						t.Fatalf("backfill must answer the asking viewer from the snapshot: %+v", f)
+					}
+				}
+			}
+			// NOTHING reaches the host inbound channel while parked (never a replay).
+			select {
+			case in := <-rb.Inbound():
+				t.Fatalf("a parked inbound leaked to the host: %+v", in)
+			default:
+			}
+		})
+	}
+}
+
+// TestParkInterceptUnparked: with the interlock released, the intercept consumes nothing
+// - normal service resumes through the inbound channel.
+func TestParkInterceptUnparked(t *testing.T) {
+	rb := NewRCBridge("http://127.0.0.1:1", "s1", "tok")
+	if rb.parkIntercept(protocol.RCInbound{Kind: protocol.RCInTurn, Text: "hi"}) {
+		t.Fatalf("an unparked bridge must not intercept")
+	}
+	if frames := drainOut(rb); len(frames) != 0 {
+		t.Fatalf("no auto-frame when unparked, got %v", frames)
+	}
+}
+
+// TestHolderCallCounter: the counter increments once per DISPATCHED completion (through
+// the REAL handler over a stub billing broker); refusals (401/402) never count; ResetCalls
+// zeroes it per handoff (founder ruling 4 - the "N calls" summary source).
+func TestHolderCallCounter(t *testing.T) {
+	sandbox(t)
+	srv, brokerCalls := billingBroker(t, "0.50")
+	defer srv.Close()
+
+	h := NewProxyOptionsHolder(ProxyOptions{Broker: srv.URL, User: "u", Model: "m", SessionKey: "sk-k", Budget: 1.00})
+	handler := ProxyHandlerLive(h)
+	post := func(auth string) int {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{"model":"m"}`))
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if got := post(""); got != 401 {
+		t.Fatalf("unauthenticated: %d, want 401", got)
+	}
+	if h.Calls() != 0 {
+		t.Fatalf("a 401 refusal must not count as a call")
+	}
+	for i := 0; i < 2; i++ { // 2 × $0.50 reaches the $1 ceiling
+		if got := post("Bearer sk-k"); got != 200 {
+			t.Fatalf("call %d: %d, want 200", i+1, got)
+		}
+	}
+	if h.Calls() != 2 {
+		t.Fatalf("Calls = %d, want 2 dispatched", h.Calls())
+	}
+	if got := post("Bearer sk-k"); got != 402 {
+		t.Fatalf("over budget: %d, want 402", got)
+	}
+	if h.Calls() != 2 {
+		t.Fatalf("a 402 refusal must not count as a call (got %d)", h.Calls())
+	}
+	if n := atomic.LoadInt32(brokerCalls); n != 2 {
+		t.Fatalf("broker dispatches = %d, want 2 (counter mirrors real dispatch)", n)
+	}
+	h.ResetCalls()
+	if h.Calls() != 0 {
+		t.Fatalf("ResetCalls must zero the counter")
+	}
+}
+
+// TestEnableRCUsesNewRCBridge: EnableRC hands back a live bridge wired exactly like the
+// exported constructor (session id + buffered channels + a working stop path).
+func TestEnableRCUsesNewRCBridge(t *testing.T) {
+	rb := NewRCBridge("http://b", "sess-9", "tok")
+	if rb.SessionID() != "sess-9" {
+		t.Fatalf("SessionID = %q", rb.SessionID())
+	}
+	done := rb.Done()
+	rb.Stop()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("Stop must close Done")
+	}
+}

--- a/internal/operator/config_test.go
+++ b/internal/operator/config_test.go
@@ -1,0 +1,451 @@
+package operator
+
+// config_test.go — RED-phase spec tests for per-session throwaway config generation
+// (features/operator/config_opencode|hermes|aider|isolation.feature made executable).
+// NO production code exists yet — the package build failure is the RED evidence.
+// REAL dependencies: a real filesystem via t.TempDir(), byte-exact golden artifacts,
+// no mocks anywhere. Stdlib testing only (repo convention).
+//
+// Proposed API under test (implemented only after founder approval):
+//
+//	type Session struct{ BaseURL, SessionKey, Model, Workdir, ScratchRoot string }
+//	type Launch struct {
+//	    Argv []string // full child argv, argv[0] = the guest binary name
+//	    Env  []string // KEY=VAL additions over the inherited parent env
+//	    Dir  string   // the session scratch dir ("" when no file is generated)
+//	}
+//	func Materialize(g Guest, s Session) (Launch, func() error, error) // cleanup fn
+//	func SweepStale(scratchRoot string, olderThan time.Duration) int
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	tBase  = "http://127.0.0.1:44017/v1"
+	tKey   = "sk-test-0123"
+	tModel = "qwen3-32b-fp8"
+)
+
+func guest(t *testing.T, name string) Guest {
+	t.Helper()
+	for _, g := range Registry() {
+		if g.Name == name {
+			return g
+		}
+	}
+	t.Fatalf("guest %q not in registry", name)
+	return Guest{}
+}
+
+func session(t *testing.T) Session {
+	t.Helper()
+	return Session{BaseURL: tBase, SessionKey: tKey, Model: tModel,
+		Workdir: t.TempDir(), ScratchRoot: t.TempDir()}
+}
+
+// listFiles returns every regular file under root, relative paths, sorted.
+func listFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err == nil && info.Mode().IsRegular() {
+			rel, _ := filepath.Rel(root, p)
+			out = append(out, rel)
+		}
+		return nil
+	})
+	sort.Strings(out)
+	return out
+}
+
+// sameStringSet fails unless got and want hold the same elements (order-free).
+func sameStringSet(t *testing.T, what string, got, want []string) {
+	t.Helper()
+	g, w := append([]string(nil), got...), append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	if !reflect.DeepEqual(g, w) {
+		t.Fatalf("%s: want %v, got %v", what, want, got)
+	}
+}
+
+// ── opencode ──────────────────────────────────────────────────────────────────────────
+
+// goldenOpencode is the byte-exact artifact (config_opencode.feature): the §4-proven
+// custom provider on @ai-sdk/openai-compatible, key by {env:...} REFERENCE (verified
+// supported in the 1.17.11 binary) so the secret never touches disk.
+const goldenOpencode = `{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "roger": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "RogerAI",
+      "options": {
+        "baseURL": "http://127.0.0.1:44017/v1",
+        "apiKey": "{env:ROGER_SESSION_KEY}"
+      },
+      "models": {
+        "qwen3-32b-fp8": { "name": "qwen3-32b-fp8" }
+      }
+    }
+  },
+  "model": "roger/qwen3-32b-fp8"
+}
+`
+
+func TestMaterializeOpencode(t *testing.T) {
+	s := session(t)
+	l, cleanup, err := Materialize(guest(t, "opencode"), s)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+	}()
+
+	if got := listFiles(t, l.Dir); !reflect.DeepEqual(got, []string{"opencode.json"}) {
+		t.Fatalf("exactly one generated file, got %v", got)
+	}
+	b, err := os.ReadFile(filepath.Join(l.Dir, "opencode.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != goldenOpencode {
+		t.Fatalf("golden artifact mismatch:\n--- want ---\n%s\n--- got ---\n%s", goldenOpencode, b)
+	}
+
+	wantArgv := []string{"opencode", "-m", "roger/qwen3-32b-fp8"}
+	if !reflect.DeepEqual(l.Argv, wantArgv) {
+		t.Fatalf("argv must pin the model so no config layer (project opencode.json) can re-route the guest: want %v, got %v", wantArgv, l.Argv)
+	}
+	sameStringSet(t, "opencode env additions", l.Env, []string{
+		"OPENCODE_CONFIG=" + filepath.Join(l.Dir, "opencode.json"),
+		"ROGER_SESSION_KEY=" + tKey,
+	})
+	if !strings.HasPrefix(filepath.Base(l.Dir), "rogerai-operator-") {
+		t.Fatalf("scratch dir naming rogerai-operator-*, got %s", l.Dir)
+	}
+	if !strings.HasPrefix(l.Dir, s.ScratchRoot) {
+		t.Fatalf("scratch dir must live under the scratch root, got %s", l.Dir)
+	}
+}
+
+// ── hermes ────────────────────────────────────────────────────────────────────────────
+
+// goldenHermes: scratch HERMES_HOME config.yaml using the keyed providers schema — the
+// ONE hermes-0.16.0 path that delivers an api_key to a loopback base_url (model_switch.py
+// :900-931 expands ${ROGER_SESSION_KEY} from the env). A bare model_aliases entry would
+// resolve to "no-key-required" and 401 against the Phase 1 bearer proxy (the regression
+// pinned in TestHermesNeverBareModelAliases).
+const goldenHermes = `providers:
+  roger:
+    base_url: http://127.0.0.1:44017/v1
+    api_key: ${ROGER_SESSION_KEY}
+model:
+  provider: roger
+  default: qwen3-32b-fp8
+`
+
+func TestMaterializeHermes(t *testing.T) {
+	s := session(t)
+	l, cleanup, err := Materialize(guest(t, "hermes"), s)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+	}()
+
+	b, err := os.ReadFile(filepath.Join(l.Dir, "hermes-home", "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != goldenHermes {
+		t.Fatalf("golden artifact mismatch:\n--- want ---\n%s\n--- got ---\n%s", goldenHermes, b)
+	}
+
+	wantArgv := []string{"hermes", "-m", "roger/qwen3-32b-fp8"}
+	if !reflect.DeepEqual(l.Argv, wantArgv) {
+		t.Fatalf("argv: want %v, got %v", wantArgv, l.Argv)
+	}
+	sameStringSet(t, "hermes env additions", l.Env, []string{
+		"HERMES_HOME=" + filepath.Join(l.Dir, "hermes-home"),
+		"ROGER_SESSION_KEY=" + tKey,
+	})
+}
+
+func TestHermesNeverBareModelAliases(t *testing.T) {
+	s := session(t)
+	l, cleanup, err := Materialize(guest(t, "hermes"), s)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+	b, err := os.ReadFile(filepath.Join(l.Dir, "hermes-home", "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "providers:") || !strings.Contains(string(b), "api_key: ${ROGER_SESSION_KEY}") {
+		t.Fatalf("hermes wiring must be the keyed providers schema with the key by env reference (a bare model_aliases entry 401s against the Phase 1 bearer proxy):\n%s", b)
+	}
+}
+
+// ── aider ─────────────────────────────────────────────────────────────────────────────
+
+func TestMaterializeAider(t *testing.T) {
+	s := session(t)
+	l, cleanup, err := Materialize(guest(t, "aider"), s)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("cleanup must be a no-op success for aider: %v", err)
+		}
+	}()
+
+	wantArgv := []string{"aider",
+		"--model", "openai/qwen3-32b-fp8",
+		"--no-show-model-warnings",
+		"--no-auto-commits",
+	}
+	if !reflect.DeepEqual(l.Argv, wantArgv) {
+		t.Fatalf("§4 flag set verbatim (--no-auto-commits is a permanent safety pin): want %v, got %v", wantArgv, l.Argv)
+	}
+	sameStringSet(t, "aider env additions", l.Env, []string{
+		"OPENAI_API_BASE=" + tBase,
+		"OPENAI_API_KEY=" + tKey,
+	})
+	if l.Dir != "" {
+		t.Fatalf("aider generates NO file — no scratch dir at all (minimization), got %s", l.Dir)
+	}
+	if got := listFiles(t, s.ScratchRoot); len(got) != 0 {
+		t.Fatalf("nothing written anywhere for aider, got %v", got)
+	}
+}
+
+// ── cross-guest isolation invariants ─────────────────────────────────────────────────
+
+// TestNeverWriteOutsideScratch: every byte lands under the session scratch dir; the
+// user's workdir (including a project opencode.json) stays byte-identical
+// (config_isolation.feature).
+func TestNeverWriteOutsideScratch(t *testing.T) {
+	for _, name := range []string{"opencode", "hermes", "aider"} {
+		t.Run(name, func(t *testing.T) {
+			s := session(t)
+			project := filepath.Join(s.Workdir, "opencode.json")
+			sentinel := []byte(`{"model":"anthropic/claude-opus-4"}`)
+			if err := os.WriteFile(project, sentinel, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			before := listFiles(t, s.Workdir)
+
+			l, cleanup, err := Materialize(guest(t, name), s)
+			if err != nil {
+				t.Fatalf("materialize: %v", err)
+			}
+			defer func() { _ = cleanup() }()
+
+			if after := listFiles(t, s.Workdir); !reflect.DeepEqual(before, after) {
+				t.Fatalf("the user's workdir must be untouched: before %v, after %v", before, after)
+			}
+			if b, _ := os.ReadFile(project); !reflect.DeepEqual(b, sentinel) {
+				t.Fatalf("the user's project opencode.json was modified")
+			}
+			if l.Dir != "" && !strings.HasPrefix(l.Dir, s.ScratchRoot) {
+				t.Fatalf("all writes stay under the scratch root, got %s", l.Dir)
+			}
+		})
+	}
+}
+
+// TestSessionKeyNeverOnDisk: the bearer secret appears in Env only — never in any
+// generated file (env-reference indirection for opencode/hermes, pure env for aider).
+func TestSessionKeyNeverOnDisk(t *testing.T) {
+	for _, name := range []string{"opencode", "hermes", "aider"} {
+		t.Run(name, func(t *testing.T) {
+			s := session(t)
+			_, cleanup, err := Materialize(guest(t, name), s)
+			if err != nil {
+				t.Fatalf("materialize: %v", err)
+			}
+			defer func() { _ = cleanup() }()
+			for _, f := range listFiles(t, s.ScratchRoot) {
+				b, err := os.ReadFile(filepath.Join(s.ScratchRoot, f))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if strings.Contains(string(b), tKey) {
+					t.Fatalf("%s: the session key must NEVER touch disk", f)
+				}
+			}
+		})
+	}
+}
+
+// TestScratchDirPrivate: 0700 — other local users cannot even enumerate the session dir.
+func TestScratchDirPrivate(t *testing.T) {
+	s := session(t)
+	l, cleanup, err := Materialize(guest(t, "opencode"), s)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+	info, err := os.Stat(l.Dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("scratch dir mode: want 0700, got %o", perm)
+	}
+}
+
+// TestCleanupRemovesScratch: cleanup removes the whole dir on every return path, is
+// idempotent, and tolerates a guest that deleted files itself.
+func TestCleanupRemovesScratch(t *testing.T) {
+	for _, name := range []string{"opencode", "hermes"} {
+		t.Run(name, func(t *testing.T) {
+			s := session(t)
+			l, cleanup, err := Materialize(guest(t, name), s)
+			if err != nil {
+				t.Fatalf("materialize: %v", err)
+			}
+			if err := cleanup(); err != nil {
+				t.Fatalf("cleanup: %v", err)
+			}
+			if _, err := os.Stat(l.Dir); !os.IsNotExist(err) {
+				t.Fatalf("scratch dir must be gone, stat err=%v", err)
+			}
+			if err := cleanup(); err != nil {
+				t.Fatalf("cleanup must be idempotent (crash-path re-entry): %v", err)
+			}
+		})
+	}
+	t.Run("guest deleted its own config", func(t *testing.T) {
+		s := session(t)
+		l, cleanup, err := Materialize(guest(t, "opencode"), s)
+		if err != nil {
+			t.Fatalf("materialize: %v", err)
+		}
+		if err := os.RemoveAll(filepath.Join(l.Dir, "opencode.json")); err != nil {
+			t.Fatal(err)
+		}
+		if err := cleanup(); err != nil {
+			t.Fatalf("cleanup must tolerate missing files: %v", err)
+		}
+		if _, err := os.Stat(l.Dir); !os.IsNotExist(err) {
+			t.Fatalf("scratch dir must be gone, stat err=%v", err)
+		}
+	})
+}
+
+// TestTwoHandoffsNeverShareScratch: rapid re-handoff mints a fresh dir every time.
+func TestTwoHandoffsNeverShareScratch(t *testing.T) {
+	s := session(t)
+	l1, c1, err := Materialize(guest(t, "opencode"), s)
+	if err != nil {
+		t.Fatalf("materialize #1: %v", err)
+	}
+	if err := c1(); err != nil {
+		t.Fatalf("cleanup #1: %v", err)
+	}
+	l2, c2, err := Materialize(guest(t, "opencode"), s)
+	if err != nil {
+		t.Fatalf("materialize #2: %v", err)
+	}
+	defer func() { _ = c2() }()
+	if l1.Dir == l2.Dir {
+		t.Fatalf("two handoffs must never share a scratch dir: %s", l1.Dir)
+	}
+	if _, err := os.Stat(l1.Dir); !os.IsNotExist(err) {
+		t.Fatalf("only the second scratch dir may exist, first still present")
+	}
+}
+
+// TestSweepStale: a leftover dir from a crashed roger is swept; fresh dirs and foreign
+// names are untouched (config_isolation.feature "swept at the next desk scan").
+func TestSweepStale(t *testing.T) {
+	root := t.TempDir()
+	dead := filepath.Join(root, "rogerai-operator-dead1")
+	live := filepath.Join(root, "rogerai-operator-live2")
+	foreign := filepath.Join(root, "someone-elses-dir")
+	for _, d := range []string{dead, live, foreign} {
+		if err := os.Mkdir(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(dead, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if swept := SweepStale(root, 24*time.Hour); swept != 1 {
+		t.Fatalf("want 1 dir swept, got %d", swept)
+	}
+	if _, err := os.Stat(dead); !os.IsNotExist(err) {
+		t.Fatalf("stale dir must be swept")
+	}
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("fresh dir must be untouched: %v", err)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Fatalf("foreign dirs are NEVER touched: %v", err)
+	}
+}
+
+// TestMaterializeReadsLiveOptions: the artifact reflects the Session values passed at
+// materialize time — the caller feeds ProxyOptionsHolder.Get() at exec, so a re-tuned
+// band lands in the wiring (config_*.feature "LIVE proxy options").
+func TestMaterializeReadsLiveOptions(t *testing.T) {
+	s := session(t)
+	s.Model = "llama-3.3-70b"
+	l, cleanup, err := Materialize(guest(t, "opencode"), s)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+	if !strings.Contains(strings.Join(l.Argv, " "), "roger/llama-3.3-70b") {
+		t.Fatalf("argv must pin the re-tuned model, got %v", l.Argv)
+	}
+	b, err := os.ReadFile(filepath.Join(l.Dir, "opencode.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "llama-3.3-70b") || strings.Contains(string(b), tModel) {
+		t.Fatalf("config must wire the LIVE model, not a stale one:\n%s", b)
+	}
+}
+
+// TestMaterializeRejectsEmptySession: money-path inputs are validated — an empty
+// session key or base URL must refuse to materialize (a keyless launch would hand the
+// guest an unauthenticated 401 wall; a URL-less one would fall back to the agent's real
+// default provider, the exact claude-exclusion failure class).
+func TestMaterializeRejectsEmptySession(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mut  func(*Session)
+	}{
+		{"empty key", func(s *Session) { s.SessionKey = "" }},
+		{"empty base URL", func(s *Session) { s.BaseURL = "" }},
+		{"empty model", func(s *Session) { s.Model = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := session(t)
+			tc.mut(&s)
+			if _, _, err := Materialize(guest(t, "opencode"), s); err == nil {
+				t.Fatalf("materialize must refuse a session with %s", tc.name)
+			}
+		})
+	}
+}

--- a/internal/operator/detect.go
+++ b/internal/operator/detect.go
@@ -1,0 +1,139 @@
+package operator
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ProbeTimeout bounds one `<bin> --version` probe (the audio.PlayTimeout discipline): a
+// wedged binary returns an error at the deadline and the guest degrades to UNVERIFIED -
+// it can never hang the desk scan. A package var (the proxyDialTimeout precedent) so a
+// test can prove the kill with a genuinely hung binary and a small deadline.
+var ProbeTimeout = 3 * time.Second
+
+// Env is the injectable runtime seam for detection (the internal/audio/audio.go Env
+// pattern): LookPath resolves a binary on PATH; Probe runs `<path> --version` BOUNDED and
+// returns its raw output. Both are injected so every PATH/version permutation is
+// table-testable with no real binary.
+type Env struct {
+	LookPath func(string) (string, error)
+	Probe    func(bin string) (string, error)
+}
+
+// DefaultEnv wires the real OS seams: exec.LookPath + a ProbeTimeout-bounded `--version`.
+func DefaultEnv() Env {
+	return Env{
+		LookPath: exec.LookPath,
+		Probe: func(bin string) (string, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), ProbeTimeout)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, bin, "--version")
+			// WaitDelay: without it, Output() blocks past the context kill whenever the
+			// probed binary spawned a child that keeps the stdout pipe open - the exact
+			// hang the bounded-probe spec forbids (caught by the real hung-binary test).
+			cmd.WaitDelay = time.Second
+			out, err := cmd.Output()
+			return string(out), err
+		},
+	}
+}
+
+// Detection is one guest found at the desk: the registry entry, the resolved PATH binary,
+// and the probed version. Unverified means the probe failed / was unparsable / is below
+// the known-good floor - the guest is STILL listed (§8: degrade gracefully, never hide)
+// so the picker can warn instead of lying that the desk is empty.
+type Detection struct {
+	Guest      Guest
+	Path       string
+	Version    string
+	Unverified bool
+}
+
+// Detect scans the desk: for each registry guest, LookPath (a miss - including a file
+// without the execute bit, which exec.LookPath already rejects - means simply absent,
+// never an error), then the bounded version probe. Pure and stateless: a re-scan reflects
+// the live PATH. It launches nothing, writes nothing, and bills nothing.
+func Detect(env Env) []Detection {
+	var out []Detection
+	for _, g := range Registry() {
+		path, err := env.LookPath(g.Bin)
+		if err != nil || path == "" {
+			continue
+		}
+		d := Detection{Guest: g, Path: path}
+		raw, perr := "", error(nil)
+		if env.Probe != nil {
+			raw, perr = env.Probe(path)
+		}
+		v, ok := ParseVersion(g.Name, raw)
+		switch {
+		case perr != nil || !ok:
+			d.Unverified = true // failed/garbled probe: UNVERIFIED, never hidden
+		case versionBelow(v, g.KnownGood):
+			d.Version, d.Unverified = v, true // below the proven floor (§8 version skew)
+		default:
+			d.Version = v
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+// ParseVersion extracts a semver-ish version from a guest's raw `--version` output. It is
+// format-tolerant across the real shapes observed on the dev box (bare "1.17.11",
+// "Hermes Agent v0.16.0 (…)", "aider 0.86.2"): the FIRST whitespace token that is a
+// dotted all-digit group (optionally v-prefixed) wins. Garbage (tracebacks, empty output)
+// returns ok=false. The guest name is accepted for future format pinning but the parse is
+// deliberately generic - a new release changing cosmetic text must not un-detect a guest.
+func ParseVersion(_ string, raw string) (string, bool) {
+	for _, tok := range strings.Fields(raw) {
+		tok = strings.TrimPrefix(tok, "v")
+		if isDottedVersion(tok) {
+			return tok, true
+		}
+	}
+	return "", false
+}
+
+// isDottedVersion reports whether s is digits separated by at least one dot ("1.17.11").
+func isDottedVersion(s string) bool {
+	parts := strings.Split(s, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+		for _, r := range p {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// versionBelow reports v < floor by numeric dot-segment comparison (missing segments = 0).
+func versionBelow(v, floor string) bool {
+	if floor == "" {
+		return false
+	}
+	a, b := strings.Split(v, "."), strings.Split(floor, ".")
+	for i := 0; i < len(a) || i < len(b); i++ {
+		av, bv := 0, 0
+		if i < len(a) {
+			av, _ = strconv.Atoi(a[i])
+		}
+		if i < len(b) {
+			bv, _ = strconv.Atoi(b[i])
+		}
+		if av != bv {
+			return av < bv
+		}
+	}
+	return false
+}

--- a/internal/operator/env_exec_test.go
+++ b/internal/operator/env_exec_test.go
@@ -1,0 +1,258 @@
+package operator
+
+// env_exec_test.go - table tests for the seams the TUI composes a child from: the REAL
+// DefaultEnv (a genuine LookPath + a bounded `--version` probe against a real script),
+// ComposeEnv's override-not-merge contract, Command's cwd/env composition, and the
+// Materialize/newScratchDir failure paths. Real dependencies only (real filesystem, a
+// real spawned probe process), stdlib testing per repo convention.
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDefaultEnvRealProbe: DefaultEnv wires a real exec.LookPath and a real bounded
+// probe - proven against an actual executable that answers --version.
+func TestDefaultEnvRealProbe(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "fakeguest")
+	script := "#!/bin/sh\n[ \"$1\" = --version ] && echo 9.9.9\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	env := DefaultEnv()
+
+	t.Run("LookPath resolves via the real PATH", func(t *testing.T) {
+		t.Setenv("PATH", dir)
+		p, err := env.LookPath("fakeguest")
+		if err != nil || p != fake {
+			t.Fatalf("LookPath = (%q, %v), want %q", p, err, fake)
+		}
+		if _, err := env.LookPath("no-such-guest-on-earth"); err == nil {
+			t.Fatalf("a missing binary must miss")
+		}
+	})
+
+	t.Run("Probe runs --version for real", func(t *testing.T) {
+		out, err := env.Probe(fake)
+		if err != nil || strings.TrimSpace(out) != "9.9.9" {
+			t.Fatalf("Probe = (%q, %v), want 9.9.9", out, err)
+		}
+	})
+
+	t.Run("Probe kills a genuinely hung binary at the deadline", func(t *testing.T) {
+		hung := filepath.Join(dir, "hungguest")
+		if err := os.WriteFile(hung, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		saved := ProbeTimeout
+		ProbeTimeout = 150 * time.Millisecond
+		defer func() { ProbeTimeout = saved }()
+		start := time.Now()
+		_, err := DefaultEnv().Probe(hung) // rebuild so the probe closes over the small deadline
+		if err == nil {
+			t.Fatalf("a hung --version must error at the deadline")
+		}
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Fatalf("the probe did not kill the hung binary promptly (took %v)", elapsed)
+		}
+	})
+
+	t.Run("Probe surfaces a failing binary as an error", func(t *testing.T) {
+		bad := filepath.Join(dir, "brokenguest")
+		if err := os.WriteFile(bad, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := env.Probe(bad); err == nil {
+			t.Fatalf("a probe exiting non-zero must error (degrades to UNVERIFIED)")
+		}
+	})
+}
+
+// TestComposeEnvOverridesNotMerges: an addition RE-DECLARING a parent var replaces it -
+// the user's real OPENAI_API_KEY must never survive into the child (config_aider.feature).
+func TestComposeEnvOverridesNotMerges(t *testing.T) {
+	parent := []string{"HOME=/home/u", "OPENAI_API_KEY=sk-users-real-key", "PATH=/usr/bin"}
+	adds := []string{"OPENAI_API_KEY=sk-session", "OPENAI_API_BASE=http://127.0.0.1:1/v1"}
+	got := ComposeEnv(parent, adds)
+	want := []string{"HOME=/home/u", "PATH=/usr/bin", "OPENAI_API_KEY=sk-session", "OPENAI_API_BASE=http://127.0.0.1:1/v1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ComposeEnv = %v, want %v", got, want)
+	}
+	// Malformed parent entries (no '=') pass through untouched rather than crashing.
+	got = ComposeEnv([]string{"JUNK", "A=1"}, []string{"A=2"})
+	if !reflect.DeepEqual(got, []string{"JUNK", "A=2"}) {
+		t.Fatalf("malformed parent entries must pass through, got %v", got)
+	}
+}
+
+// TestCommandComposition: the child runs the RESOLVED binary in the USER'S workdir
+// (never the scratch dir) with the composed env.
+func TestCommandComposition(t *testing.T) {
+	l := Launch{Argv: []string{"opencode", "-m", "roger/m"}, Env: []string{"K=v"}, Dir: "/scratch/x"}
+	c := Command(l, "/resolved/opencode", "/work/project", []string{"HOME=/h", "K=old"})
+	if c.Path != "/resolved/opencode" {
+		t.Fatalf("path = %q, want the resolved binary", c.Path)
+	}
+	if !reflect.DeepEqual(c.Args, []string{"/resolved/opencode", "-m", "roger/m"}) {
+		t.Fatalf("args = %v", c.Args)
+	}
+	if c.Dir != "/work/project" {
+		t.Fatalf("dir = %q, want the launch workdir (never the scratch dir)", c.Dir)
+	}
+	if !reflect.DeepEqual(c.Env, []string{"HOME=/h", "K=v"}) {
+		t.Fatalf("env = %v, want the composed override", c.Env)
+	}
+}
+
+// TestMaterializeUnknownStrategy: a registry bug (unset strategy) refuses loudly rather
+// than launching an unwired guest.
+func TestMaterializeUnknownStrategy(t *testing.T) {
+	s := Session{BaseURL: "http://x/v1", SessionKey: "k", Model: "m",
+		Workdir: t.TempDir(), ScratchRoot: t.TempDir()}
+	if _, _, err := Materialize(Guest{Name: "mystery", Bin: "mystery"}, s); err == nil {
+		t.Fatalf("an unknown wiring strategy must refuse to materialize")
+	}
+}
+
+// TestMaterializeScratchRootFailure: an unusable scratch root fails cleanly (no partial
+// dirs, no panic) for both file-backed strategies.
+func TestMaterializeScratchRootFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores directory modes")
+	}
+	root := filepath.Join(t.TempDir(), "sealed")
+	if err := os.Mkdir(root, 0o500); err != nil { // read+exec only: MkdirTemp must fail
+		t.Fatal(err)
+	}
+	s := Session{BaseURL: "http://x/v1", SessionKey: "k", Model: "m",
+		Workdir: t.TempDir(), ScratchRoot: root}
+	for _, name := range []string{"opencode", "hermes"} {
+		if _, _, err := Materialize(guest(t, name), s); err == nil {
+			t.Fatalf("%s: an unwritable scratch root must fail the materialize", name)
+		}
+	}
+}
+
+// TestMaterializeDefaultScratchRoot: an empty ScratchRoot falls back to os.TempDir()
+// (the production default the TUI relies on).
+func TestMaterializeDefaultScratchRoot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	s := Session{BaseURL: "http://x/v1", SessionKey: "k", Model: "m", Workdir: t.TempDir()}
+	l, cleanup, err := Materialize(guest(t, "opencode"), s)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+	if !strings.HasPrefix(l.Dir, tmp) {
+		t.Fatalf("scratch dir %s not under os.TempDir() %s", l.Dir, tmp)
+	}
+}
+
+// TestSweepStaleEdgeCases: a missing root sweeps nothing; stale FILES (not dirs) with
+// the prefix are left alone; the age boundary is respected.
+func TestSweepStaleEdgeCases(t *testing.T) {
+	if got := SweepStale(filepath.Join(t.TempDir(), "nope"), time.Hour); got != 0 {
+		t.Fatalf("missing root: swept %d, want 0", got)
+	}
+	root := t.TempDir()
+	f := filepath.Join(root, "rogerai-operator-file")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(f, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if got := SweepStale(root, 24*time.Hour); got != 0 {
+		t.Fatalf("a stale FILE must not be swept (dirs only), swept %d", got)
+	}
+	if _, err := os.Stat(f); err != nil {
+		t.Fatalf("the file was removed: %v", err)
+	}
+}
+
+// TestVersionBelowTable: numeric dot-segment comparison across lengths and boundaries.
+func TestVersionBelowTable(t *testing.T) {
+	cases := []struct {
+		v, floor string
+		want     bool
+	}{
+		{"0.9.0", "1.17.11", true},
+		{"1.17.11", "1.17.11", false},
+		{"1.17.12", "1.17.11", false},
+		{"2.0", "1.17.11", false},
+		{"1.17", "1.17.11", true}, // missing segment counts as 0
+		{"1.17.11", "", false},    // no floor: nothing is below
+		{"10.0.0", "9.9.9", false},
+	}
+	for _, tc := range cases {
+		if got := versionBelow(tc.v, tc.floor); got != tc.want {
+			t.Fatalf("versionBelow(%q, %q) = %v, want %v", tc.v, tc.floor, got, tc.want)
+		}
+	}
+}
+
+// TestParseVersionEdge: dotted-token discipline - punctuation-wrapped or non-numeric
+// tokens never parse as a version.
+func TestParseVersionEdge(t *testing.T) {
+	cases := []struct {
+		raw  string
+		ok   bool
+		want string
+	}{
+		{"v1.2.3", true, "1.2.3"},
+		{"version: 1.2", true, "1.2"},
+		{"1.", false, ""},
+		{".1", false, ""},
+		{"1", false, ""},
+		{"1.2a.3", false, ""},
+		{"built (2026.6.5)", false, ""}, // parens keep the token from parsing
+	}
+	for _, tc := range cases {
+		got, ok := ParseVersion("any", tc.raw)
+		if ok != tc.ok || got != tc.want {
+			t.Fatalf("ParseVersion(%q) = (%q, %v), want (%q, %v)", tc.raw, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestMaterializeRejectsUnsafeValues: audit regression - Model/BaseURL are interpolated
+// into JSON/YAML templates, so a value carrying quotes/newlines/control bytes (or the
+// YAML ": " hazard) must REFUSE to materialize (fail-closed) rather than emit a broken
+// or injectable config. Band values from the broker never contain these; a value that
+// does is hostile or corrupt.
+func TestMaterializeRejectsUnsafeValues(t *testing.T) {
+	base := func() Session {
+		return Session{BaseURL: "http://127.0.0.1:1/v1", SessionKey: "k", Model: "m",
+			Workdir: t.TempDir(), ScratchRoot: t.TempDir()}
+	}
+	cases := []struct {
+		name string
+		mut  func(*Session)
+	}{
+		{"newline in model", func(s *Session) { s.Model = "m\nproviders: {}" }},
+		{"quote in model", func(s *Session) { s.Model = `m"},"x":{` }},
+		{"newline in base URL", func(s *Session) { s.BaseURL = "http://x/v1\napi_key: stolen" }},
+		{"backslash in model", func(s *Session) { s.Model = `m\"` }},
+		{"yaml colon-space in model", func(s *Session) { s.Model = "m: evil" }},
+		{"control byte in base URL", func(s *Session) { s.BaseURL = "http://x/v1\x07" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, name := range []string{"opencode", "hermes", "aider"} {
+				s := base()
+				tc.mut(&s)
+				if _, cleanup, err := Materialize(guest(t, name), s); err == nil {
+					_ = cleanup()
+					t.Fatalf("%s: unsafe %s must refuse to materialize", name, tc.name)
+				}
+			}
+		})
+	}
+}

--- a/internal/operator/materialize.go
+++ b/internal/operator/materialize.go
@@ -1,0 +1,268 @@
+package operator
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// scratchPrefix names every per-handoff scratch dir (rogerai-operator-<random>) so the
+// crash sweep can recognize its own leftovers and NEVER touch a foreign dir.
+const scratchPrefix = "rogerai-operator-"
+
+// SessionKeyEnv is the env var the generated configs reference the bearer secret by
+// ({env:...} / ${...}); the key itself NEVER touches disk (config_isolation.feature).
+const SessionKeyEnv = "ROGER_SESSION_KEY"
+
+// Session is the live wiring a handoff materializes against - fed from
+// ProxyOptionsHolder.Get() AT EXEC TIME (never options frozen at first bind).
+type Session struct {
+	BaseURL    string // the local proxy base, e.g. http://127.0.0.1:44017/v1
+	SessionKey string // the per-session bearer secret (env-delivered, never written)
+	Model      string // the tuned band's model
+	Workdir    string // the user's confirmed workdir - the child's cwd, NEVER the scratch dir
+	// ScratchRoot overrides where the session scratch dir is minted ("" = os.TempDir()).
+	ScratchRoot string
+}
+
+// Launch is a composed child launch: the full argv (argv[0] = the guest binary name),
+// the env ADDITIONS over the inherited parent env, and the session scratch dir ("" when
+// the guest needs no file at all - aider).
+type Launch struct {
+	Argv []string
+	Env  []string
+	Dir  string
+}
+
+// goldenOpencodeTmpl is the §4-proven custom provider on @ai-sdk/openai-compatible. The
+// apiKey is the literal {env:ROGER_SESSION_KEY} reference (verified supported in the
+// 1.17.11 binary) so the secret never lands on disk.
+const goldenOpencodeTmpl = `{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "roger": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "RogerAI",
+      "options": {
+        "baseURL": "%s",
+        "apiKey": "{env:%s}"
+      },
+      "models": {
+        "%s": { "name": "%s" }
+      }
+    }
+  },
+  "model": "roger/%s"
+}
+`
+
+// goldenHermesTmpl is the KEYED providers schema - the ONE hermes-0.16.0 path that
+// delivers an api_key to a loopback base_url (model_switch.py:900-931 expands ${VAR}
+// from the env). A bare model_aliases entry resolves to "no-key-required" on loopback
+// and 401s against the Phase 1 bearer proxy (permanent regression, config_hermes.feature).
+const goldenHermesTmpl = `providers:
+  roger:
+    base_url: %s
+    api_key: ${%s}
+model:
+  provider: roger
+  default: %s
+`
+
+// Materialize composes the launch for guest g against the live session s: argv, env
+// additions, and (for the file-backed strategies) a fresh private scratch dir holding the
+// generated config. The returned cleanup removes the whole scratch dir; it is idempotent,
+// tolerates a guest that deleted files itself, and MUST run on every return path (clean,
+// crash, spawn failure). Money-path inputs are validated: an empty key would hand the
+// guest a 401 wall, an empty base URL/model would fall back to the agent's real default
+// provider - the exact claude-exclusion failure class.
+func Materialize(g Guest, s Session) (Launch, func() error, error) {
+	if s.SessionKey == "" || s.BaseURL == "" || s.Model == "" {
+		return Launch{}, nil, fmt.Errorf("operator: refusing to materialize %s: missing %s", g.Name, describeMissing(s))
+	}
+	// Fail-closed value validation (audit regression): Model/BaseURL are interpolated
+	// into the JSON/YAML templates below, so quotes/backslashes/control bytes (or the
+	// YAML ": " hazard) would produce a broken - or injectable - config. Broker band
+	// values never contain these; a value that does is corrupt or hostile.
+	for _, v := range []string{s.Model, s.BaseURL} {
+		if !safeConfigValue(v) {
+			return Launch{}, nil, fmt.Errorf("operator: refusing to materialize %s: unsafe characters in model/base URL", g.Name)
+		}
+	}
+	noop := func() error { return nil }
+	switch g.Strategy {
+	case StrategyEnvFlags:
+		// aider: pure env + flags, ZERO generated files - no scratch dir is created at all
+		// (minimization: nothing to leak on crash). --no-auto-commits is a permanent SAFETY
+		// pin (a guest must never commit to the user's repo on its own);
+		// --no-show-model-warnings suppresses the unknown-model wall for the band's model.
+		return Launch{
+			Argv: []string{g.Bin, "--model", "openai/" + s.Model, "--no-show-model-warnings", "--no-auto-commits"},
+			Env:  []string{"OPENAI_API_BASE=" + s.BaseURL, "OPENAI_API_KEY=" + s.SessionKey},
+		}, noop, nil
+
+	case StrategyScratchConfig:
+		dir, err := newScratchDir(s.ScratchRoot)
+		if err != nil {
+			return Launch{}, nil, err
+		}
+		cfg := filepath.Join(dir, "opencode.json")
+		body := fmt.Sprintf(goldenOpencodeTmpl, s.BaseURL, SessionKeyEnv, s.Model, s.Model, s.Model)
+		if err := os.WriteFile(cfg, []byte(body), 0o600); err != nil {
+			_ = os.RemoveAll(dir)
+			return Launch{}, nil, err
+		}
+		return Launch{
+			// The argv -m pin beats EVERY config layer: a user project's own opencode.json
+			// loads AFTER OPENCODE_CONFIG in 1.17.11 and could otherwise silently re-route
+			// the guest (config_opencode.feature precedence hazard).
+			Argv: []string{g.Bin, "-m", "roger/" + s.Model},
+			Env:  []string{"OPENCODE_CONFIG=" + cfg, SessionKeyEnv + "=" + s.SessionKey},
+			Dir:  dir,
+		}, cleanupFn(dir), nil
+
+	case StrategyScratchHome:
+		dir, err := newScratchDir(s.ScratchRoot)
+		if err != nil {
+			return Launch{}, nil, err
+		}
+		home := filepath.Join(dir, "hermes-home")
+		if err := os.Mkdir(home, 0o700); err != nil {
+			_ = os.RemoveAll(dir)
+			return Launch{}, nil, err
+		}
+		body := fmt.Sprintf(goldenHermesTmpl, s.BaseURL, SessionKeyEnv, s.Model)
+		if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte(body), 0o600); err != nil {
+			_ = os.RemoveAll(dir)
+			return Launch{}, nil, err
+		}
+		return Launch{
+			Argv: []string{g.Bin, "-m", "roger/" + s.Model},
+			Env:  []string{"HERMES_HOME=" + home, SessionKeyEnv + "=" + s.SessionKey},
+			Dir:  dir,
+		}, cleanupFn(dir), nil
+	}
+	return Launch{}, nil, errors.New("operator: unknown wiring strategy for " + g.Name)
+}
+
+// safeConfigValue reports whether v can be interpolated verbatim into the generated
+// JSON/YAML configs: no control bytes (incl. newlines), no quotes/backslashes/backticks,
+// and no YAML ": " plain-scalar hazard.
+func safeConfigValue(v string) bool {
+	if strings.Contains(v, ": ") {
+		return false
+	}
+	for _, r := range v {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+		switch r {
+		case '"', '\'', '\\', '`':
+			return false
+		}
+	}
+	return true
+}
+
+// describeMissing names the empty money-path field(s) for the refusal error.
+func describeMissing(s Session) string {
+	var miss []string
+	if s.SessionKey == "" {
+		miss = append(miss, "session key")
+	}
+	if s.BaseURL == "" {
+		miss = append(miss, "base URL")
+	}
+	if s.Model == "" {
+		miss = append(miss, "model")
+	}
+	return strings.Join(miss, ", ")
+}
+
+// newScratchDir mints one private (0700) per-handoff dir under root (os.TempDir() when
+// empty). MkdirTemp's random suffix guarantees two rapid handoffs never share a dir.
+func newScratchDir(root string) (string, error) {
+	if root == "" {
+		root = os.TempDir()
+	}
+	dir, err := os.MkdirTemp(root, scratchPrefix)
+	if err != nil {
+		return "", fmt.Errorf("operator: scratch dir: %w", err)
+	}
+	// MkdirTemp already creates 0700 (modulo umask quirks) - pin it explicitly: the dir
+	// holds a file whose CONTENT references the session-key env var, and other local
+	// users must not even enumerate it.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	return dir, nil
+}
+
+// cleanupFn removes the whole scratch dir: idempotent (RemoveAll on a missing dir is
+// nil) and tolerant of whatever the guest left - or deleted - inside it.
+func cleanupFn(dir string) func() error {
+	return func() error { return os.RemoveAll(dir) }
+}
+
+// SweepStale removes rogerai-operator-* dirs under root older than olderThan - the
+// best-effort crash sweep run at the next desk scan (a crash of roger ITSELF mid-handoff
+// leaks the dir; the per-handoff cleanup covers every other path). Foreign names and
+// fresh dirs are NEVER touched. Returns how many dirs were removed.
+func SweepStale(root string, olderThan time.Duration) int {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return 0
+	}
+	cutoff := time.Now().Add(-olderThan)
+	swept := 0
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), scratchPrefix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || !info.ModTime().Before(cutoff) {
+			continue
+		}
+		if os.RemoveAll(filepath.Join(root, e.Name())) == nil {
+			swept++
+		}
+	}
+	return swept
+}
+
+// ComposeEnv layers the launch's env additions over the inherited parent env,
+// OVERRIDING (not merging) any parent variable an addition re-declares - a user's real
+// OPENAI_API_KEY must never leak into the child, or the guest bills their real account
+// instead of the tuned band (config_aider.feature).
+func ComposeEnv(parent, additions []string) []string {
+	override := map[string]bool{}
+	for _, kv := range additions {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			override[kv[:i]] = true
+		}
+	}
+	out := make([]string, 0, len(parent)+len(additions))
+	for _, kv := range parent {
+		if i := strings.IndexByte(kv, '='); i > 0 && override[kv[:i]] {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, additions...)
+}
+
+// Command builds the child *exec.Cmd for a composed launch: the RESOLVED binary path,
+// the launch argv, the user's workdir as cwd (the guest edits the user's project; only
+// its CONFIG lives in scratch - mixing the two would make the guest edit throwaway files
+// and then delete its own work), and the parent env with the launch additions overriding.
+func Command(l Launch, binPath, workdir string, parentEnv []string) *exec.Cmd {
+	c := exec.Command(binPath, l.Argv[1:]...)
+	c.Dir = workdir
+	c.Env = ComposeEnv(parentEnv, l.Env)
+	return c
+}

--- a/internal/operator/registry.go
+++ b/internal/operator/registry.go
@@ -1,0 +1,79 @@
+// Package operator is the pure core of Guest Operators Phase 2 ("hand the mic" to an
+// installed agent CLI): the static registry of known guests, PATH detection through an
+// injectable Env seam, and per-session throwaway config materialization. It has ZERO
+// bubbletea dependencies (the internal/audio precedent) - internal/tui keeps only the
+// command/picker/exec glue. Spec: features/operator/*.feature (founder-approved
+// 2026-07-07); design: rogerai-internal-docs/GUEST-OPERATORS.md.
+package operator
+
+// Wiring strategies (design doc §4, empirically proven per guest). The strategy names are
+// pinned by detection.feature ("Registry entries carry the empirically-proven wiring
+// strategy") and drive Materialize.
+const (
+	// StrategyScratchConfig: a throwaway opencode.json in the session scratch dir, pointed
+	// at via OPENCODE_CONFIG, with the model ALSO pinned on the argv (-m roger/<model>) so
+	// no config layer (a user project's own opencode.json loads AFTER OPENCODE_CONFIG in
+	// 1.17.11) can re-route the guest.
+	StrategyScratchConfig = "scratch-config"
+	// StrategyScratchHome: a throwaway HERMES_HOME (config.yaml + sessions + checkpoints
+	// all land inside it) using the KEYED providers.<name> schema with api_key ${VAR} env
+	// expansion. NEVER the bare model_aliases DirectAlias route - it resolves to
+	// "no-key-required" on loopback and 401s against the Phase 1 bearer proxy (permanent
+	// regression, config_hermes.feature).
+	StrategyScratchHome = "scratch-home"
+	// StrategyEnvFlags: pure env + flags, zero generated files (aider): OPENAI_API_BASE +
+	// OPENAI_API_KEY in the child env, model + safety flags on the argv.
+	StrategyEnvFlags = "env-and-flags"
+)
+
+// Guest is one registry entry: an agent CLI that can take the mic at THE DESK.
+type Guest struct {
+	Name        string // the desk name ("opencode")
+	Bin         string // the PATH binary to look up
+	Provider    string // wire tag - all MVP guests speak the OpenAI-compatible wire
+	InstallHint string // the one-liner shown for a not-installed suggestion row
+	// KnownGood is the version floor proven end-to-end on the dev box; a probe below it
+	// (or unparsable) degrades the detection to UNVERIFIED - never hidden (§8 version skew).
+	KnownGood string
+	Strategy  string // one of the Strategy* constants
+	// NeedsSetup marks a guest that is detectable but not launchable without user setup
+	// (reserved for the future claude row - picking it prints SetupNote instead of execing).
+	// Every MVP guest is config-generated, so none of the three sets it.
+	NeedsSetup bool
+	SetupNote  string
+
+	// Per-brand presence seam (founder direction 2026-07-06): a dedicated design pass
+	// will land each operator's wordmark as DATA-ONLY registry changes - the transition
+	// logic never changes. All three are optional; empty means the tasteful text-only
+	// house default.
+	BrandPlate  string // multi-line ASCII wordmark for the PATCHING YOU THROUGH screen
+	BrandAccent string // accent color (hex like "#fab387" or ANSI-256 index) for plate + glyph
+	BrandGlyph  string // single-cell picker-row glyph
+}
+
+// Registry is the ONE source of who can ever appear at the desk (MVP set, design doc §4/§6).
+// claude and codex are EXCLUDED in v1: they speak the Anthropic /v1/messages + Responses-API
+// wire, and a naive launch silently falls back to the user's REAL Anthropic account - the
+// exact failure §4 measured. Order is the desk display order.
+func Registry() []Guest {
+	return []Guest{
+		{
+			Name: "opencode", Bin: "opencode", Provider: "openai",
+			InstallHint: "curl -fsSL https://opencode.ai/install | bash",
+			KnownGood:   "1.17.11", // proven end-to-end on the dev box, 2026-07-06
+			Strategy:    StrategyScratchConfig,
+		},
+		{
+			Name: "hermes", Bin: "hermes", Provider: "openai",
+			InstallHint: "pip install hermes-agent",
+			KnownGood:   "0.16.0", // proven end-to-end on the dev box, 2026-07-06
+			Strategy:    StrategyScratchHome,
+		},
+		{
+			Name: "aider", Bin: "aider", Provider: "openai",
+			InstallHint: "uv tool install aider-chat",
+			KnownGood:   "0.86.2", // verified at GREEN stage (founder ruling 6): installed + run live 2026-07-06
+			Strategy:    StrategyEnvFlags,
+		},
+	}
+}

--- a/internal/operator/registry_test.go
+++ b/internal/operator/registry_test.go
@@ -1,0 +1,268 @@
+package operator
+
+// registry_test.go — RED-phase spec tests for the Guest Operators Phase 2 detection
+// registry (features/operator/detection.feature made table-executable). NO production
+// code exists yet: this package intentionally fails to compile ("undefined: Registry",
+// "undefined: Detect", …) — that build failure is the RED evidence for the not-yet-built
+// unit, pasted in the approval report. Real deps only: the Env seam is the
+// internal/audio/audio.go:35 pattern (injected LookPath + bounded Probe), no mocks.
+// Stdlib testing only (repo convention pinned in internal/client/proxy_hardening_test.go:21).
+//
+// Proposed API under test (to be implemented ONLY after founder approval):
+//
+//	type Guest struct{ Name, Bin, Provider, InstallHint, KnownGood string }
+//	type Detection struct{ Guest Guest; Path, Version string; Unverified bool }
+//	type Env struct {
+//	    LookPath func(string) (string, error)
+//	    Probe    func(bin string) (string, error) // runs `bin --version`, bounded
+//	}
+//	func Registry() []Guest
+//	func Detect(env Env) []Detection
+//	func ParseVersion(guest, raw string) (version string, ok bool)
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// notFound mimics exec.LookPath's miss for every binary.
+func notFound(string) (string, error) { return "", errors.New("executable file not found in $PATH") }
+
+// lookup returns a LookPath seam resolving only the given name->path pairs.
+func lookup(paths map[string]string) func(string) (string, error) {
+	return func(bin string) (string, error) {
+		if p, ok := paths[bin]; ok {
+			return p, nil
+		}
+		return "", errors.New("executable file not found in $PATH")
+	}
+}
+
+func detectionNames(ds []Detection) []string {
+	var names []string
+	for _, d := range ds {
+		names = append(names, d.Guest.Name)
+	}
+	return names
+}
+
+// TestRegistryMVPSet: the registry is exactly the §4-proven MVP set, in order, with
+// claude/codex excluded and every field populated.
+func TestRegistryMVPSet(t *testing.T) {
+	reg := Registry()
+	var names []string
+	for _, g := range reg {
+		names = append(names, g.Name)
+	}
+	if want := []string{"opencode", "hermes", "aider"}; !reflect.DeepEqual(names, want) {
+		t.Fatalf("registry must be the MVP set in order %v, got %v", want, names)
+	}
+	for _, g := range reg {
+		if g.Name == "claude" || g.Name == "codex" {
+			t.Fatalf("claude/codex are EXCLUDED v1, registry lists %q", g.Name)
+		}
+		if g.Bin == "" || g.Provider == "" || g.InstallHint == "" {
+			t.Fatalf("%s: every entry carries bin/provider/install hint, got %+v", g.Name, g)
+		}
+	}
+}
+
+// TestRegistryWiringStrategies pins each entry's empirically-proven wiring identity.
+func TestRegistryWiringStrategies(t *testing.T) {
+	byName := map[string]Guest{}
+	for _, g := range Registry() {
+		byName[g.Name] = g
+	}
+	if v := byName["opencode"].KnownGood; v != "1.17.11" {
+		t.Fatalf("opencode known-good must pin 1.17.11 (dev box, 2026-07-06), got %q", v)
+	}
+	if v := byName["hermes"].KnownGood; v != "0.16.0" {
+		t.Fatalf("hermes known-good must pin 0.16.0 (dev box, 2026-07-06), got %q", v)
+	}
+	// aider: no known-good pin yet — not installed on the dev box; founder ruling pending.
+	for _, n := range []string{"opencode", "hermes", "aider"} {
+		if p := byName[n].Provider; p != "openai" {
+			t.Fatalf("%s provider tag must be openai (OpenAI-compatible wire), got %q", n, p)
+		}
+	}
+}
+
+// TestDetect is the found / not-found / PATH-edge / version table
+// (detection.feature scenarios 3-13).
+func TestDetect(t *testing.T) {
+	allPaths := map[string]string{
+		"opencode": "/home/u/.opencode/bin/opencode",
+		"hermes":   "/home/u/.local/bin/hermes",
+		"aider":    "/home/u/.local/bin/aider",
+	}
+	versionOK := func(bin string) (string, error) {
+		switch bin {
+		case allPaths["opencode"]:
+			return "1.17.11\n", nil
+		case allPaths["hermes"]:
+			return "Hermes Agent v0.16.0 (2026.6.5) · upstream 9688c1a9", nil
+		case allPaths["aider"]:
+			return "aider 0.86.1", nil
+		}
+		return "", errors.New("unknown bin")
+	}
+
+	cases := []struct {
+		name       string
+		env        Env
+		wantNames  []string
+		unverified map[string]bool // name -> expected Unverified flag (nil = not asserted)
+		versions   map[string]string
+	}{
+		{
+			name:      "all three on PATH, registry order, versions verified",
+			env:       Env{LookPath: lookup(allPaths), Probe: versionOK},
+			wantNames: []string{"opencode", "hermes", "aider"},
+			versions:  map[string]string{"opencode": "1.17.11", "hermes": "0.16.0", "aider": "0.86.1"},
+		},
+		{
+			name:      "missing guests are absent, never an error",
+			env:       Env{LookPath: lookup(map[string]string{"opencode": allPaths["opencode"]}), Probe: versionOK},
+			wantNames: []string{"opencode"},
+		},
+		{
+			name:      "empty PATH detects nothing",
+			env:       Env{LookPath: notFound, Probe: versionOK},
+			wantNames: nil,
+		},
+		{
+			name: "exists but not executable is not at the desk (LookPath contract)",
+			env: Env{LookPath: func(bin string) (string, error) {
+				if bin == "opencode" {
+					return "", errors.New("permission denied")
+				}
+				return "", errors.New("executable file not found in $PATH")
+			}, Probe: versionOK},
+			wantNames: nil,
+		},
+		{
+			name: "failed version probe degrades to UNVERIFIED, never hidden",
+			env: Env{LookPath: lookup(map[string]string{"opencode": allPaths["opencode"]}),
+				Probe: func(string) (string, error) { return "", errors.New("exit status 1") }},
+			wantNames:  []string{"opencode"},
+			unverified: map[string]bool{"opencode": true},
+		},
+		{
+			name: "garbage version output degrades to UNVERIFIED",
+			env: Env{LookPath: lookup(map[string]string{"hermes": allPaths["hermes"]}),
+				Probe: func(string) (string, error) { return "Traceback (most recent call last): ...", nil }},
+			wantNames:  []string{"hermes"},
+			unverified: map[string]bool{"hermes": true},
+		},
+		{
+			name: "version below the known-good floor is detected but unverified",
+			env: Env{LookPath: lookup(map[string]string{"opencode": "/usr/bin/opencode"}),
+				Probe: func(string) (string, error) { return "0.9.0", nil }},
+			wantNames:  []string{"opencode"},
+			unverified: map[string]bool{"opencode": true},
+			versions:   map[string]string{"opencode": "0.9.0"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Detect(tc.env)
+			if names := detectionNames(got); !reflect.DeepEqual(names, tc.wantNames) {
+				t.Fatalf("detections: want %v, got %v", tc.wantNames, names)
+			}
+			for _, d := range got {
+				if tc.unverified != nil && d.Unverified != tc.unverified[d.Guest.Name] {
+					t.Fatalf("%s: Unverified=%v, want %v", d.Guest.Name, d.Unverified, tc.unverified[d.Guest.Name])
+				}
+				if want, ok := tc.versions[d.Guest.Name]; ok && d.Version != want {
+					t.Fatalf("%s: version %q, want %q", d.Guest.Name, d.Version, want)
+				}
+			}
+		})
+	}
+}
+
+// TestDetectRecordsResolvedPath: each detection carries the LookPath result so the
+// picker/plate can show WHICH binary will run.
+func TestDetectRecordsResolvedPath(t *testing.T) {
+	got := Detect(Env{
+		LookPath: lookup(map[string]string{"opencode": "/home/u/.opencode/bin/opencode"}),
+		Probe:    func(string) (string, error) { return "1.17.11", nil },
+	})
+	if len(got) != 1 || got[0].Path != "/home/u/.opencode/bin/opencode" {
+		t.Fatalf("detection must record the resolved path, got %+v", got)
+	}
+}
+
+// TestDetectRescanIsStateless: Detect holds no cache — a changed PATH is reflected on
+// the next call (the picker's `r` re-scan).
+func TestDetectRescanIsStateless(t *testing.T) {
+	probe := func(string) (string, error) { return "aider 0.86.1", nil }
+	if got := Detect(Env{LookPath: notFound, Probe: probe}); len(got) != 0 {
+		t.Fatalf("empty PATH must detect nothing, got %v", detectionNames(got))
+	}
+	got := Detect(Env{LookPath: lookup(map[string]string{"aider": "/home/u/.local/bin/aider"}), Probe: probe})
+	if names := detectionNames(got); !reflect.DeepEqual(names, []string{"aider"}) {
+		t.Fatalf("re-scan must reflect the changed PATH, got %v", names)
+	}
+}
+
+// TestDetectBoundedProbe: a wedged `--version` cannot hang the scan — the Probe seam is
+// bounded by the caller contract; Detect must complete promptly when the probe errors at
+// its deadline (the seam returns the timeout error; Detect never retries or blocks).
+func TestDetectBoundedProbe(t *testing.T) {
+	start := time.Now()
+	got := Detect(Env{
+		LookPath: lookup(map[string]string{"hermes": "/home/u/.local/bin/hermes"}),
+		Probe:    func(string) (string, error) { return "", errors.New("probe deadline exceeded") },
+	})
+	if elapsed := time.Since(start); elapsed >= 2*time.Second {
+		t.Fatalf("the scan must not block, took %v", elapsed)
+	}
+	if len(got) != 1 || !got[0].Unverified {
+		t.Fatalf("a deadline-exceeded probe degrades to unverified, got %+v", got)
+	}
+}
+
+// TestParseVersion is the raw-output table across the real formats observed on the dev
+// box (detection.feature scenario outline).
+func TestParseVersion(t *testing.T) {
+	cases := []struct {
+		guest, raw, want string
+		ok               bool
+	}{
+		{"opencode", "1.17.11", "1.17.11", true},
+		{"opencode", "1.17.11\n", "1.17.11", true},
+		{"hermes", "Hermes Agent v0.16.0 (2026.6.5) · upstream 9688c1a9", "0.16.0", true},
+		{"aider", "aider 0.86.1", "0.86.1", true},
+		{"opencode", "", "", false},
+		{"hermes", "Traceback (most recent call last): ...", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.guest+"/"+tc.raw, func(t *testing.T) {
+			got, ok := ParseVersion(tc.guest, tc.raw)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("ParseVersion(%q, %q) = (%q, %v), want (%q, %v)", tc.guest, tc.raw, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// TestReservedRCOperatorKinds pins the Phase 2 wire-name reservations
+// (rc_interlock.feature "reserved operator wire names"): documented constants in
+// internal/protocol/rc.go, NO behavior attached in v1. Asserted here (not in a protocol
+// test file) so the RED compile failure stays contained to this new package.
+func TestReservedRCOperatorKinds(t *testing.T) {
+	if protocol.RCKindOperatorStatus != "operator_status" {
+		t.Fatalf("RCKindOperatorStatus must reserve \"operator_status\"")
+	}
+	if protocol.RCInOperatorHandoff != "operator_handoff" {
+		t.Fatalf("RCInOperatorHandoff must reserve \"operator_handoff\"")
+	}
+	if protocol.RCInOperatorRecall != "operator_recall" {
+		t.Fatalf("RCInOperatorRecall must reserve \"operator_recall\"")
+	}
+}

--- a/internal/protocol/rc.go
+++ b/internal/protocol/rc.go
@@ -36,6 +36,17 @@ const (
 	RCInBackfill  = "backfill"  // ask the host for a transcript snapshot for Viewer
 )
 
+// RESERVED operator wire names (Guest Operators Phase 2, founder ruling 7, 2026-07-07).
+// v1 attaches NO behavior to any of these: a guest-operator handoff is announced with plain
+// RCKindStatus frames (carrying RCFrame.Operator additively). The names are reserved NOW so
+// old hosts and future surfaces can never collide on them later (the persistent-state
+// lesson: additive, idempotent wire evolution).
+const (
+	RCKindOperatorStatus = "operator_status"  // future dedicated operator-state frame kind
+	RCInOperatorHandoff  = "operator_handoff" // future remote-initiated handoff inbound kind
+	RCInOperatorRecall   = "operator_recall"  // future remote "give the DJ the mic back" inbound kind
+)
+
 // RCFrame is one broker-relayed event on a remote-control session. NEVER persisted at rest;
 // it lives only in transit and in the broker's bounded transient replay ring.
 type RCFrame struct {
@@ -50,6 +61,7 @@ type RCFrame struct {
 	Approve   *bool  `json:"approve,omitempty"`    // confirm_done: the answer (pointer distinguishes unset)
 	Viewer    string `json:"viewer,omitempty"`     // backfill: the ONE addressed viewer id (others skip)
 	HostUp    *bool  `json:"host_up,omitempty"`    // status: host reachable? (pointer distinguishes unset)
+	Operator  string `json:"operator,omitempty"`   // status: the guest operator at the desk (Phase 2, additive; "" = the DJ)
 }
 
 // RCInbound is what a remote surface (or the broker itself, for backfill) sends TO the host.

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -198,7 +198,9 @@ func (m model) enterAgent() (tea.Model, tea.Cmd) {
 	}
 	m.agentIn.Focus()
 	m.status = stDim.Render("AGENT ready · esc exits")
-	return m, textinput.Blink
+	// Async desk scan (Guest Operators): LookPath + bounded version probes off the event
+	// loop, landing as operatorDetectedMsg - the same pattern as onSharesDetected.
+	return m, tea.Batch(textinput.Blink, operatorScanCmd())
 }
 
 // refreshAgentModel re-resolves the agent's model (open channel, else this session's
@@ -302,6 +304,15 @@ const eventCost = harness.EventKind(1000)
 // other keys feed the prompt input. Because this owns its keys (and never consults
 // presetForKey), a typed `0` is a literal digit, NEVER a re-entry into AGENT.
 func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// A live guest-operator handoff (staging or execing) owns the terminal: no key
+	// reaches the TUI until the exec callback returns the desk.
+	if m.operatorHandoff != nil {
+		return m, nil
+	}
+	// The /operator picker owns every key while open (same modal contract as /model).
+	if m.operatorPicker {
+		return m.onOperatorPickerKey(k)
+	}
 	// The /model picker owns every key while open (arrow + enter to choose, esc to
 	// cancel) so a digit/preset/left-right is NEVER stolen out from under it.
 	if m.agentPicker {
@@ -582,7 +593,7 @@ func (m model) dequeueAgentPrompts() (model, tea.Cmd) {
 // TestAgentCommandRegistrySeam: every entry must dispatch, never "unknown:").
 // Sorted; slash-prefixed canonical names only - short aliases (/dj /y /rc /h) stay
 // typable but are not suggested.
-var agentCommands = []string{"/clear", "/commands", "/copy", "/help", "/model", "/persona", "/remote-control"}
+var agentCommands = []string{"/clear", "/commands", "/copy", "/help", "/model", "/operator", "/persona", "/remote-control"}
 
 // agentSlashCandidates returns the agentCommands entries the input's command word
 // prefix-matches (case-insensitive, PREFIX-only), in registry (sorted) order - the
@@ -684,6 +695,10 @@ func (m model) runAgentCommand(line string) (tea.Model, tea.Cmd) {
 		note("✓ copied the agent transcript to the clipboard")
 		m.status = copiedToast("the agent transcript")
 		return m, clipboardWrite(txt)
+	case "operator", "mic", "guest", "op":
+		// Hand the mic to a guest operator (an installed agent CLI) on the open channel
+		// (Guest Operators Phase 2). Aliases /mic /guest /op are typable, never suggested.
+		return m.runOperatorCommand(fields[1:])
 	case "remote-control", "remote", "rc":
 		// Put THIS session on the air (BASE STATION) — continue it from another surface
 		// logged into your account. `/remote-control off` takes it back off the air.
@@ -695,6 +710,7 @@ func (m model) runAgentCommand(line string) (tea.Model, tea.Cmd) {
 		note("/model switches model · /clear resets · /copy yanks the transcript (⌃y) · /persona shows dj.md · esc exits")
 		note("the agent can read_file / list_dir / web_fetch on its own · write_file / run_shell ask first")
 		note("/remote-control puts this session on your BASE STATION (continue it from any logged-in surface)")
+		note("/operator hands the mic to a guest CLI at the desk (opencode · hermes · aider) on your open channel")
 		return m, nil
 	default:
 		note("unknown: /" + cmd + " · /help for AGENT commands")
@@ -1033,6 +1049,11 @@ func previewClip(s string) string {
 // safe (it leans on the shared styles, which strip color under NO_COLOR, and clips
 // every line to width).
 func (m model) agentView(w int) string {
+	// A guest-operator handoff in staging owns the whole screen: the ONE staged
+	// PATCHING YOU THROUGH paint before the exec (anti-blank, operator.go).
+	if m.operatorHandoff != nil {
+		return m.operatorPatchView(w)
+	}
 	var b strings.Builder
 	mdl := ""
 	root := "."
@@ -1093,6 +1114,12 @@ func (m model) agentView(w int) string {
 	m.agentVP.SetContent(content)
 	if m.agentVP.Height > 0 {
 		b.WriteString(m.agentVP.View() + "\n")
+	}
+	// The /operator hand-the-mic picker (Guest Operators Phase 2): same modal shape as
+	// the /model picker directly below.
+	if m.operatorPicker {
+		b.WriteString(m.operatorPickerView(w))
+		return b.String()
 	}
 	// The /model picker: a small modal list of selectable models (recent / last-tuned +
 	// on-air bands). The cursor row is reverse-video with a carat, matching the band /

--- a/internal/tui/agent_slash_complete_test.go
+++ b/internal/tui/agent_slash_complete_test.go
@@ -66,7 +66,7 @@ func lineAbovePrompt(t *testing.T, tm tea.Model) string {
 }
 
 // allCommandsStrip is the full sorted registry as the strip renders it on a bare "/".
-const allCommandsStrip = "/clear · /commands · /copy · /help · /model · /persona · /remote-control"
+const allCommandsStrip = "/clear · /commands · /copy · /help · /model · /operator · /persona · /remote-control"
 
 // TestAgentSlashStripMatrix drives the strip with real typed keys: which commands it
 // suggests for what input, and when it hides. Matching is case-insensitive and

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -1,0 +1,520 @@
+package tui
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rogerai-fyi/roger/internal/client"
+	"github.com/rogerai-fyi/roger/internal/glyphs"
+	"github.com/rogerai-fyi/roger/internal/operator"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// operator.go is the TUI glue for Guest Operators Phase 2 (THE DESK): the /operator
+// command + picker, the staged PATCHING YOU THROUGH handoff via tea.ExecProcess, the
+// return-to-the-desk summary, and the remote-control interlock hooks. Everything pure
+// (registry / detection / config materialization) lives in internal/operator; this file
+// keeps only command, picker, and exec glue. Specs: features/operator/*.feature
+// (founder-approved 2026-07-07); design: rogerai-internal-docs/GUEST-OPERATORS.md.
+
+// --- seams (package vars so the BDD drives the real model with no mocks) -------------
+
+var (
+	// operatorDetectEnv supplies the detection Env (real PATH by default); the picker's
+	// r re-scan and the AGENT-entry scan both read it live.
+	operatorDetectEnv = operator.DefaultEnv
+	// operatorExec issues the child-process command (tea.ExecProcess in production; the
+	// BDD records the composed *exec.Cmd instead of suspending the test terminal).
+	operatorExec = func(c *exec.Cmd, fn func(error) tea.Msg) tea.Cmd {
+		return tea.ExecProcess(c, fn)
+	}
+	// operatorTermOut receives the defensive terminal-reset preamble on return.
+	operatorTermOut io.Writer = os.Stdout
+	// operatorScratchRoot overrides where session scratch dirs are minted ("" = os.TempDir()).
+	operatorScratchRoot = ""
+	// operatorStageDelay is one beat of PATCHING YOU THROUGH: the staged frame is
+	// GUARANTEED painted before the exec cmd is issued (anti-blank - the exec must never
+	// cut from a stale screen to a foreign TUI).
+	operatorStageDelay = 450 * time.Millisecond
+)
+
+// operatorStaleAge: scratch dirs older than this are crash leftovers, swept at the next
+// desk scan (a crash of roger itself is the only path that leaks one).
+const operatorStaleAge = 24 * time.Hour
+
+// operatorResetSeq is the defensive terminal reset run on EVERY return from a guest
+// (empirically needed - a guest TUI can leave any combination of modes on): pop the kitty
+// keyboard protocol, disable all mouse reporting modes, exit bracketed paste. What the
+// radio itself uses (mouse cell motion) is re-enabled AFTER this, only if the user has
+// the mouse on (m.mouseOff is respected).
+const operatorResetSeq = "\x1b[<u" + // pop the kitty keyboard protocol
+	"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" + // all mouse reporting off
+	"\x1b[?2004l" // exit bracketed paste
+
+// --- messages -------------------------------------------------------------------------
+
+type operatorDetectedMsg struct{ ds []operator.Detection } // an async desk scan landed
+type operatorExecMsg struct{}                              // the staged paint elapsed; issue the exec
+type operatorDoneMsg struct{ err error }                   // the ExecProcess return callback
+
+// operatorHandoff is the live handoff state: staging (the PATCHING plate is up) until
+// execing flips, then the guest has the terminal until operatorDoneMsg.
+type operatorHandoff struct {
+	det     operator.Detection
+	launch  operator.Launch
+	cleanup func() error
+	start   time.Time
+	execing bool
+}
+
+// operatorRow is one picker row: the resident DJ, a detected guest, or the single dim
+// not-installed suggestion at the bottom (which the cursor skips).
+type operatorRow struct {
+	label      string
+	det        operator.Detection
+	isDJ       bool
+	suggestion bool
+	hint       string
+}
+
+// --- detection ------------------------------------------------------------------------
+
+// operatorScanCmd scans the desk asynchronously (the onSharesDetected pattern): sweep
+// stale crash leftovers, then LookPath + bounded version-probe every registry guest.
+func operatorScanCmd() tea.Cmd {
+	return func() tea.Msg {
+		root := operatorScratchRoot
+		if root == "" {
+			root = os.TempDir()
+		}
+		operator.SweepStale(root, operatorStaleAge)
+		return operatorDetectedMsg{ds: operator.Detect(operatorDetectEnv())}
+	}
+}
+
+// onOperatorDetected folds an async desk scan into the model; an open picker re-derives
+// its rows in place (the r re-scan) with the cursor clamped to a selectable row.
+func (m model) onOperatorDetected(msg operatorDetectedMsg) (tea.Model, tea.Cmd) {
+	m.operatorDetections = msg.ds
+	if m.operatorPicker {
+		m.operatorRows = m.buildOperatorRows()
+		if m.operatorCursor >= len(m.operatorRows) {
+			m.operatorCursor = 0
+		}
+		m.operatorCursor = operatorNearestSelectable(m.operatorRows, m.operatorCursor)
+	}
+	return m, nil
+}
+
+// --- the /operator command -----------------------------------------------------------
+
+// runOperatorCommand dispatches /operator (aliases /mic /guest /op): bare opens the
+// picker (never a zero-row one - §3), a name direct-jumps like /model <name>. Unknown
+// names are a local note, NEVER a chat turn (no spend from a typo).
+func (m model) runOperatorCommand(args []string) (tea.Model, tea.Cmd) {
+	if len(args) == 0 {
+		if len(m.operatorDetections) == 0 {
+			m.rcNote("no guests at the desk - a guest operator is an agent CLI on your PATH (opencode · hermes · aider)")
+			return m, nil
+		}
+		m.operatorPicker = true
+		m.operatorRows = m.buildOperatorRows()
+		m.operatorCursor = 0
+		return m, nil
+	}
+	want := strings.ToLower(args[0])
+	for _, d := range m.operatorDetections {
+		if strings.ToLower(d.Guest.Name) == want {
+			return m.startOperatorHandoff(d)
+		}
+	}
+	for _, g := range operator.Registry() {
+		if strings.ToLower(g.Name) == want {
+			m.rcNote(g.Name + " is not at the desk · get it: " + g.InstallHint)
+			return m, nil
+		}
+	}
+	m.rcNote(args[0] + " is not a known operator - /operator lists the desk")
+	return m, nil
+}
+
+// buildOperatorRows derives the picker rows: the resident DJ first, every detected guest
+// in registry order, then AT MOST ONE dim not-installed suggestion at the bottom - and
+// only while the desk is sparse (a single guest). A healthy desk (2+ guests) advertises
+// nothing (operator_command.feature: with opencode+aider detected the rows are exactly
+// DJ · opencode · aider).
+func (m model) buildOperatorRows() []operatorRow {
+	rows := []operatorRow{{label: "DJ", isDJ: true}}
+	seen := map[string]bool{}
+	for _, d := range m.operatorDetections {
+		rows = append(rows, operatorRow{label: d.Guest.Name, det: d})
+		seen[d.Guest.Name] = true
+	}
+	if len(m.operatorDetections) < 2 {
+		for _, g := range operator.Registry() {
+			if !seen[g.Name] {
+				rows = append(rows, operatorRow{label: g.Name, suggestion: true, hint: g.InstallHint})
+				break // at most ONE suggestion row
+			}
+		}
+	}
+	return rows
+}
+
+// operatorNearestSelectable clamps a cursor onto a non-suggestion row (preferring the
+// row itself, then upward) - the cursor is NEVER on the suggestion row.
+func operatorNearestSelectable(rows []operatorRow, i int) int {
+	for j := i; j >= 0; j-- {
+		if j < len(rows) && !rows[j].suggestion {
+			return j
+		}
+	}
+	return 0
+}
+
+// onOperatorPickerKey owns EVERY key while the picker is open (the /model modal
+// contract): cursor rows skip the suggestion, enter picks, r re-scans, esc keeps the DJ.
+func (m model) onOperatorPickerKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
+	closePicker := func() {
+		m.operatorPicker = false
+		m.operatorRows = nil
+	}
+	switch k.String() {
+	case "up", "k":
+		for i := m.operatorCursor - 1; i >= 0; i-- {
+			if !m.operatorRows[i].suggestion {
+				m.operatorCursor = i
+				break
+			}
+		}
+		return m, nil
+	case "down", "j":
+		for i := m.operatorCursor + 1; i < len(m.operatorRows); i++ {
+			if !m.operatorRows[i].suggestion {
+				m.operatorCursor = i
+				break
+			}
+		}
+		return m, nil
+	case "r":
+		// Re-scan the desk in place; the rows re-derive when the scan lands.
+		return m, operatorScanCmd()
+	case "enter":
+		if m.operatorCursor < 0 || m.operatorCursor >= len(m.operatorRows) {
+			return m, nil
+		}
+		row := m.operatorRows[m.operatorCursor]
+		closePicker()
+		switch {
+		case row.isDJ:
+			m.rcNote("the DJ keeps the mic")
+			return m, nil
+		case row.det.Guest.NeedsSetup:
+			// Installed-but-not-configured (reserved for the future claude row): a setup
+			// note, never an exec.
+			note := row.det.Guest.SetupNote
+			if note == "" {
+				note = row.label + " needs setup before it can take the mic"
+			}
+			m.rcNote(note)
+			return m, nil
+		default:
+			return m.startOperatorHandoff(row.det)
+		}
+	case "esc":
+		closePicker()
+		m.rcNote("the DJ keeps the mic")
+		return m, nil
+	default:
+		return m, nil // the picker is modal - swallow everything else
+	}
+}
+
+// operatorPickerView renders the hand-the-mic modal (clones the /model picker shape:
+// cursor carat row, pad() cells, truncVisible clamp, dim hint footer).
+func (m model) operatorPickerView(w int) string {
+	var b strings.Builder
+	mdl := ""
+	if m.proxyHolder != nil {
+		mdl = m.proxyHolder.Get().Model
+	}
+	tail := ""
+	if mdl != "" {
+		tail = " - the guest runs on " + mdl + ", through your open channel"
+	}
+	b.WriteString("\n" + truncVisible("  "+stSelText.Render("hand the mic")+stDim.Render(tail), w) + "\n")
+	for i, row := range m.operatorRows {
+		switch {
+		case row.suggestion:
+			b.WriteString(truncVisible("  "+stDim.Render("   "+pad(row.label, 12)+" not at the desk · get it: "+row.hint), w) + "\n")
+		case i == m.operatorCursor:
+			b.WriteString(truncVisible("  "+stSelText.Render(" ▸ "+pad(row.label, 12))+" "+operatorRowGlyph(row)+stDim.Render(operatorRowDetail(row)), w) + "\n")
+		default:
+			b.WriteString(truncVisible("  "+stDim.Render("   "+pad(row.label, 12)+" ")+operatorRowGlyph(row)+stDim.Render(operatorRowDetail(row)), w) + "\n")
+		}
+	}
+	hint := "↑↓ pick · ⏎ hand the mic · r re-scan the desk · esc keep the DJ"
+	if m.narrow() {
+		hint = "↑↓ · ⏎ · r · esc"
+	}
+	b.WriteString(truncVisible("  "+stDim.Render(hint), w) + "\n")
+	return b.String()
+}
+
+// operatorBrandBlock renders a guest's optional ASCII wordmark for the PATCHING screen,
+// each line width-clamped and tinted with the brand accent (house key style when unset).
+// "" when the registry carries no plate - the seam costs nothing until the art lands.
+func operatorBrandBlock(g operator.Guest, w int) string {
+	if g.BrandPlate == "" {
+		return ""
+	}
+	st := operatorBrandStyle(g.BrandAccent)
+	var b strings.Builder
+	for _, line := range strings.Split(strings.TrimRight(g.BrandPlate, "\n"), "\n") {
+		b.WriteString(truncVisible("  "+st.Render(line), w) + "\n")
+	}
+	return b.String()
+}
+
+// operatorBrandStyle maps a registry accent to a render style (the house stKey when "").
+// Accents are data ("#fab387" / an ANSI-256 index); NO_COLOR stripping still applies.
+func operatorBrandStyle(accent string) lipgloss.Style {
+	if accent == "" {
+		return stKey
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(accent))
+}
+
+// operatorRowGlyph is the optional per-brand picker-row glyph (one cell + a space), "".
+func operatorRowGlyph(row operatorRow) string {
+	if row.det.Guest.BrandGlyph == "" {
+		return ""
+	}
+	return operatorBrandStyle(row.det.Guest.BrandAccent).Render(row.det.Guest.BrandGlyph) + " "
+}
+
+// operatorRowDetail is the dim descriptor cell for a selectable picker row.
+func operatorRowDetail(row operatorRow) string {
+	if row.isDJ {
+		return "resident · the house agent · stays in the TUI"
+	}
+	d := "guest · patches into your open channel · billed as usual"
+	if row.det.Guest.NeedsSetup {
+		d = "needs setup first - pick it to see how"
+	} else if row.det.Unverified {
+		v := row.det.Version
+		if v == "" {
+			v = "unknown"
+		}
+		d += " · version " + v + " unproven"
+	}
+	return d
+}
+
+// --- the handoff ----------------------------------------------------------------------
+
+// startOperatorHandoff gates the handoff on the channel actually carrying it, then puts
+// up ONE staged PATCHING YOU THROUGH paint before the exec is issued (anti-blank).
+func (m model) startOperatorHandoff(d operator.Detection) (tea.Model, tea.Cmd) {
+	// No band tuned: a disconnected proxy REFUSES to spend (Phase 1 ruling 5), so a
+	// launch now would only hand the guest a wall of 502s - block it at the desk.
+	if m.proxyHolder == nil || !m.proxyHolder.Connected() {
+		m.agentLines = append(m.agentLines,
+			stRed.Render("✕ ")+stEmber.Render("no channel to patch into - a guest runs on your open channel"),
+			stDim.Render("· ")+stDim.Render("tune in first: press ")+stKey.Render("[1]")+stDim.Render(", ⏎ on a band opens the channel · then come back with ")+stKey.Render("[0]"))
+		return m, nil
+	}
+	// The DJ's in-flight turn owns the completer and the terminal; a queued prompt
+	// would drain into a new turn against a suspended TUI - both block the handoff.
+	if m.agentBusy || (m.agent != nil && m.agent.running.Load()) {
+		m.rcNote("the DJ is mid-turn - let it finish (esc cancels), then hand off")
+		return m, nil
+	}
+	if len(m.agentQueued) > 0 {
+		m.rcNote("prompts are queued for the DJ - let the queue drain, then hand off")
+		return m, nil
+	}
+	m.operatorPicker = false
+	m.operatorRows = nil
+	m.operatorHandoff = &operatorHandoff{det: d}
+	m.status = stDim.Render("patching you through to " + d.Guest.Name + "…")
+	// One beat of staging: the plate paints, THEN operatorExecMsg issues the exec.
+	return m, tea.Tick(operatorStageDelay, func(time.Time) tea.Msg { return operatorExecMsg{} })
+}
+
+// onOperatorExec materializes the wiring from the LIVE proxy options, arms the fresh
+// per-handoff budget, parks the remote-control bridge, and issues the exec command.
+func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
+	h := m.operatorHandoff
+	if h == nil || h.execing {
+		return m, nil
+	}
+	if m.proxyHolder == nil { // defensive: staging outlived the proxy
+		m.operatorHandoff = nil
+		return m, nil
+	}
+	// Re-check the DJ-idle preconditions AT EXEC TIME (audit regression): the bridge
+	// parks only now, so a turn injected during the staging beat would otherwise run -
+	// and bill - under the suspended TUI, into the guest's freshly reset accumulator.
+	if m.agentBusy || (m.agent != nil && m.agent.running.Load()) || len(m.agentQueued) > 0 {
+		m.operatorHandoff = nil
+		m.rcNote("handoff aborted - the DJ picked up a turn while patching · /operator again once it finishes")
+		m.status = stDim.Render("back at the desk · the DJ is standing by")
+		return m, nil
+	}
+	// LIVE options at exec time - never the options frozen at first bind.
+	opts := m.proxyHolder.Get()
+	sess := operator.Session{
+		BaseURL: m.endpoint, SessionKey: opts.SessionKey, Model: opts.Model,
+		Workdir: agentRoot(), ScratchRoot: operatorScratchRoot,
+	}
+	launch, cleanup, err := operator.Materialize(h.det.Guest, sess)
+	if err != nil {
+		m.operatorHandoff = nil
+		m.agentLines = append(m.agentLines, stRed.Render("✕ ")+stEmber.Render("couldn't hand the mic off: "+err.Error()))
+		m.status = stDim.Render("back at the desk · the DJ is standing by")
+		return m, nil
+	}
+	// Fresh money state per handoff (ruling 4): the $2 default budget, zero spend, zero
+	// calls - the summary and the 402 ceiling are THIS guest's numbers. The bearer key
+	// is NOT rotated (a re-tune mid-session keeps the guest's config working).
+	m.proxyHolder.SetBudget(client.DefaultSessionBudget)
+	m.proxyHolder.ResetSpend()
+	m.proxyHolder.ResetCalls()
+	h.launch, h.cleanup, h.start, h.execing = launch, cleanup, time.Now(), true
+	// BASE STATION interlock: announce the handoff, then PARK the bridge BEFORE the exec
+	// cmd is returned - inbound remote turns are dropped at the bridge with a status
+	// auto-frame (never queued, never replayed), backfill is answered from this snapshot.
+	if m.rcBridge != nil {
+		m.rcEmit(client.OperatorStatusFrame(h.det.Guest.Name))
+		m.rcBridge.Park(h.det.Guest.Name, m.agentTranscriptText())
+	}
+	c := operator.Command(launch, h.det.Path, sess.Workdir, os.Environ())
+	return m, operatorExec(c, func(err error) tea.Msg { return operatorDoneMsg{err: err} })
+}
+
+// onOperatorDone is the return to the desk - it runs for EVERY child outcome: defensive
+// terminal reset, scratch cleanup, bridge unpark + status frame, balance refresh, and the
+// honest one-line summary read from the proxy accumulator (never the child's claims).
+func (m model) onOperatorDone(msg operatorDoneMsg) (tea.Model, tea.Cmd) {
+	h := m.operatorHandoff
+	m.operatorHandoff = nil
+	if h == nil {
+		return m, nil
+	}
+	if h.cleanup != nil {
+		_ = h.cleanup() // every return path cleans the scratch config
+	}
+	// Defensive terminal reset FIRST (the guest may have left kitty-kbd / mouse /
+	// bracketed-paste modes on), then re-enable only what the radio uses (below).
+	_, _ = io.WriteString(operatorTermOut, operatorResetSeq)
+	// Unpark the bridge and announce the DJ is back. Nil-safe and dead-bridge-safe: a
+	// revoke-all mid-handoff Stops the bridge; Unpark/Emit are no-ops then.
+	if m.rcBridge != nil {
+		m.rcBridge.Unpark()
+		m.rcEmit(protocol.RCFrame{Kind: protocol.RCKindStatus, Text: "the DJ is back at the desk"})
+	}
+	guest := h.det.Guest.Name
+	cmds := []tea.Cmd{fetchBalance(m.broker, m.user)}
+	if !m.mouseOff {
+		cmds = append(cmds, tea.EnableMouseCellMotion)
+	}
+	// The summary numbers come from the proxy accumulator (duration is measured here),
+	// and the interactive TUI goes back to UNCAPPED (Phase 1: Budget 0 for the hands-on
+	// flow) on EVERY return path - including a spawn failure (audit regression: the
+	// early return used to leave the DJ session parked at the guest's $2 cap).
+	var spend float64
+	var calls int64
+	budget := 0.0
+	if m.proxyHolder != nil {
+		spend, calls = m.proxyHolder.Spent(), m.proxyHolder.Calls()
+		budget = m.proxyHolder.Get().Budget
+		m.proxyHolder.SetBudget(0)
+	}
+	// A spawn failure (the exec never started) is the one true error note.
+	var ee *exec.ExitError
+	if msg.err != nil && !errors.As(msg.err, &ee) {
+		m.agentLines = append(m.agentLines, stRed.Render("✕ ")+stEmber.Render("couldn't hand the mic off to "+guest+": "+msg.err.Error()))
+		m.status = stDim.Render("back at the desk · the DJ is standing by")
+		return m, tea.Batch(cmds...)
+	}
+	summary := guest + " had the mic for " + operatorFmtDur(time.Since(h.start)) +
+		" · " + plural(int(calls), "call") + " · " + fmt.Sprintf("$%.2f", spend)
+	if ee != nil {
+		// A guest quitting (Ctrl-C = 130, any non-zero, or a signal) is NORMAL radio
+		// traffic: the calm house ✕, never a scary escalation.
+		drop := "the guest dropped off - back at the desk"
+		if code := ee.ExitCode(); code >= 0 {
+			drop = fmt.Sprintf("the guest dropped off (exit %d) - back at the desk", code)
+		}
+		m.agentLines = append(m.agentLines, stRed.Render("✕ ")+stEmber.Render(drop))
+		m.rcNote(summary)
+	} else {
+		m.agentLines = append(m.agentLines, stDim.Render("· ")+stDim.Render("back at the desk · ")+stDim.Render(summary)+stDim.Render(" · the DJ is standing by"))
+	}
+	if budget > 0 && spend >= budget-1e-9 {
+		// "The guest went quiet" must never be a mystery: the ceiling was the reason.
+		m.agentLines = append(m.agentLines, stDim.Render("· ")+stEmber.Render("the session budget was reached")+stDim.Render(" - the proxy answered 402 past "+fmt.Sprintf("$%.2f", budget)))
+	}
+	m.status = stDim.Render("back at the desk · the DJ is standing by")
+	return m, tea.Batch(cmds...)
+}
+
+// operatorFmtDur renders a mic-time duration radio-style: 42s / 14m / 1h05m.
+func operatorFmtDur(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%dh%02dm", int(d.Hours()), int(d.Minutes())%60)
+	}
+}
+
+// operatorPatchView is the ONE staged PATCHING YOU THROUGH paint (the connectingView
+// staging discipline): mic-to / on-band / wire lines + the live BASE URL / MODEL plate,
+// painted before the exec so the cut to the guest TUI is never from a stale screen.
+func (m model) operatorPatchView(w int) string {
+	h := m.operatorHandoff
+	if h == nil {
+		return ""
+	}
+	mdl := ""
+	if m.proxyHolder != nil {
+		mdl = m.proxyHolder.Get().Model
+	}
+	var b strings.Builder
+	b.WriteString("  " + stSelBar.Render("▌") + " " + stBrand.Render("AGENT") + stDim.Render(" · handing off") +
+		"      " + stRed.Render(glyphs.Fold("((•))")) + "  " + stBrand.Render("PATCHING YOU THROUGH…") + "\n\n")
+	step := func(label, val, detail string) {
+		line := "  " + stRed.Render(glyphOnAir) + " " + stDim.Render(pad(label, 8)) + stKey.Render(val)
+		if detail != "" {
+			line += stDim.Render("  " + detail)
+		}
+		b.WriteString(truncVisible(line, w) + "\n")
+	}
+	// PER-BRAND PLATE SEAM: the design pass lands each operator's wordmark as data-only
+	// registry changes (Guest.BrandPlate/BrandAccent); the default is the text-only house
+	// style (the name on the mic-to line below carries it until the art exists).
+	if brand := operatorBrandBlock(h.det.Guest, w); brand != "" {
+		b.WriteString(brand + "\n")
+	}
+	step("mic to", h.det.Guest.Name, "(guest operator)")
+	step("on band", mdl, "your open channel · usual relay pricing")
+	step("wire", "config generated in a scratch dir", "your own setup is untouched")
+	row := func(label, value string) string {
+		return "      " + stDim.Render(pad(label, 9)) + stKey.Render(value)
+	}
+	b.WriteString("\n" + truncVisible(row("BASE URL", m.endpoint), w) + "\n")
+	b.WriteString(truncVisible(row("MODEL", mdl), w) + "\n\n")
+	b.WriteString(truncVisible("  "+stDim.Render("the radio steps aside while the guest is on the mic · exit the guest to come back"), w) + "\n")
+	return b.String()
+}

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -367,7 +367,11 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 	// the TUI off AGENT mid-staging - never exec the guest under another modal.
 	if m.mode != modeAgent || m.agentBusy || (m.agent != nil && m.agent.running.Load()) || len(m.agentQueued) > 0 {
 		m.operatorHandoff = nil
-		m.rcNote("handoff aborted - the DJ picked up a turn while patching · /operator again once it finishes")
+		if m.mode != modeAgent {
+			m.rcNote("handoff aborted - you left the desk mid-patch · /operator from AGENT to try again")
+		} else {
+			m.rcNote("handoff aborted - the DJ picked up a turn while patching · /operator again once it finishes")
+		}
 		m.status = stDim.Render("back at the desk · the DJ is standing by")
 		return m, nil
 	}

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -363,7 +363,9 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 	// Re-check the DJ-idle preconditions AT EXEC TIME (audit regression): the bridge
 	// parks only now, so a turn injected during the staging beat would otherwise run -
 	// and bill - under the suspended TUI, into the guest's freshly reset accumulator.
-	if m.agentBusy || (m.agent != nil && m.agent.running.Load()) || len(m.agentQueued) > 0 {
+	// The mode check covers global keys (ctrl+c quit-confirm, alt+m, a preset) pulling
+	// the TUI off AGENT mid-staging - never exec the guest under another modal.
+	if m.mode != modeAgent || m.agentBusy || (m.agent != nil && m.agent.running.Load()) || len(m.agentQueued) > 0 {
 		m.operatorHandoff = nil
 		m.rcNote("handoff aborted - the DJ picked up a turn while patching · /operator again once it finishes")
 		m.status = stDim.Render("back at the desk · the DJ is standing by")

--- a/internal/tui/operator_audit_regression_test.go
+++ b/internal/tui/operator_audit_regression_test.go
@@ -119,3 +119,25 @@ func TestExecRecheckAbortsWhenDJPickedUp(t *testing.T) {
 		t.Fatalf("an aborted handoff must not leave the $%v cap armed (budget=%v)", client.DefaultSessionBudget, b)
 	}
 }
+
+// TestExecAbortsOutsideAgentMode: audit minor (2nd pass). A global key during the
+// staging beat (ctrl+c quit-confirm, alt+m, a preset) can move the TUI off modeAgent;
+// the staged operatorExecMsg must then ABORT, never exec the guest under another modal.
+func TestExecAbortsOutsideAgentMode(t *testing.T) {
+	m, holder, execs := opRegressionSeed(t)
+	var tm tea.Model
+	tm, _ = m.runAgentCommand("/operator opencode")
+	mm := asModel(tm)
+	mm.mode = modeBrowse // a global key pulled the TUI away mid-staging
+	tm, _ = mm.Update(operatorExecMsg{})
+	got := asModel(tm)
+	if len(*execs) != 0 {
+		t.Fatalf("the exec was issued outside AGENT mode")
+	}
+	if got.operatorHandoff != nil {
+		t.Fatalf("the aborted handoff must clear its staging state")
+	}
+	if b := holder.Get().Budget; b != 0 {
+		t.Fatalf("an aborted handoff must not leave the cap armed (budget=%v)", b)
+	}
+}

--- a/internal/tui/operator_audit_regression_test.go
+++ b/internal/tui/operator_audit_regression_test.go
@@ -1,0 +1,121 @@
+package tui
+
+// operator_audit_regression_test.go - permanent regressions for the two money-path bugs
+// the claude-audit pre-push gate caught on the first Phase 2 push (2026-07-06):
+//   (a) the spawn-failure early return skipped the SetBudget(0) restore, leaving the
+//       interactive DJ session capped at the guest's $2 - surprise 402s later;
+//   (b) the 450ms staging window (handoff staged, bridge not yet parked) let a remote
+//       turn start a billed DJ turn that would then run under the suspended TUI and
+//       corrupt the guest's freshly reset accumulator.
+// Candidates for promotion into the approved .feature set at the next founder review.
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rogerai-fyi/roger/internal/client"
+	"github.com/rogerai-fyi/roger/internal/operator"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// opRegressionSeed stages a handoff-capable AGENT model with a live holder and one
+// detected guest, with the exec/scratch seams captured for the test.
+func opRegressionSeed(t *testing.T) (model, *client.ProxyOptionsHolder, *[]*exec.Cmd) {
+	t.Helper()
+	saveExec, saveRoot, saveDelay := operatorExec, operatorScratchRoot, operatorStageDelay
+	var execs []*exec.Cmd
+	operatorExec = func(c *exec.Cmd, _ func(error) tea.Msg) tea.Cmd {
+		execs = append(execs, c)
+		return nil
+	}
+	operatorScratchRoot = t.TempDir()
+	operatorStageDelay = time.Millisecond
+	t.Cleanup(func() { operatorExec, operatorScratchRoot, operatorStageDelay = saveExec, saveRoot, saveDelay })
+
+	m := asModel(agentReady(t))
+	m.proxyHolder = client.NewProxyOptionsHolder(client.ProxyOptions{
+		Broker: "http://127.0.0.1:1", User: "tester", Model: "qwen3-32b-fp8", SessionKey: client.NewSessionKey(),
+	})
+	m.endpoint = "http://127.0.0.1:1/v1"
+	g, _ := func() (operator.Guest, bool) {
+		for _, g := range operator.Registry() {
+			if g.Name == "opencode" {
+				return g, true
+			}
+		}
+		return operator.Guest{}, false
+	}()
+	m.operatorDetections = []operator.Detection{{Guest: g, Path: "/fake/opencode", Version: g.KnownGood}}
+	return m, m.proxyHolder, &execs
+}
+
+// TestSpawnFailureRestoresUncappedBudget: audit finding (a). A spawn failure must leave
+// the interactive session UNCAPPED (Budget 0) like every other return path - never
+// parked at the guest's $2 with the spend zeroed.
+func TestSpawnFailureRestoresUncappedBudget(t *testing.T) {
+	m, holder, _ := opRegressionSeed(t)
+	var tm tea.Model
+	tm, _ = m.runAgentCommand("/operator opencode")
+	tm, _ = tm.Update(operatorExecMsg{})
+	if got := holder.Get().Budget; got != client.DefaultSessionBudget {
+		t.Fatalf("handoff must arm the $%v budget, got %v", client.DefaultSessionBudget, got)
+	}
+	// The exec never started: bubbletea delivers a non-ExitError to the callback.
+	tm, _ = tm.Update(operatorDoneMsg{err: &exec.Error{Name: "opencode", Err: exec.ErrNotFound}})
+	if got := asModel(tm).proxyHolder.Get().Budget; got != 0 {
+		t.Fatalf("spawn failure left the DJ session capped at $%v (want uncapped 0) - later turns would 402", got)
+	}
+}
+
+// TestStagingWindowRemoteTurnDropped: audit finding (b), host side. A remote turn landing
+// AFTER the handoff is staged but BEFORE the bridge parks must be dropped with the
+// "guest has the mic" status frame - never queued, never a DJ turn.
+func TestStagingWindowRemoteTurnDropped(t *testing.T) {
+	m, _, _ := opRegressionSeed(t)
+	fb := newFakeBridge()
+	m.rcBridge = fb
+	var tm tea.Model
+	tm, _ = m.runAgentCommand("/operator opencode") // staged; NOT yet execed/parked
+	tm, _ = tm.Update(remoteInboundMsg(protocol.RCInbound{Kind: protocol.RCInTurn, Text: "sneaky staging turn", Origin: "phone"}))
+	got := asModel(tm)
+	if got.agentBusy || len(got.agentQueued) != 0 {
+		t.Fatalf("a staging-window remote turn started/queued a DJ turn (busy=%v queue=%v)", got.agentBusy, got.agentQueued)
+	}
+	if v := stripANSI(got.View()); strings.Contains(v, "sneaky staging turn") {
+		t.Fatalf("the dropped turn reached the transcript")
+	}
+	sawStatus := false
+	for _, f := range fb.emitted {
+		if f.Kind == protocol.RCKindStatus && f.Operator == "opencode" {
+			sawStatus = true
+		}
+	}
+	if !sawStatus {
+		t.Fatalf("the sender must be told the guest has the mic (frames: %+v)", fb.emitted)
+	}
+}
+
+// TestExecRecheckAbortsWhenDJPickedUp: audit finding (b), belt half. Even if a turn DID
+// slip in during staging, onOperatorExec must re-check the DJ-idle preconditions and
+// abort rather than exec over a live turn (billing it into the guest's accumulator).
+func TestExecRecheckAbortsWhenDJPickedUp(t *testing.T) {
+	m, holder, execs := opRegressionSeed(t)
+	var tm tea.Model
+	tm, _ = m.runAgentCommand("/operator opencode")
+	mm := asModel(tm)
+	mm.agentBusy = true // a turn slipped in during the staging beat
+	tm, _ = mm.Update(operatorExecMsg{})
+	got := asModel(tm)
+	if len(*execs) != 0 {
+		t.Fatalf("the exec was issued over a live DJ turn")
+	}
+	if got.operatorHandoff != nil {
+		t.Fatalf("the aborted handoff must clear its staging state")
+	}
+	if b := holder.Get().Budget; b != 0 {
+		t.Fatalf("an aborted handoff must not leave the $%v cap armed (budget=%v)", client.DefaultSessionBudget, b)
+	}
+}

--- a/internal/tui/operator_bdd_test.go
+++ b/internal/tui/operator_bdd_test.go
@@ -1,0 +1,55 @@
+package tui
+
+// operator_bdd_test.go - the godog harness for the Guest Operators Phase 2 spec set
+// (features/operator/*.feature, founder-approved 2026-07-07). GREEN wiring: step
+// definitions split by ownership - detection/config scenarios bind against
+// internal/operator (pure package, real filesystem), command/picker/handoff/interlock
+// scenarios drive the REAL bubbletea model (the rc_confirm_bdd_test.go pattern) with a
+// REAL ProxyOptionsHolder + hardened proxy over a stub billing broker and a REAL
+// client.RCBridge polling a stub RC broker. The only test seams are the operator.go
+// package seams (exec, terminal writer, scratch root, detect env, stage delay) - the
+// production paths run for real underneath them, no mocks.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/operator"
+)
+
+func TestGuestOperatorBDD(t *testing.T) {
+	// Sandbox the process HOME/config for the duration: the real money path signs relay
+	// requests with the local user key (LoadOrCreateUserKey) and must never touch the
+	// developer's real config.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	st := &opBDD{}
+
+	// Rebind the operator seams at the suite boundary and restore after: the exec seam
+	// records the composed child command instead of suspending the test terminal; the
+	// terminal writer captures the reset preamble; the detect env resolves each
+	// scenario's declared PATH; the stage delay shrinks so picker-enter round-trips fast.
+	saveExec, saveTerm, saveEnv, saveRoot, saveDelay :=
+		operatorExec, operatorTermOut, operatorDetectEnv, operatorScratchRoot, operatorStageDelay
+	operatorExec = st.seamExec
+	operatorTermOut = opTermTap{st}
+	operatorDetectEnv = func() operator.Env { return st.tuiDetectEnv() }
+	operatorStageDelay = 5 * time.Millisecond
+	t.Cleanup(func() {
+		operatorExec, operatorTermOut, operatorDetectEnv, operatorScratchRoot, operatorStageDelay =
+			saveExec, saveTerm, saveEnv, saveRoot, saveDelay
+		st.closeServers()
+	})
+
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			initializeOperatorScenarios(t, st, sc)
+		},
+		Options: &godog.Options{Format: "pretty", Paths: []string{"../../features/operator"}, TestingT: t, Strict: true},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("guest-operator scenarios failed (see godog output above)")
+	}
+}

--- a/internal/tui/operator_brand_test.go
+++ b/internal/tui/operator_brand_test.go
@@ -1,0 +1,74 @@
+package tui
+
+// operator_brand_test.go - the per-brand presence SEAM (founder direction 2026-07-06):
+// each registry entry can carry a data-only BrandPlate/BrandAccent/BrandGlyph that the
+// PATCHING YOU THROUGH screen and the picker render inside RogerAI's frame. The art pass
+// lands as registry data; these tests pin that the seam renders it without any change to
+// the transition logic, and that the EMPTY default stays the text-only house style.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/operator"
+)
+
+// brandGuestDetection builds a detection for a fake guest carrying brand data.
+func brandGuestDetection() operator.Detection {
+	return operator.Detection{
+		Guest: operator.Guest{
+			Name: "opencode", Bin: "opencode", Provider: "openai",
+			InstallHint: "x", KnownGood: "1.17.11", Strategy: operator.StrategyScratchConfig,
+			BrandPlate:  "█▀█ █▀█ █▀▀ █▄░█\n█▄█ █▀▀ ██▄ █░▀█",
+			BrandAccent: "#fab387",
+			BrandGlyph:  "◆",
+		},
+		Path: "/fake/opencode", Version: "1.17.11",
+	}
+}
+
+// TestOperatorBrandPlateRenders: a registry BrandPlate lands on the PATCHING screen
+// between the header and the wire plate; no logic change needed (data-only seam).
+func TestOperatorBrandPlateRenders(t *testing.T) {
+	m := asModel(agentReady(t))
+	m.operatorHandoff = &operatorHandoff{det: brandGuestDetection()}
+	view := stripANSI(m.operatorPatchView(120))
+	if !strings.Contains(view, "█▀█ █▀█ █▀▀ █▄░█") || !strings.Contains(view, "█▄█ █▀▀ ██▄ █░▀█") {
+		t.Fatalf("the brand plate lines must render on the PATCHING screen:\n%s", view)
+	}
+	head := strings.Index(view, "PATCHING YOU THROUGH")
+	plate := strings.Index(view, "█▀█")
+	mic := strings.Index(view, "mic to")
+	if !(head < plate && plate < mic) {
+		t.Fatalf("plate must sit between the header and the mic-to line (head=%d plate=%d mic=%d)", head, plate, mic)
+	}
+}
+
+// TestOperatorBrandDefaultUnchanged: no BrandPlate = the text-only house default, with
+// no stray blank block where the plate would sit.
+func TestOperatorBrandDefaultUnchanged(t *testing.T) {
+	d := brandGuestDetection()
+	d.Guest.BrandPlate, d.Guest.BrandAccent, d.Guest.BrandGlyph = "", "", ""
+	m := asModel(agentReady(t))
+	m.operatorHandoff = &operatorHandoff{det: d}
+	view := stripANSI(m.operatorPatchView(120))
+	if !strings.Contains(view, "PATCHING YOU THROUGH") || !strings.Contains(view, "mic to") {
+		t.Fatalf("the default patch view must keep the house layout:\n%s", view)
+	}
+	if strings.Contains(view, "█") {
+		t.Fatalf("no brand art may render without registry data:\n%s", view)
+	}
+}
+
+// TestOperatorBrandGlyphInPicker: a BrandGlyph decorates the guest's picker row; rows
+// without one are untouched.
+func TestOperatorBrandGlyphInPicker(t *testing.T) {
+	m := asModel(agentReady(t))
+	m.operatorDetections = []operator.Detection{brandGuestDetection()}
+	m.operatorPicker = true
+	m.operatorRows = m.buildOperatorRows()
+	view := stripANSI(m.operatorPickerView(120))
+	if !strings.Contains(view, "◆") {
+		t.Fatalf("the brand glyph must decorate the guest row:\n%s", view)
+	}
+}

--- a/internal/tui/operator_command_test.go
+++ b/internal/tui/operator_command_test.go
@@ -1,0 +1,91 @@
+package tui
+
+// operator_command_test.go — RED-phase spec tests for the /operator command joining the
+// canonical agentCommands registry (features/operator/operator_command.feature; Guest
+// Operators Phase 2). These tests reference ONLY existing symbols so the tui package
+// still compiles: they fail ASSERTIVELY today ("/operator" is not registered yet), which
+// is the RED evidence. Picker-state and handoff scenarios need new model fields and are
+// carried by the .feature files (the approval artifacts) + the godog runner
+// (operator_bdd_test.go) until GREEN.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOperatorInCommandRegistry: /operator is a first-class registry entry — the strip,
+// /commands, and TestAgentCommandRegistrySeam pick it up from the ONE list
+// (agent.go:585). The aliases follow the /dj //y pattern: typable, never registered.
+func TestOperatorInCommandRegistry(t *testing.T) {
+	seen := map[string]bool{}
+	for _, c := range agentCommands {
+		seen[c] = true
+	}
+	if !seen["/operator"] {
+		t.Fatalf("agentCommands must list /operator (Guest Operators Phase 2), got %v", agentCommands)
+	}
+	for _, alias := range []string{"/mic", "/guest", "/op"} {
+		if seen[alias] {
+			t.Fatalf("alias %s must be typable but NOT registered/suggested (the /dj //y pattern), got %v", alias, agentCommands)
+		}
+	}
+}
+
+// TestOperatorDispatches: /operator and each alias dispatch in runAgentCommand — a
+// suggested or documented command can never come back "unknown:".
+func TestOperatorDispatches(t *testing.T) {
+	for _, cmd := range []string{"/operator", "/mic", "/guest", "/op"} {
+		t.Run(cmd, func(t *testing.T) {
+			m := asModel(agentReady(t))
+			nm, _ := m.runAgentCommand(cmd)
+			if view := stripANSI(asModel(nm).View()); strings.Contains(view, "unknown:") {
+				t.Fatalf("%s must dispatch, runAgentCommand said unknown:\n%s", cmd, view)
+			}
+		})
+	}
+}
+
+// TestOperatorZeroGuestsNote: with no guest detected (the default test model — nothing
+// on the fake desk), bare /operator prints the desk note instead of opening a one-row
+// picker (§3: "zero guests: /operator never opens a one-row picker").
+func TestOperatorZeroGuestsNote(t *testing.T) {
+	m := asModel(agentReady(t))
+	nm, _ := m.runAgentCommand("/operator")
+	view := stripANSI(asModel(nm).View())
+	if !strings.Contains(view, "no guests at the desk") {
+		t.Fatalf("bare /operator with zero guests must print the desk note, got:\n%s", view)
+	}
+}
+
+// TestOperatorUnknownNameIsNoteNotTurn: /operator <garbage> is a local note — it must
+// never be submitted as a chat turn (no spend from a typo).
+func TestOperatorUnknownNameIsNoteNotTurn(t *testing.T) {
+	m := asModel(agentReady(t))
+	nm, _ := m.runAgentCommand("/operator warez9000")
+	got := asModel(nm)
+	if got.agentBusy {
+		t.Fatalf("/operator <unknown> must never start a turn")
+	}
+	view := stripANSI(got.View())
+	if strings.Contains(view, "unknown: /operator") {
+		t.Fatalf("/operator with an argument must dispatch as the operator command:\n%s", view)
+	}
+}
+
+// TestOperatorSlashStripSuggestsCanonicalOnly: typing /o suggests /operator; the
+// aliases never appear in the candidate set (they are not registry entries).
+func TestOperatorSlashStripSuggestsCanonicalOnly(t *testing.T) {
+	cands := agentSlashCandidates("/o")
+	found := false
+	for _, c := range cands {
+		if c == "/operator" {
+			found = true
+		}
+		if c == "/mic" || c == "/guest" {
+			t.Fatalf("aliases must never be suggested, got %v", cands)
+		}
+	}
+	if !found {
+		t.Fatalf("agentSlashCandidates(\"/o\") must include /operator, got %v", cands)
+	}
+}

--- a/internal/tui/operator_steps_pure_test.go
+++ b/internal/tui/operator_steps_pure_test.go
@@ -1,0 +1,765 @@
+package tui
+
+// operator_steps_pure_test.go - godog step definitions for the PURE half of the Guest
+// Operators Phase 2 spec set (features/operator/detection|config_*|config_isolation
+// .feature): they bind directly against internal/operator with a real filesystem
+// (per-scenario sandbox dirs), injected Env seams, and zero mocks. The TUI-driving steps
+// live in operator_steps_tui_test.go; the shared suite state is opBDD (declared there).
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/client"
+	"github.com/rogerai-fyi/roger/internal/operator"
+)
+
+// --- detection env seam ----------------------------------------------------------------
+
+// pureEnv builds an operator.Env over the scenario's configured LookPath / probe tables.
+func (s *opBDD) pureEnv() operator.Env {
+	return operator.Env{
+		LookPath: func(bin string) (string, error) {
+			if err, ok := s.lookErr[bin]; ok {
+				return "", err
+			}
+			if p, ok := s.pathOf[bin]; ok {
+				return p, nil
+			}
+			return "", errors.New("executable file not found in $PATH")
+		},
+		Probe: func(bin string) (string, error) {
+			for name, p := range s.pathOf {
+				if p != bin {
+					continue
+				}
+				if s.probeBlocks[name] {
+					time.Sleep(10 * time.Millisecond) // the bounded seam returns AT the deadline
+					return "", errors.New("probe deadline exceeded")
+				}
+				if err, ok := s.probeErrs[name]; ok {
+					return "", err
+				}
+				if out, ok := s.probeOuts[name]; ok {
+					return out, nil
+				}
+				return "", errors.New("no probe response configured")
+			}
+			return "", errors.New("unknown bin")
+		},
+	}
+}
+
+func (s *opBDD) findDetection(name string) (operator.Detection, bool) {
+	for _, d := range s.ds {
+		if d.Guest.Name == name {
+			return d, true
+		}
+	}
+	return operator.Detection{}, false
+}
+
+func (s *opBDD) detectionNames() []string {
+	var out []string
+	for _, d := range s.ds {
+		out = append(out, d.Guest.Name)
+	}
+	return out
+}
+
+// --- registry steps ----------------------------------------------------------------------
+
+func (s *opBDD) theGuestOperatorRegistry() error { return nil } // Background anchor
+
+func (s *opBDD) registryListsExactly(a, b, c string) error {
+	var names []string
+	for _, g := range operator.Registry() {
+		names = append(names, g.Name)
+	}
+	if want := []string{a, b, c}; !reflect.DeepEqual(names, want) {
+		return fmt.Errorf("registry = %v, want %v", names, want)
+	}
+	return nil
+}
+
+func (s *opBDD) noRegistryEntryNamed(a, b string) error {
+	for _, g := range operator.Registry() {
+		if g.Name == a || g.Name == b {
+			return fmt.Errorf("registry lists excluded entry %q", g.Name)
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) everyEntryCarriesFields() error {
+	for _, g := range operator.Registry() {
+		if g.Name == "" || g.Bin == "" || g.Provider == "" || g.InstallHint == "" || g.KnownGood == "" {
+			return fmt.Errorf("%s: missing field(s) in %+v", g.Name, g)
+		}
+	}
+	return nil
+}
+
+func registryGuest(name string) (operator.Guest, error) {
+	for _, g := range operator.Registry() {
+		if g.Name == name {
+			return g, nil
+		}
+	}
+	return operator.Guest{}, fmt.Errorf("guest %q not in registry", name)
+}
+
+func (s *opBDD) entryUsesStrategyWithVersion(name, strategy, version string) error {
+	g, err := registryGuest(name)
+	if err != nil {
+		return err
+	}
+	if g.Strategy != strategy {
+		return fmt.Errorf("%s strategy = %q, want %q", name, g.Strategy, strategy)
+	}
+	if g.KnownGood != version {
+		return fmt.Errorf("%s known-good = %q, want %q", name, g.KnownGood, version)
+	}
+	return nil
+}
+
+func (s *opBDD) aiderEnvFlagsNoConfig() error {
+	g, err := registryGuest("aider")
+	if err != nil {
+		return err
+	}
+	if g.Strategy != operator.StrategyEnvFlags {
+		return fmt.Errorf("aider strategy = %q, want %q", g.Strategy, operator.StrategyEnvFlags)
+	}
+	return nil
+}
+
+// --- LookPath / probe givens ---------------------------------------------------------------
+
+func (s *opBDD) lookPathResolves(bin, path string) error {
+	s.pathOf[bin] = path
+	delete(s.lookErr, bin)
+	return nil
+}
+
+func (s *opBDD) lookPathFails(bin, msg string) error {
+	delete(s.pathOf, bin)
+	s.lookErr[bin] = errors.New(msg)
+	return nil
+}
+
+func (s *opBDD) lookPathFailsForEverything() error {
+	s.pathOf = map[string]string{}
+	s.lookErr = map[string]error{}
+	return nil
+}
+
+func (s *opBDD) lookPathResolvesEveryRegistryBinary() error {
+	for _, g := range operator.Registry() {
+		s.pathOf[g.Bin] = "/fake/" + g.Bin
+	}
+	return nil
+}
+
+func (s *opBDD) probeAnswers(guest, out string) error {
+	s.probeOuts[guest] = out
+	return nil
+}
+
+func (s *opBDD) probeFails(guest, msg string) error {
+	s.probeErrs[guest] = errors.New(msg)
+	return nil
+}
+
+func (s *opBDD) probeBlocksPastDeadline(guest string) error {
+	s.probeBlocks[guest] = true
+	return nil
+}
+
+// --- the scan --------------------------------------------------------------------------------
+
+// deskScanned runs the sweep + detect exactly like the TUI's desk scan (operatorScanCmd):
+// stale rogerai-operator-* leftovers are swept first, then the registry is detected.
+func (s *opBDD) deskScanned() error {
+	operator.SweepStale(s.scratchRoot, operatorStaleAge)
+	s.ds = operator.Detect(s.pureEnv())
+	return nil
+}
+
+func (s *opBDD) detectionsInOrder(a, b, c string) error {
+	if want := []string{a, b, c}; !reflect.DeepEqual(s.detectionNames(), want) {
+		return fmt.Errorf("detections = %v, want %v", s.detectionNames(), want)
+	}
+	return nil
+}
+
+func (s *opBDD) detectionsExactly(name string) error {
+	if want := []string{name}; !reflect.DeepEqual(s.detectionNames(), want) {
+		return fmt.Errorf("detections = %v, want %v", s.detectionNames(), want)
+	}
+	return nil
+}
+
+func (s *opBDD) detectionsEmpty() error {
+	if len(s.ds) != 0 {
+		return fmt.Errorf("detections = %v, want none", s.detectionNames())
+	}
+	return nil
+}
+
+func (s *opBDD) noErrorSurfaced() error { return nil } // Detect has no error path by design
+
+func (s *opBDD) detectionsInclude(name string) error {
+	if _, ok := s.findDetection(name); !ok {
+		return fmt.Errorf("detections %v do not include %q", s.detectionNames(), name)
+	}
+	return nil
+}
+
+func (s *opBDD) detectionsDoNotInclude(name string) error {
+	if _, ok := s.findDetection(name); ok {
+		return fmt.Errorf("detections must not include %q", name)
+	}
+	return nil
+}
+
+func (s *opBDD) eachDetectionRecordsPath() error {
+	for _, d := range s.ds {
+		if d.Path == "" || d.Path != s.pathOf[d.Guest.Bin] {
+			return fmt.Errorf("%s: path %q, want %q", d.Guest.Name, d.Path, s.pathOf[d.Guest.Bin])
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) detectionVersionVerified(name, version string) error {
+	d, ok := s.findDetection(name)
+	if !ok {
+		return fmt.Errorf("%q not detected", name)
+	}
+	if d.Version != version || d.Unverified {
+		return fmt.Errorf("%s: version=%q unverified=%v, want %q verified", name, d.Version, d.Unverified, version)
+	}
+	return nil
+}
+
+func (s *opBDD) detectionUnverifiedEmptyVersion(name string) error {
+	d, ok := s.findDetection(name)
+	if !ok {
+		return fmt.Errorf("%q not detected", name)
+	}
+	if !d.Unverified || d.Version != "" {
+		return fmt.Errorf("%s: version=%q unverified=%v, want unverified with empty version", name, d.Version, d.Unverified)
+	}
+	return nil
+}
+
+func (s *opBDD) detectionUnverified(name string) error {
+	d, ok := s.findDetection(name)
+	if !ok {
+		return fmt.Errorf("%q not detected", name)
+	}
+	if !d.Unverified {
+		return fmt.Errorf("%s must be unverified", name)
+	}
+	return nil
+}
+
+func (s *opBDD) detectionUnverifiedWithVersion(name, version string) error {
+	d, ok := s.findDetection(name)
+	if !ok {
+		return fmt.Errorf("%q not detected", name)
+	}
+	if !d.Unverified || d.Version != version {
+		return fmt.Errorf("%s: version=%q unverified=%v, want unverified with version %q", name, d.Version, d.Unverified, version)
+	}
+	return nil
+}
+
+func (s *opBDD) scanCompletes() error { return nil } // Detect returned (a hung probe would fail the step timeout)
+
+func (s *opBDD) rawVersionParsed(raw, guest string) error {
+	raw = strings.ReplaceAll(raw, `\n`, "\n") // the outline table carries literal \n
+	s.parsed, s.parsedOK = operator.ParseVersion(guest, raw)
+	return nil
+}
+
+func (s *opBDD) parsedVersionIs(want string) error {
+	if !s.parsedOK || s.parsed != want {
+		return fmt.Errorf("parsed = (%q, %v), want %q", s.parsed, s.parsedOK, want)
+	}
+	return nil
+}
+
+// noFileWrittenAnywhere: the scenario's sandbox roots stayed empty/untouched (detection
+// is read-only; aider materialization writes nothing).
+func (s *opBDD) noFileWrittenAnywhere() error {
+	if got := treeSnapshot(s.scratchRoot); len(got) != 0 {
+		return fmt.Errorf("files appeared under the scratch root: %v", keysOf(got))
+	}
+	if s.workSnap != nil {
+		if got := treeSnapshot(s.sess.Workdir); !reflect.DeepEqual(got, s.workSnap) {
+			return fmt.Errorf("the workdir changed: %v", keysOf(got))
+		}
+	}
+	// The sandbox home too: nothing may appear there beyond files a Given planted.
+	if got, planted := treeSnapshot(s.home), len(s.realFiles); len(got) != planted {
+		return fmt.Errorf("files appeared under the home sandbox: %v", keysOf(got))
+	}
+	return nil
+}
+
+func (s *opBDD) noRequestHitProxy() error {
+	if n := s.proxyHits.Load(); n != 0 {
+		return fmt.Errorf("%d request(s) hit the local proxy during a read-only scan", n)
+	}
+	return nil
+}
+
+// --- config materialization ------------------------------------------------------------------
+
+func (s *opBDD) liveProxySession(base, key, model string) error {
+	s.sess = operator.Session{BaseURL: base, SessionKey: key, Model: model,
+		Workdir: s.workdir, ScratchRoot: s.scratchRoot}
+	return nil
+}
+
+func (s *opBDD) aSessionScratchDir() error { return nil } // the per-scenario root exists
+
+func (s *opBDD) materialize(name string) error {
+	g, err := registryGuest(name)
+	if err != nil {
+		return err
+	}
+	s.prevLaunch = s.launch
+	s.launch, s.cleanup, s.matErr = operator.Materialize(g, s.sess)
+	if s.matErr != nil {
+		return fmt.Errorf("materialize %s: %v", name, s.matErr)
+	}
+	s.matGuest = name
+	return nil
+}
+
+func (s *opBDD) materializeAndExit(name string) error {
+	if err := s.materialize(name); err != nil {
+		return err
+	}
+	return s.cleanup()
+}
+
+func (s *opBDD) materializeAgain(name string) error { return s.materialize(name) }
+
+func (s *opBDD) scratchContainsExactlyOneFile(name string) error {
+	got := keysOf(treeSnapshot(s.launch.Dir))
+	if !reflect.DeepEqual(got, []string{name}) {
+		return fmt.Errorf("scratch dir files = %v, want exactly [%s]", got, name)
+	}
+	return nil
+}
+
+func (s *opBDD) scratchContains(rel string) error {
+	if _, err := os.Stat(filepath.Join(s.launch.Dir, filepath.FromSlash(rel))); err != nil {
+		return fmt.Errorf("scratch dir lacks %s: %v", rel, err)
+	}
+	return nil
+}
+
+func (s *opBDD) fileEqualsGolden(rel string, doc *godog.DocString) error {
+	b, err := os.ReadFile(filepath.Join(s.launch.Dir, filepath.FromSlash(rel)))
+	if err != nil {
+		return err
+	}
+	want := doc.Content
+	if got := string(b); got != want && got != want+"\n" {
+		return fmt.Errorf("golden mismatch for %s:\n--- want ---\n%s\n--- got ---\n%s", rel, want, got)
+	}
+	return nil
+}
+
+func (s *opBDD) argvIsExactly(want string) error {
+	if got := strings.Join(s.launch.Argv, " "); got != want {
+		return fmt.Errorf("argv = %q, want %q", got, want)
+	}
+	return nil
+}
+
+func (s *opBDD) argvPins(frag string) error {
+	if got := strings.Join(s.launch.Argv, " "); !strings.Contains(got, frag) {
+		return fmt.Errorf("argv %q does not pin %q", got, frag)
+	}
+	return nil
+}
+
+func (s *opBDD) argvContains(frag string) error { return s.argvPins(frag) }
+
+func (s *opBDD) envAdditionsExactly(table *godog.Table) error {
+	var want []string
+	for _, row := range table.Rows {
+		if len(row.Cells) != 2 {
+			return fmt.Errorf("env table rows need 2 cells")
+		}
+		v := strings.ReplaceAll(row.Cells[1].Value, "<scratch>", s.launch.Dir)
+		want = append(want, row.Cells[0].Value+"="+v)
+	}
+	got := append([]string(nil), s.launch.Env...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("env additions = %v, want %v", s.launch.Env, want)
+	}
+	return nil
+}
+
+// parentEnvInherited: the additions are ONLY additions - composing over a parent env
+// keeps every non-overridden parent var byte-identical.
+func (s *opBDD) parentEnvInherited() error {
+	parent := []string{"HOME=/keep/home", "PATH=/keep/path", "LANG=C.UTF-8"}
+	composed := operator.ComposeEnv(parent, s.launch.Env)
+	for _, kv := range parent {
+		if !containsStr(composed, kv) {
+			return fmt.Errorf("parent var %q lost in composition %v", kv, composed)
+		}
+	}
+	if len(composed) != len(parent)+len(s.launch.Env) {
+		return fmt.Errorf("composition len = %d, want parent+additions only", len(composed))
+	}
+	return nil
+}
+
+func (s *opBDD) noScratchFileContains(secret string) error {
+	var offenders []string
+	_ = filepath.Walk(s.scratchRoot, func(p string, info os.FileInfo, err error) error {
+		if err == nil && info.Mode().IsRegular() {
+			if b, e := os.ReadFile(p); e == nil && strings.Contains(string(b), secret) {
+				offenders = append(offenders, p)
+			}
+		}
+		return nil
+	})
+	if len(offenders) != 0 {
+		return fmt.Errorf("the session key is on disk: %v", offenders)
+	}
+	return nil
+}
+
+func (s *opBDD) workdirHasProjectConfig(model string) error {
+	p := filepath.Join(s.sess.Workdir, "opencode.json")
+	body := []byte(`{"model":"` + model + `"}`)
+	if err := os.WriteFile(p, body, 0o644); err != nil {
+		return err
+	}
+	s.projectCfg = body
+	return nil
+}
+
+func (s *opBDD) projectConfigNotModified() error {
+	b, err := os.ReadFile(filepath.Join(s.sess.Workdir, "opencode.json"))
+	if err != nil || !reflect.DeepEqual(b, s.projectCfg) {
+		return fmt.Errorf("the user's project opencode.json was modified (err=%v)", err)
+	}
+	return nil
+}
+
+func (s *opBDD) bandRetuned(model string) error {
+	s.sess.Model = model
+	return nil
+}
+
+func (s *opBDD) fileWiresModel(rel, model string) error {
+	b, err := os.ReadFile(filepath.Join(s.launch.Dir, filepath.FromSlash(rel)))
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(string(b), model) {
+		return fmt.Errorf("%s does not wire model %q:\n%s", rel, model, b)
+	}
+	return nil
+}
+
+func (s *opBDD) guestExitsCleanly() error { return s.cleanup() } // the return callback runs
+func (s *opBDD) guestCrashesExit1() error { return s.cleanup() } // …for EVERY child outcome
+
+func (s *opBDD) scratchDirGone() error {
+	if s.launch.Dir == "" {
+		return nil
+	}
+	if _, err := os.Stat(s.launch.Dir); !os.IsNotExist(err) {
+		return fmt.Errorf("scratch dir %s still exists (err=%v)", s.launch.Dir, err)
+	}
+	return nil
+}
+
+// homePath resolves a "~/…" spec path into the scenario's sandboxed fake home.
+func (s *opBDD) homePath(spec string) string {
+	return filepath.Join(s.home, strings.TrimPrefix(spec, "~/"))
+}
+
+func (s *opBDD) userHasRealFile(spec string) error {
+	p := s.homePath(spec)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	body := []byte("# the user's real config - " + spec + "\n")
+	if err := os.WriteFile(p, body, 0o644); err != nil {
+		return err
+	}
+	if s.realFiles == nil {
+		s.realFiles = map[string][]byte{}
+	}
+	s.realFiles[spec] = body
+	return nil
+}
+
+func (s *opBDD) realFileByteIdentical(spec string) error {
+	b, err := os.ReadFile(s.homePath(spec))
+	if err != nil || !reflect.DeepEqual(b, s.realFiles[spec]) {
+		return fmt.Errorf("%s changed (err=%v)", spec, err)
+	}
+	return nil
+}
+
+func (s *opBDD) nothingWrittenUnder(spec string) error {
+	dir := s.homePath(spec)
+	got := keysOf(treeSnapshot(dir))
+	var want []string
+	for k := range s.realFiles {
+		if rel, ok := strings.CutPrefix(k, strings.TrimSuffix(spec, "/")+"/"); ok {
+			want = append(want, filepath.FromSlash(rel))
+		} else if filepath.Dir(s.homePath(k)) == dir {
+			want = append(want, filepath.Base(k))
+		}
+	}
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("files under %s = %v, want only the pre-existing %v", spec, got, want)
+	}
+	return nil
+}
+
+func (s *opBDD) hermesConfigHasKeyedProviders() error {
+	b, err := os.ReadFile(filepath.Join(s.launch.Dir, "hermes-home", "config.yaml"))
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(string(b), "providers:") || !strings.Contains(string(b), "api_key: ${"+operator.SessionKeyEnv+"}") {
+		return fmt.Errorf("hermes config must use the keyed providers schema with an env api_key reference:\n%s", b)
+	}
+	return nil
+}
+
+// --- aider-only steps --------------------------------------------------------------------------
+
+func (s *opBDD) noScratchDirForSession() error {
+	if s.launch.Dir != "" {
+		return fmt.Errorf("aider must create no scratch dir, got %s", s.launch.Dir)
+	}
+	if got := scratchDirsUnder(s.scratchRoot); len(got) != 0 {
+		return fmt.Errorf("scratch dirs exist: %v", got)
+	}
+	return nil
+}
+
+func (s *opBDD) parentEnvSets(key, val string) error {
+	s.parentEnv = append([]string{"HOME=/keep/home", "PATH=/keep/path"}, key+"="+val)
+	return nil
+}
+
+func (s *opBDD) childEnvSets(key, val string) error {
+	parent := s.parentEnv
+	if parent == nil {
+		parent = []string{"HOME=/keep/home"}
+	}
+	composed := operator.ComposeEnv(parent, s.launch.Env)
+	var got []string
+	for _, kv := range composed {
+		if strings.HasPrefix(kv, key+"=") {
+			got = append(got, strings.TrimPrefix(kv, key+"="))
+		}
+	}
+	if len(got) != 1 || got[0] != val {
+		return fmt.Errorf("child env %s = %v, want exactly [%s] (override, not merge)", key, got, val)
+	}
+	return nil
+}
+
+// --- isolation steps -----------------------------------------------------------------------------
+
+func (s *opBDD) sentinelSnapshot() error {
+	s.homeSnap = treeSnapshot(s.home)
+	s.workSnap = treeSnapshot(s.sess.Workdir)
+	return nil
+}
+
+func (s *opBDD) everyWrittenPathUnderScratch() error {
+	if s.launch.Dir != "" && !strings.HasPrefix(s.launch.Dir, s.scratchRoot) {
+		return fmt.Errorf("scratch dir %s escaped the root %s", s.launch.Dir, s.scratchRoot)
+	}
+	if err := s.homeMatchesSentinel(); err != nil {
+		return err
+	}
+	return s.workdirMatchesSentinel()
+}
+
+func (s *opBDD) homeMatchesSentinel() error {
+	if got := treeSnapshot(s.home); !reflect.DeepEqual(got, s.homeSnap) {
+		return fmt.Errorf("the user's home changed: %v", keysOf(got))
+	}
+	return nil
+}
+
+func (s *opBDD) workdirMatchesSentinel() error {
+	if got := treeSnapshot(s.sess.Workdir); !reflect.DeepEqual(got, s.workSnap) {
+		return fmt.Errorf("the launch workdir changed: %v", keysOf(got))
+	}
+	return nil
+}
+
+func (s *opBDD) scratchDirMode0700() error {
+	info, err := os.Stat(s.launch.Dir)
+	if err != nil {
+		return err
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		return fmt.Errorf("scratch dir mode = %o, want 0700", perm)
+	}
+	return nil
+}
+
+func (s *opBDD) childWorkdirIsLaunchWorkdir() error {
+	c := operator.Command(s.launch, "/fake/bin", s.sess.Workdir, []string{"HOME=/keep"})
+	if c.Dir != s.sess.Workdir {
+		return fmt.Errorf("child dir = %q, want the launch workdir %q", c.Dir, s.sess.Workdir)
+	}
+	return nil
+}
+
+func (s *opBDD) childWorkdirNotScratch() error {
+	c := operator.Command(s.launch, "/fake/bin", s.sess.Workdir, []string{"HOME=/keep"})
+	if s.launch.Dir != "" && c.Dir == s.launch.Dir {
+		return fmt.Errorf("child dir must never be the scratch dir")
+	}
+	return nil
+}
+
+func (s *opBDD) noOperatorScratchRemains() error {
+	if got := scratchDirsUnder(s.scratchRoot); len(got) != 0 {
+		return fmt.Errorf("rogerai-operator scratch dirs remain: %v", got)
+	}
+	return nil
+}
+
+func (s *opBDD) guestRemovedFilesInScratch() error {
+	return os.RemoveAll(filepath.Join(s.launch.Dir, "opencode.json"))
+}
+
+func (s *opBDD) cleanupStillSucceeds() error {
+	if err := s.cleanup(); err != nil {
+		return fmt.Errorf("cleanup: %v", err)
+	}
+	return nil
+}
+
+func (s *opBDD) leftoverScratchDirOld(name string) error {
+	p := filepath.Join(s.scratchRoot, name)
+	if err := os.Mkdir(p, 0o700); err != nil {
+		return err
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	return os.Chtimes(p, old, old)
+}
+
+func (s *opBDD) freshScratchDir(name string) error {
+	return os.Mkdir(filepath.Join(s.scratchRoot, name), 0o700)
+}
+
+func (s *opBDD) namedDirRemoved(name string) error {
+	if _, err := os.Stat(filepath.Join(s.scratchRoot, name)); !os.IsNotExist(err) {
+		return fmt.Errorf("%s should be swept (err=%v)", name, err)
+	}
+	return nil
+}
+
+func (s *opBDD) namedDirUntouched(name string) error {
+	if _, err := os.Stat(filepath.Join(s.scratchRoot, name)); err != nil {
+		return fmt.Errorf("%s should be untouched: %v", name, err)
+	}
+	return nil
+}
+
+func (s *opBDD) secondScratchDiffers() error {
+	if s.prevLaunch.Dir == "" || s.launch.Dir == "" || s.prevLaunch.Dir == s.launch.Dir {
+		return fmt.Errorf("scratch dirs must differ: first=%q second=%q", s.prevLaunch.Dir, s.launch.Dir)
+	}
+	return nil
+}
+
+func (s *opBDD) onlySecondScratchExists() error {
+	got := scratchDirsUnder(s.scratchRoot)
+	if len(got) != 1 || got[0] != s.launch.Dir {
+		return fmt.Errorf("scratch dirs = %v, want only %s", got, s.launch.Dir)
+	}
+	return nil
+}
+
+func (s *opBDD) childEnvContainsSessionKey() error {
+	for _, kv := range s.launch.Env {
+		if strings.HasPrefix(kv, operator.SessionKeyEnv+"=") {
+			return nil
+		}
+	}
+	return fmt.Errorf("launch env %v lacks %s", s.launch.Env, operator.SessionKeyEnv)
+}
+
+func (s *opBDD) budgetCappedAtDefault() error {
+	if client.DefaultSessionBudget != 2.00 {
+		return fmt.Errorf("DefaultSessionBudget = %v, want the founder-ruled $2.00", client.DefaultSessionBudget)
+	}
+	return nil
+}
+
+// --- small shared helpers --------------------------------------------------------------------
+
+// treeSnapshot maps every regular file under root (relative path) to its content.
+func treeSnapshot(root string) map[string]string {
+	out := map[string]string{}
+	_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err == nil && info.Mode().IsRegular() {
+			rel, _ := filepath.Rel(root, p)
+			b, _ := os.ReadFile(p)
+			out[rel] = string(b)
+		}
+		return nil
+	})
+	return out
+}
+
+func keysOf(m map[string]string) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func scratchDirsUnder(root string) []string {
+	matches, _ := filepath.Glob(filepath.Join(root, "rogerai-operator-*"))
+	sort.Strings(matches)
+	return matches
+}
+
+func containsStr(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/operator_steps_tui_test.go
+++ b/internal/tui/operator_steps_tui_test.go
@@ -1,0 +1,1750 @@
+package tui
+
+// operator_steps_tui_test.go - godog step definitions for the TUI half of the Guest
+// Operators Phase 2 spec set (features/operator/operator_command|handoff_lifecycle|
+// rc_interlock.feature): they drive the REAL bubbletea model (the rc_confirm_bdd pattern),
+// a REAL ProxyOptionsHolder behind a real httptest proxy + stub billing broker (spend and
+// call counts accumulate through the actual money path, never set by hand), and a REAL
+// client.RCBridge polling a stub RC broker for the interlock. The only seams are the
+// package-level exec/terminal/scan seams in operator.go - no mocks.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/client"
+	"github.com/rogerai-fyi/roger/internal/operator"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// opBDD is the shared per-scenario state for the whole operator spec set (the pure
+// detection/config steps live in operator_steps_pure_test.go).
+type opBDD struct {
+	t *testing.T
+
+	// pure detection seams
+	pathOf      map[string]string
+	lookErr     map[string]error
+	probeOuts   map[string]string
+	probeErrs   map[string]error
+	probeBlocks map[string]bool
+	ds          []operator.Detection
+	parsed      string
+	parsedOK    bool
+
+	// sandbox roots (per scenario)
+	scratchRoot string
+	workdir     string
+	home        string
+
+	// config materialization
+	sess       operator.Session
+	launch     operator.Launch
+	prevLaunch operator.Launch
+	cleanup    func() error
+	matErr     error
+	matGuest   string
+	projectCfg []byte
+	realFiles  map[string][]byte
+	homeSnap   map[string]string
+	workSnap   map[string]string
+	parentEnv  []string
+
+	// TUI
+	tm        tea.Model
+	holder    *client.ProxyOptionsHolder
+	keyAtSeed string
+	tuiPaths  map[string]string // guest bin -> fake path for the TUI-side detect seam
+
+	// money servers (real HTTP through the real proxy handler)
+	brokerSrv *httptest.Server
+	proxySrv  *httptest.Server
+	proxyHits atomic.Int64
+	costMu    sync.Mutex
+	costs     []string // per-call X-RogerAI-Cost values the stub broker bills
+
+	// exec seam recordings
+	execCmds     []*exec.Cmd
+	parkedAtExec []bool
+	spawnFail    bool
+	resetBuf     *bytes.Buffer
+	collected    []tea.Msg
+	retCalls     int64
+	retSpend     float64
+	firstDir     string
+
+	// RC interlock (a REAL client.RCBridge against a stub RC broker)
+	rcSrv    *httptest.Server
+	rcQueue  chan protocol.RCInbound
+	rc401    atomic.Bool
+	bridge   *client.RCBridge
+	framesMu sync.Mutex
+	frames   []protocol.RCFrame
+}
+
+// seamExec is the recording exec seam: it captures the composed child command (and
+// whether the bridge was already parked at issue time) instead of suspending the test
+// terminal; scenarios deliver operatorDoneMsg to simulate the child outcome.
+func (s *opBDD) seamExec(c *exec.Cmd, _ func(error) tea.Msg) tea.Cmd {
+	parked := false
+	if s.bridge != nil {
+		_, parked = s.bridge.Parked()
+	}
+	s.execCmds = append(s.execCmds, c)
+	s.parkedAtExec = append(s.parkedAtExec, parked)
+	return nil
+}
+
+// opTermTap routes the operator terminal-reset seam into the live scenario's buffer.
+type opTermTap struct{ s *opBDD }
+
+func (w opTermTap) Write(p []byte) (int, error) { return w.s.resetBuf.Write(p) }
+
+func (s *opBDD) reset(t *testing.T) {
+	s.closeServers()
+	*s = opBDD{
+		t:           t,
+		pathOf:      map[string]string{},
+		lookErr:     map[string]error{},
+		probeOuts:   map[string]string{},
+		probeErrs:   map[string]error{},
+		probeBlocks: map[string]bool{},
+		tuiPaths:    map[string]string{},
+		resetBuf:    &bytes.Buffer{},
+	}
+	s.scratchRoot = t.TempDir()
+	s.workdir = t.TempDir()
+	s.home = t.TempDir()
+	operatorScratchRoot = s.scratchRoot
+}
+
+func (s *opBDD) closeServers() {
+	if s.bridge != nil {
+		s.bridge.Stop()
+	}
+	for _, srv := range []*httptest.Server{s.brokerSrv, s.proxySrv, s.rcSrv} {
+		if srv != nil {
+			srv.Close()
+		}
+	}
+}
+
+// --- model plumbing ---------------------------------------------------------------------
+
+func (s *opBDD) model() model { return asModel(s.tm) }
+
+func (s *opBDD) mutate(f func(m *model)) {
+	m := asModel(s.tm)
+	f(&m)
+	s.tm = m
+}
+
+// update feeds one message through the REAL Update loop and returns the emitted Cmd.
+func (s *opBDD) update(msg tea.Msg) tea.Cmd {
+	nm, cmd := s.tm.Update(msg)
+	s.tm = nm
+	return cmd
+}
+
+// pressKey sends a key and folds any synchronously-produced msg back in (the r re-scan
+// cmd, the staging tick) - the same round-trip the bubbletea runtime performs.
+func (s *opBDD) pressKey(k string) {
+	cmd := s.update(keyMsg(k))
+	for _, msg := range collectCmdMsgs(cmd) {
+		if msg != nil {
+			s.update(msg)
+		}
+	}
+}
+
+// collectCmdMsgs executes a Cmd tree (Batch-aware) and returns the produced messages.
+func collectCmdMsgs(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, c := range batch {
+			out = append(out, collectCmdMsgs(c)...)
+		}
+		return out
+	}
+	if msg == nil {
+		return nil
+	}
+	return []tea.Msg{msg}
+}
+
+func (s *opBDD) view() string { return stripANSI(s.model().View()) }
+
+// --- money servers: a stub billing broker + the REAL hardened proxy over it -------------
+
+func (s *opBDD) startMoneyServers(model string) {
+	s.brokerSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		s.costMu.Lock()
+		cost := "0"
+		if len(s.costs) > 0 {
+			cost, s.costs = s.costs[0], s.costs[1:]
+		}
+		s.costMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if cost != "0" {
+			w.Header().Set("X-RogerAI-Cost", cost)
+		}
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"roger"}}]}`))
+	}))
+	s.holder = client.NewProxyOptionsHolder(client.ProxyOptions{
+		Broker: s.brokerSrv.URL, User: "tester", Model: model, SessionKey: client.NewSessionKey(),
+	})
+	inner := client.ProxyHandlerLive(s.holder)
+	s.proxySrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.proxyHits.Add(1)
+		inner.ServeHTTP(w, r)
+	}))
+}
+
+// proxyCallsCosts drives N real guest-shaped requests through the REAL proxy (bearer
+// auth, model rewrite, budget gate); each is billed the given cost by the stub broker.
+func (s *opBDD) proxyCallsCosts(costs []string) error {
+	key := s.holder.Get().SessionKey
+	for _, c := range costs {
+		s.costMu.Lock()
+		s.costs = append(s.costs, c)
+		s.costMu.Unlock()
+		req, _ := http.NewRequest(http.MethodPost, s.proxySrv.URL+"/v1/chat/completions",
+			strings.NewReader(`{"model":"whatever-the-guest-defaults-to"}`))
+		req.Header.Set("Authorization", "Bearer "+key)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("proxy call: %v", err)
+		}
+		resp.Body.Close()
+	}
+	return nil
+}
+
+// --- seeding ------------------------------------------------------------------------------
+
+// seedTUI enters [0] AGENT off a real seeded BROWSE and (when a band model is given)
+// wires a live holder + real proxy endpoint like openChannel does.
+func (s *opBDD) seedTUI(bandModel string) {
+	m := browseSeed(120)
+	m.mouseOff = false // the handoff specs default to "the user has the mouse on"
+	var tm tea.Model = m
+	tm, _ = tm.Update(keyMsg("0"))
+	mm := asModel(tm)
+	if bandModel != "" {
+		s.startMoneyServers(bandModel)
+		mm.proxyHolder = s.holder
+		mm.endpoint = s.proxySrv.URL + "/v1"
+		mm.broker = s.brokerSrv.URL
+		s.keyAtSeed = s.holder.Get().SessionKey
+	}
+	s.tm = mm
+}
+
+func (s *opBDD) agentSessionAtPrompt() error {
+	s.seedTUI("qwen3-32b-fp8")
+	return nil
+}
+
+func (s *opBDD) agentSessionTuned(bandModel string) error {
+	s.seedTUI(bandModel)
+	return nil
+}
+
+func (s *opBDD) addDetected(name string) error {
+	g, err := registryGuest(name)
+	if err != nil {
+		return err
+	}
+	s.tuiPaths[g.Bin] = "/fake/" + g.Bin
+	s.mutate(func(m *model) {
+		m.operatorDetections = append(m.operatorDetections,
+			operator.Detection{Guest: g, Path: "/fake/" + g.Bin, Version: g.KnownGood})
+	})
+	return nil
+}
+
+func (s *opBDD) detectedGuests(a string) error { return s.addDetected(a) }
+
+func (s *opBDD) detectedGuestsTwo(a, b string) error {
+	if err := s.addDetected(a); err != nil {
+		return err
+	}
+	return s.addDetected(b)
+}
+
+func (s *opBDD) noGuestsDetected() error {
+	s.tuiPaths = map[string]string{}
+	s.mutate(func(m *model) {
+		m.operatorDetections = nil
+	})
+	return nil
+}
+
+func (s *opBDD) undetectedGuestsTwo(a, b string) error {
+	if err := s.undetectedGuest(a); err != nil {
+		return err
+	}
+	return s.undetectedGuest(b)
+}
+
+// undetectedGuest verifies the named registry guest is absent from the scenario's desk
+// (it was simply never detected - the Given documents the state, this pins it).
+func (s *opBDD) undetectedGuest(name string) error {
+	for _, d := range s.model().operatorDetections {
+		if d.Guest.Name == name {
+			return fmt.Errorf("%s unexpectedly detected", name)
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) detectedGuestRequiresSetup(name string) error {
+	s.mutate(func(m *model) {
+		m.operatorDetections = append(m.operatorDetections, operator.Detection{
+			Guest: operator.Guest{
+				Name: name, Bin: name, Provider: "anthropic", InstallHint: "n/a", KnownGood: "0.0.1",
+				NeedsSetup: true,
+				SetupNote:  name + " needs a key first - export its API key, then /operator " + name,
+			},
+			Path: "/fake/" + name, Version: "0.0.1",
+		})
+	})
+	return nil
+}
+
+// tuiDetectEnv backs the operatorDetectEnv seam for the r re-scan: it resolves exactly
+// the fake paths the scenario declared and probes the registry's known-good versions.
+func (s *opBDD) tuiDetectEnv() operator.Env {
+	return operator.Env{
+		LookPath: func(bin string) (string, error) {
+			if p, ok := s.tuiPaths[bin]; ok {
+				return p, nil
+			}
+			return "", errors.New("executable file not found in $PATH")
+		},
+		Probe: func(bin string) (string, error) {
+			for _, g := range operator.Registry() {
+				if s.tuiPaths[g.Bin] == bin {
+					return g.KnownGood, nil
+				}
+			}
+			return "", errors.New("unknown bin")
+		},
+	}
+}
+
+// --- command + picker steps -----------------------------------------------------------------
+
+func (s *opBDD) userRuns(line string) error {
+	nm, _ := s.model().runAgentCommand(line)
+	s.tm = nm
+	return nil
+}
+
+func (s *opBDD) userHasTyped(text string) error {
+	s.tm = typeRunes(s.tm, text)
+	return nil
+}
+
+func (s *opBDD) registryContains(cmd string) error {
+	if !containsStr(agentCommands, cmd) {
+		return fmt.Errorf("agentCommands %v lacks %s", agentCommands, cmd)
+	}
+	return nil
+}
+
+func (s *opBDD) registryNotContains(cmd string) error {
+	if containsStr(agentCommands, cmd) {
+		return fmt.Errorf("agentCommands must not list the alias %s", cmd)
+	}
+	return nil
+}
+
+func (s *opBDD) registrySortedLowercaseUnique() error {
+	seen := map[string]bool{}
+	for i, c := range agentCommands {
+		if c != strings.ToLower(c) {
+			return fmt.Errorf("%s is not lowercase", c)
+		}
+		if seen[c] {
+			return fmt.Errorf("%s is duplicated", c)
+		}
+		seen[c] = true
+		if i > 0 && agentCommands[i-1] >= c {
+			return fmt.Errorf("registry not sorted at %s", c)
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) transcriptDoesNotShow(text string) error {
+	if strings.Contains(s.view(), text) {
+		return fmt.Errorf("transcript shows %q:\n%s", text, s.view())
+	}
+	return nil
+}
+
+func (s *opBDD) transcriptShows(text string) error {
+	if !strings.Contains(s.view(), text) {
+		return fmt.Errorf("transcript lacks %q:\n%s", text, s.view())
+	}
+	return nil
+}
+
+func (s *opBDD) transcriptNotes(text string) error { return s.transcriptShows(text) }
+
+func (s *opBDD) stripIncludes(cmd string) error {
+	cands := agentSlashCandidates(s.model().agentIn.Value())
+	if !containsStr(cands, cmd) {
+		return fmt.Errorf("candidates %v lack %s", cands, cmd)
+	}
+	return nil
+}
+
+func (s *opBDD) stripNeverIncludesAliases(a, b string) error {
+	cands := agentSlashCandidates(s.model().agentIn.Value())
+	if containsStr(cands, a) || containsStr(cands, b) {
+		return fmt.Errorf("candidates %v suggest an alias", cands)
+	}
+	return nil
+}
+
+func (s *opBDD) noPickerOpens() error {
+	if s.model().operatorPicker {
+		return fmt.Errorf("the operator picker opened")
+	}
+	return nil
+}
+
+func (s *opBDD) pickerOpen() error {
+	if !s.model().operatorPicker {
+		return fmt.Errorf("the operator picker is not open")
+	}
+	return nil
+}
+
+func (s *opBDD) pickerClosed() error {
+	if s.model().operatorPicker {
+		return fmt.Errorf("the operator picker is still open")
+	}
+	return nil
+}
+
+func (s *opBDD) pickerRowLabels() []string {
+	var out []string
+	for _, r := range s.model().operatorRows {
+		out = append(out, r.label)
+	}
+	return out
+}
+
+func (s *opBDD) pickerRowsAre(a, b string) error {
+	want := []string{"DJ", a, b}
+	got := s.pickerRowLabels()
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		return fmt.Errorf("picker rows = %v, want %v", got, want)
+	}
+	return nil
+}
+
+func (s *opBDD) pickerRowsWithSuggestion(detected string) error {
+	rows := s.model().operatorRows
+	if len(rows) != 3 || rows[0].label != "DJ" || rows[1].label != detected || !rows[2].suggestion {
+		return fmt.Errorf("picker rows = %v (want DJ, %s, one suggestion)", s.pickerRowLabels(), detected)
+	}
+	for _, r := range rows[:2] {
+		if r.suggestion {
+			return fmt.Errorf("only the LAST row may be the suggestion")
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) suggestionShowsInstallHint() error {
+	rows := s.model().operatorRows
+	last := rows[len(rows)-1]
+	if !last.suggestion || last.hint == "" {
+		return fmt.Errorf("no suggestion hint on the last row: %+v", last)
+	}
+	if !strings.Contains(s.view(), last.hint) {
+		return fmt.Errorf("the rendered picker lacks the install hint %q", last.hint)
+	}
+	return nil
+}
+
+func (s *opBDD) pressDownPastLast() error {
+	for i := 0; i < len(s.model().operatorRows)+3; i++ {
+		s.pressKey("down")
+	}
+	return nil
+}
+
+func (s *opBDD) cursorStaysOn(label string) error {
+	m := s.model()
+	if m.operatorCursor >= len(m.operatorRows) || m.operatorRows[m.operatorCursor].label != label {
+		return fmt.Errorf("cursor on %v, want %s", s.pickerRowLabels(), label)
+	}
+	return nil
+}
+
+func (s *opBDD) cursorNeverOnSuggestion() error {
+	m := s.model()
+	if m.operatorRows[m.operatorCursor].suggestion {
+		return fmt.Errorf("the cursor landed on the suggestion row")
+	}
+	s.pressKey("down") // even one more press stays off it
+	m = s.model()
+	if m.operatorRows[m.operatorCursor].suggestion {
+		return fmt.Errorf("the cursor reached the suggestion row after another down")
+	}
+	return nil
+}
+
+func (s *opBDD) userPicks(label string) error {
+	m := s.model()
+	target := -1
+	for i, r := range m.operatorRows {
+		if r.label == label {
+			target = i
+		}
+	}
+	if target < 0 {
+		return fmt.Errorf("no picker row %q in %v", label, s.pickerRowLabels())
+	}
+	for i := 0; i < len(m.operatorRows)+2 && s.model().operatorCursor != target; i++ {
+		if s.model().operatorCursor < target {
+			s.pressKey("down")
+		} else {
+			s.pressKey("up")
+		}
+	}
+	if s.model().operatorCursor != target {
+		return fmt.Errorf("could not navigate to row %q", label)
+	}
+	s.pressKey("enter")
+	return nil
+}
+
+func (s *opBDD) userPressesEsc() error { s.pressKey("esc"); return nil }
+func (s *opBDD) userPresses(k string) error {
+	s.pressKey(k)
+	return nil
+}
+
+func (s *opBDD) pickerStillOpen() error { return s.pickerOpen() }
+
+func (s *opBDD) tuiDidNotSwitchModes() error {
+	if s.model().mode != modeAgent {
+		return fmt.Errorf("the TUI left AGENT mode (mode=%d)", s.model().mode)
+	}
+	return nil
+}
+
+func (s *opBDD) guestAppearsOnPath(name string) error {
+	g, err := registryGuest(name)
+	if err != nil {
+		return err
+	}
+	s.tuiPaths[g.Bin] = "/fake/" + g.Bin
+	return nil
+}
+
+func (s *opBDD) pickerRowsInclude(label string) error {
+	if !containsStr(s.pickerRowLabels(), label) {
+		return fmt.Errorf("picker rows %v lack %s", s.pickerRowLabels(), label)
+	}
+	return nil
+}
+
+func (s *opBDD) transcriptShowsInstallHint(name string) error {
+	g, err := registryGuest(name)
+	if err != nil {
+		return err
+	}
+	return s.transcriptShows(g.InstallHint)
+}
+
+func (s *opBDD) noChatTurnSubmitted() error {
+	m := s.model()
+	if m.agentBusy || len(m.agentQueued) != 0 {
+		return fmt.Errorf("a chat turn was submitted/queued")
+	}
+	return nil
+}
+
+func (s *opBDD) nameNotKnownOperator() error { return s.transcriptShows("is not a known operator") }
+
+// --- handoff lifecycle steps ---------------------------------------------------------------
+
+func (s *opBDD) holderDisconnected() error {
+	s.holder.Disconnect()
+	return nil
+}
+
+func (s *opBDD) djTurnInFlight() error {
+	s.mutate(func(m *model) { m.agentBusy = true })
+	return nil
+}
+
+func (s *opBDD) djTurnInFlightAndQueued() error {
+	s.mutate(func(m *model) {
+		m.agentBusy = true
+		m.agentQueued = append(m.agentQueued, "parked ask")
+	})
+	return nil
+}
+
+func (s *opBDD) noChildLaunched() error {
+	if len(s.execCmds) != 0 {
+		return fmt.Errorf("a child exec was issued: %v", s.execCmds[0].Args)
+	}
+	return nil
+}
+
+func (s *opBDD) pointsAtTuningIn() error { return s.transcriptShows("tune in first") }
+func (s *opBDD) notesDJMidTurn() error   { return s.transcriptShows("mid-turn") }
+
+// fireExec advances a staged handoff to the exec (the staging tick's message).
+func (s *opBDD) fireExec() {
+	if h := s.model().operatorHandoff; h != nil && !h.execing {
+		s.update(operatorExecMsg{})
+	}
+}
+
+// ensureHandoff makes sure the full begin path ran for the named guest: /operator <name>
+// if nothing is staged, then the staging tick.
+func (s *opBDD) ensureHandoff(name string) error {
+	if s.model().operatorHandoff == nil && len(s.execCmds) == 0 {
+		if err := s.userRuns("/operator " + name); err != nil {
+			return err
+		}
+	}
+	s.fireExec()
+	if len(s.execCmds) == 0 {
+		return fmt.Errorf("no exec was issued for %s (transcript: %s)", name, s.view())
+	}
+	return nil
+}
+
+func (s *opBDD) handoffBegins(name string) error {
+	if err := s.ensureHandoff(name); err != nil {
+		return err
+	}
+	last := s.execCmds[len(s.execCmds)-1]
+	if !strings.Contains(last.Path, name) {
+		return fmt.Errorf("exec path %q is not the %s binary", last.Path, name)
+	}
+	return nil
+}
+
+func (s *opBDD) guestHasTheMic() error { return s.ensureHandoff("opencode") }
+
+func (s *opBDD) nextPaintShows(text string) error {
+	if !strings.Contains(s.view(), text) {
+		return fmt.Errorf("the staged paint lacks %q:\n%s", text, s.view())
+	}
+	return nil
+}
+
+func (s *opBDD) paintShowsMicTo(name string) error {
+	v := s.view()
+	if !strings.Contains(v, "mic to") || !strings.Contains(v, name) {
+		return fmt.Errorf("no mic-to line for %s:\n%s", name, v)
+	}
+	return nil
+}
+
+func (s *opBDD) paintShowsOnBand(mdl string) error {
+	v := s.view()
+	if !strings.Contains(v, "on band") || !strings.Contains(v, mdl) {
+		return fmt.Errorf("no on-band line for %s:\n%s", mdl, v)
+	}
+	return nil
+}
+
+func (s *opBDD) paintShowsWireLine(text string) error { return s.nextPaintShows(text) }
+
+func (s *opBDD) execOnlyAfterPaint() error {
+	if len(s.execCmds) != 0 {
+		return fmt.Errorf("the exec was issued before the staged paint")
+	}
+	s.fireExec()
+	if len(s.execCmds) != 1 {
+		return fmt.Errorf("the staging tick did not issue exactly one exec (%d)", len(s.execCmds))
+	}
+	return nil
+}
+
+func (s *opBDD) paintShowsBaseURL() error { return s.nextPaintShows(s.model().endpoint) }
+
+func (s *opBDD) paintShowsModel(mdl string) error {
+	v := s.view()
+	if !strings.Contains(v, "MODEL") || !strings.Contains(v, mdl) {
+		return fmt.Errorf("no MODEL %s on the staged paint:\n%s", mdl, v)
+	}
+	return nil
+}
+
+func (s *opBDD) bandRetunedSinceBind() error {
+	s.holder.SetBand(client.ProxyOptions{Broker: s.brokerSrv.URL, User: "tester", Model: "llama-3.3-70b"})
+	return nil
+}
+
+func (s *opBDD) childCarriesCurrentOptions() error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	last := s.execCmds[len(s.execCmds)-1]
+	argv := strings.Join(last.Args, " ")
+	if !strings.Contains(argv, "llama-3.3-70b") {
+		return fmt.Errorf("child argv %q does not carry the re-tuned model", argv)
+	}
+	cfg := envValue(last.Env, "OPENCODE_CONFIG")
+	b, err := os.ReadFile(cfg)
+	if err != nil {
+		return fmt.Errorf("read scratch config: %v", err)
+	}
+	if !strings.Contains(string(b), s.model().endpoint) {
+		return fmt.Errorf("scratch config does not carry the live endpoint")
+	}
+	return nil
+}
+
+func (s *opBDD) neverFrozenOptions() error {
+	last := s.execCmds[len(s.execCmds)-1]
+	if strings.Contains(strings.Join(last.Args, " "), "qwen3-32b-fp8") {
+		return fmt.Errorf("child argv carries the first-bind model")
+	}
+	return nil
+}
+
+func (s *opBDD) previousSessionSpent(amount string) error {
+	return s.proxyCallsCosts([]string{amount})
+}
+
+func (s *opBDD) holderBudgetIsDefault() error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	if b := s.holder.Get().Budget; b != client.DefaultSessionBudget {
+		return fmt.Errorf("holder budget = %v, want %v", b, client.DefaultSessionBudget)
+	}
+	return nil
+}
+
+func (s *opBDD) holderSpendZero() error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	if v := s.holder.Spent(); v != 0 {
+		return fmt.Errorf("holder spend = %v, want $0.00", v)
+	}
+	return nil
+}
+
+func (s *opBDD) holderCallsZero() error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	if n := s.holder.Calls(); n != 0 {
+		return fmt.Errorf("holder calls = %d, want 0", n)
+	}
+	return nil
+}
+
+func (s *opBDD) childEnvCarriesSameKey() error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	last := s.execCmds[len(s.execCmds)-1]
+	if envValue(last.Env, operator.SessionKeyEnv) != s.holder.Get().SessionKey {
+		return fmt.Errorf("child env key differs from the proxy's")
+	}
+	return nil
+}
+
+func (s *opBDD) keyNotRotated() error {
+	if s.holder.Get().SessionKey != s.keyAtSeed {
+		return fmt.Errorf("the handoff rotated the session bearer key")
+	}
+	return nil
+}
+
+// doReturn delivers the ExecProcess callback and executes the emitted Cmd tree
+// (balance refresh + mouse restore) collecting the produced messages.
+func (s *opBDD) doReturn(err error) {
+	if s.holder != nil {
+		s.retCalls, s.retSpend = s.holder.Calls(), s.holder.Spent()
+	}
+	if h := s.model().operatorHandoff; h != nil && h.launch.Dir != "" {
+		s.firstDir = h.launch.Dir
+	}
+	cmd := s.update(operatorDoneMsg{err: err})
+	s.collected = collectCmdMsgs(cmd)
+}
+
+// realExitErr produces a REAL *exec.ExitError with the given code (a real child ran).
+func realExitErr(code int) error {
+	return exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+}
+
+// realKillErr produces a REAL signal-death *exec.ExitError (exit code -1).
+func realKillErr() error {
+	return exec.Command("sh", "-c", "kill -KILL $$").Run()
+}
+
+func (s *opBDD) guestReturnsAfter(minutes, calls int, spend string) error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	s.model().operatorHandoff.start = time.Now().Add(-time.Duration(minutes) * time.Minute)
+	costs := make([]string, calls)
+	costs[0] = spend // one metered call carries the whole session cost; the rest bill $0
+	for i := 1; i < calls; i++ {
+		costs[i] = "0"
+	}
+	if err := s.proxyCallsCosts(costs); err != nil {
+		return err
+	}
+	s.doReturn(nil)
+	return nil
+}
+
+func (s *opBDD) guestReturnsExit(code int) error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	if code == 0 {
+		s.doReturn(nil)
+	} else {
+		s.doReturn(realExitErr(code))
+	}
+	return nil
+}
+
+func (s *opBDD) guestKilled() error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	s.doReturn(realKillErr())
+	return nil
+}
+
+func (s *opBDD) guestReturnsAnyExit() error { return s.guestReturnsExit(1) }
+func (s *opBDD) guestReturnsPlain() error {
+	s.doReturn(nil)
+	return nil
+}
+
+func (s *opBDD) resetPreambleRan() error {
+	got := s.resetBuf.String()
+	for _, seq := range []string{"\x1b[<u", "\x1b[?1000l", "\x1b[?1002l", "\x1b[?1003l", "\x1b[?1006l", "\x1b[?2004l"} {
+		if !strings.Contains(got, seq) {
+			return fmt.Errorf("terminal reset preamble missing %q (got %q)", seq, got)
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) mouseModesDisabled() error {
+	got := s.resetBuf.String()
+	for _, seq := range []string{"\x1b[?1000l", "\x1b[?1002l", "\x1b[?1003l", "\x1b[?1006l"} {
+		if !strings.Contains(got, seq) {
+			return fmt.Errorf("mouse disable missing %q", seq)
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) mouseReenabled() error {
+	for _, msg := range s.collected {
+		if strings.Contains(fmt.Sprintf("%T", msg), "enableMouseCellMotion") {
+			return nil
+		}
+	}
+	return fmt.Errorf("mouse cell motion was not re-enabled (msgs: %v)", s.collectedTypes())
+}
+
+func (s *opBDD) mouseNotReenabled() error {
+	for _, msg := range s.collected {
+		if strings.Contains(fmt.Sprintf("%T", msg), "enableMouse") {
+			return fmt.Errorf("mouse reporting was re-enabled despite m.mouseOff")
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) collectedTypes() []string {
+	var out []string
+	for _, m := range s.collected {
+		out = append(out, fmt.Sprintf("%T", m))
+	}
+	return out
+}
+
+func (s *opBDD) balanceRefreshRequested() error {
+	for _, msg := range s.collected {
+		if _, ok := msg.(balanceMsg); ok {
+			return nil
+		}
+	}
+	return fmt.Errorf("no balance refresh among %v", s.collectedTypes())
+}
+
+func (s *opBDD) userMouseOff() error {
+	s.mutate(func(m *model) { m.mouseOff = true })
+	return nil
+}
+
+// summaryFigures parses "N calls · $X.YZ" out of the rendered summary line.
+func (s *opBDD) summaryFigures() (int64, string, error) {
+	re := regexp.MustCompile(`(\d+) calls? · \$([0-9.]+)`)
+	match := re.FindStringSubmatch(s.view())
+	if match == nil {
+		return 0, "", fmt.Errorf("no summary line in:\n%s", s.view())
+	}
+	n, _ := strconv.ParseInt(match[1], 10, 64)
+	return n, match[2], nil
+}
+
+func (s *opBDD) summaryCallsEqualHolder() error {
+	n, _, err := s.summaryFigures()
+	if err != nil {
+		return err
+	}
+	if n != s.retCalls {
+		return fmt.Errorf("summary calls %d != holder counter %d", n, s.retCalls)
+	}
+	return nil
+}
+
+func (s *opBDD) summarySpendEqualsHolder() error {
+	_, spend, err := s.summaryFigures()
+	if err != nil {
+		return err
+	}
+	if want := fmt.Sprintf("%.2f", s.retSpend); spend != want {
+		return fmt.Errorf("summary spend $%s != holder Spent() $%s", spend, want)
+	}
+	return nil
+}
+
+func (s *opBDD) noteIsCalm() error {
+	v := s.view()
+	if !strings.Contains(v, "✕ the guest dropped off") {
+		return fmt.Errorf("the drop-off note is missing its calm ✕ form:\n%s", v)
+	}
+	if strings.Contains(v, "couldn't hand the mic off") {
+		return fmt.Errorf("a drop-off must not be styled as a launch error")
+	}
+	return nil
+}
+
+func (s *opBDD) restoreAndSummaryRan() error {
+	if err := s.resetPreambleRan(); err != nil {
+		return err
+	}
+	return s.transcriptShows("had the mic for")
+}
+
+func (s *opBDD) summaryLineRenders() error {
+	if _, _, err := s.summaryFigures(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *opBDD) scratchConfigCleaned() error { return s.noOperatorScratchRemains() }
+
+func (s *opBDD) binaryVanishes() error {
+	s.spawnFail = true
+	return nil
+}
+
+func (s *opBDD) tuiPaintingAgain() error {
+	if s.spawnFail {
+		s.fireExec()
+		s.doReturn(&exec.Error{Name: "opencode", Err: exec.ErrNotFound})
+		s.spawnFail = false
+	}
+	if s.model().operatorHandoff != nil {
+		return fmt.Errorf("a handoff is still holding the screen")
+	}
+	if !strings.Contains(s.view(), "ask ›") {
+		return fmt.Errorf("the ask prompt is not painting:\n%s", s.view())
+	}
+	return nil
+}
+
+func (s *opBDD) errorNoteNamesLaunchFailure() error {
+	return s.transcriptShows("couldn't hand the mic off")
+}
+
+func (s *opBDD) guestSpendsToBudget() error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	return s.proxyCallsCosts([]string{"0.70", "0.70", "0.70"}) // the 3rd crosses the $2 ceiling
+}
+
+func (s *opBDD) summaryNotesBudgetReached() error {
+	return s.transcriptShows("session budget was reached")
+}
+
+func (s *opBDD) summarySpendAtOrPastBudget() error {
+	_, spend, err := s.summaryFigures()
+	if err != nil {
+		return err
+	}
+	v, _ := strconv.ParseFloat(spend, 64)
+	if v < client.DefaultSessionBudget {
+		return fmt.Errorf("summary spend $%s is under the $%.2f ceiling", spend, client.DefaultSessionBudget)
+	}
+	return nil
+}
+
+func (s *opBDD) bandGoesOffAir() error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	if err := s.proxyCallsCosts([]string{"0.05"}); err != nil { // spend settled before the drop
+		return err
+	}
+	s.holder.Disconnect()
+	return nil
+}
+
+func (s *opBDD) summaryShowsSpendBeforeDrop() error { return s.transcriptShows("$0.05") }
+
+func (s *opBDD) deskUsableForRetune() error {
+	m := s.model()
+	if m.mode != modeAgent || m.operatorHandoff != nil || m.agentBusy {
+		return fmt.Errorf("the desk is not usable (mode=%d busy=%v)", m.mode, m.agentBusy)
+	}
+	return nil
+}
+
+func (s *opBDD) noKeyHandlingDuringExec() error {
+	before := s.view()
+	for _, k := range []string{"x", "1", "esc", "enter"} {
+		s.pressKey(k)
+	}
+	if s.view() != before {
+		return fmt.Errorf("a key changed the suspended TUI")
+	}
+	if s.model().agentIn.Value() != "" {
+		return fmt.Errorf("a key reached the prompt input during the handoff")
+	}
+	return nil
+}
+
+func (s *opBDD) guestReturnsAfterSpending(amount string) error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	if err := s.proxyCallsCosts([]string{amount}); err != nil {
+		return err
+	}
+	s.doReturn(nil)
+	return nil
+}
+
+func (s *opBDD) userRunsOperatorAgain() error {
+	if err := s.userRuns("/operator opencode"); err != nil {
+		return err
+	}
+	s.fireExec()
+	return nil
+}
+
+func (s *opBDD) secondHandoffFreshScratch() error {
+	dirs := scratchDirsUnder(s.scratchRoot)
+	if len(dirs) != 1 {
+		return fmt.Errorf("scratch dirs = %v, want exactly the second session's", dirs)
+	}
+	if dirs[0] == s.firstDir {
+		return fmt.Errorf("the second handoff reused the first scratch dir")
+	}
+	return nil
+}
+
+func (s *opBDD) holderSpendZeroAgain() error {
+	if v := s.holder.Spent(); v != 0 {
+		return fmt.Errorf("holder spend = %v after the second handoff, want $0.00", v)
+	}
+	return nil
+}
+
+func (s *opBDD) holderCallsZeroAgain() error {
+	if n := s.holder.Calls(); n != 0 {
+		return fmt.Errorf("holder calls = %d after the second handoff, want 0", n)
+	}
+	return nil
+}
+
+func (s *opBDD) namedGuestReturns(name string) error {
+	if err := s.ensureHandoff(name); err != nil {
+		return err
+	}
+	s.doReturn(nil)
+	return nil
+}
+
+func (s *opBDD) aiderCarriesNoOpencodeArtifacts() error {
+	if err := s.ensureHandoff("aider"); err != nil {
+		return err
+	}
+	last := s.execCmds[len(s.execCmds)-1]
+	if !strings.Contains(last.Path, "aider") {
+		return fmt.Errorf("the second exec is not aider: %s", last.Path)
+	}
+	if envValue(last.Env, "OPENCODE_CONFIG") != "" {
+		return fmt.Errorf("aider child env carries OPENCODE_CONFIG")
+	}
+	return nil
+}
+
+func (s *opBDD) firstScratchGone() error {
+	if s.firstDir == "" {
+		return nil // the first guest (aider two-guest flow) had no scratch dir at all
+	}
+	if _, err := os.Stat(s.firstDir); !os.IsNotExist(err) {
+		return fmt.Errorf("the first session's scratch dir remains: %s", s.firstDir)
+	}
+	return nil
+}
+
+func envValue(env []string, key string) string {
+	v := ""
+	for _, kv := range env { // last one wins, matching child-process semantics
+		if strings.HasPrefix(kv, key+"=") {
+			v = strings.TrimPrefix(kv, key+"=")
+		}
+	}
+	return v
+}
+
+// --- RC interlock steps -------------------------------------------------------------------
+
+const opRCSession = "opsess"
+
+func (s *opBDD) startRCBroker() {
+	s.rcQueue = make(chan protocol.RCInbound, 32)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/rc/"+opRCSession+"/poll", func(w http.ResponseWriter, r *http.Request) {
+		if s.rc401.Load() {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		select {
+		case in := <-s.rcQueue:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(in)
+		case <-time.After(40 * time.Millisecond):
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+	mux.HandleFunc("/rc/"+opRCSession+"/events", func(w http.ResponseWriter, r *http.Request) {
+		var fs []protocol.RCFrame
+		_ = json.NewDecoder(r.Body).Decode(&fs)
+		s.framesMu.Lock()
+		s.frames = append(s.frames, fs...)
+		s.framesMu.Unlock()
+	})
+	s.rcSrv = httptest.NewServer(mux)
+	s.bridge = client.NewRCBridge(s.rcSrv.URL, opRCSession, "host-token")
+	s.bridge.Run()
+}
+
+func (s *opBDD) hostSessionWithBridge() error {
+	s.seedTUI("qwen3-32b-fp8")
+	s.startRCBroker()
+	s.mutate(func(m *model) { m.rcBridge = s.bridge })
+	return nil
+}
+
+func (s *opBDD) tunedBandAndDetectedGuest(name string) error { return s.addDetected(name) }
+
+func (s *opBDD) framesSnapshot() []protocol.RCFrame {
+	s.framesMu.Lock()
+	defer s.framesMu.Unlock()
+	return append([]protocol.RCFrame(nil), s.frames...)
+}
+
+func (s *opBDD) statusFrameCount() int {
+	n := 0
+	for _, f := range s.framesSnapshot() {
+		if f.Kind == protocol.RCKindStatus {
+			n++
+		}
+	}
+	return n
+}
+
+func waitFor(cond func() bool, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+func (s *opBDD) statusFrameEmittedBeforeExec() error {
+	if len(s.execCmds) == 0 {
+		return fmt.Errorf("no exec was issued")
+	}
+	if !waitFor(func() bool { return s.statusFrameCount() > 0 }, 2*time.Second) {
+		return fmt.Errorf("no status frame reached the broker")
+	}
+	// "before the exec": the emit precedes the Park in onOperatorExec and the Park is
+	// strictly proven to precede the exec (parkedAtExec); the pump preserves order, so
+	// the FIRST frame on the wire must be the handoff-start status frame.
+	first := s.framesSnapshot()[0]
+	if first.Kind != protocol.RCKindStatus || first.Operator == "" {
+		return fmt.Errorf("the first wire frame is not the operator status frame: %+v", first)
+	}
+	if len(s.parkedAtExec) == 0 || !s.parkedAtExec[len(s.parkedAtExec)-1] {
+		return fmt.Errorf("the exec was issued before the interlock engaged")
+	}
+	return nil
+}
+
+func (s *opBDD) frameNamesOperator(name string) error {
+	for _, f := range s.framesSnapshot() {
+		if f.Kind == protocol.RCKindStatus && f.Operator == name {
+			return nil
+		}
+	}
+	return fmt.Errorf("no status frame names operator %q (frames: %+v)", name, s.framesSnapshot())
+}
+
+func (s *opBDD) bridgeIsParked() error {
+	if _, parked := s.bridge.Parked(); !parked {
+		return fmt.Errorf("the bridge is not parked")
+	}
+	return nil
+}
+
+func (s *opBDD) parkedBeforeExecReturned() error {
+	if len(s.parkedAtExec) == 0 || !s.parkedAtExec[len(s.parkedAtExec)-1] {
+		return fmt.Errorf("the bridge was not parked when the exec cmd was issued")
+	}
+	return nil
+}
+
+// viewerSendsTurn queues an inbound turn on the stub broker and waits for the bridge to
+// consume it (parked: the status auto-frame lands; unparked: it reaches Inbound()).
+func (s *opBDD) viewerSendsTurn(text string) error {
+	base := s.statusFrameCount()
+	s.rcQueue <- protocol.RCInbound{Kind: protocol.RCInTurn, Text: text, Origin: "phone"}
+	_, parked := s.bridge.Parked()
+	if parked {
+		if !waitFor(func() bool { return s.statusFrameCount() > base }, 2*time.Second) {
+			return fmt.Errorf("the parked bridge never answered the turn with a status frame")
+		}
+		return nil
+	}
+	if !waitFor(func() bool { return len(s.rcQueue) == 0 }, 2*time.Second) {
+		return fmt.Errorf("the bridge never polled the turn")
+	}
+	return nil
+}
+
+func (s *opBDD) turnNotQueuedForDJ() error {
+	select {
+	case in := <-s.bridge.Inbound():
+		return fmt.Errorf("a parked turn reached the host inbound: %+v", in)
+	default:
+	}
+	if q := s.model().agentQueued; len(q) != 0 {
+		return fmt.Errorf("a parked turn was queued for the DJ: %v", q)
+	}
+	return nil
+}
+
+func (s *opBDD) viewersReceiveGuestHasMicStatus() error {
+	for _, f := range s.framesSnapshot() {
+		if f.Kind == protocol.RCKindStatus && strings.Contains(f.Text, "guest has the mic") {
+			return nil
+		}
+	}
+	return fmt.Errorf("no 'guest has the mic' status frame (frames: %+v)", s.framesSnapshot())
+}
+
+func (s *opBDD) noAgentTurnFires(text string) error {
+	if err := s.turnNotQueuedForDJ(); err != nil {
+		return err
+	}
+	if strings.Contains(s.view(), text) {
+		return fmt.Errorf("the dropped turn %q reached the transcript", text)
+	}
+	if s.model().agentBusy {
+		return fmt.Errorf("an agent turn fired")
+	}
+	return nil
+}
+
+func (s *opBDD) viewersSentNTurns(n int) error {
+	for i := 0; i < n; i++ {
+		if err := s.viewerSendsTurn(fmt.Sprintf("parked turn %d", i+1)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) guestReturnsAndUnparks() error {
+	s.doReturn(nil)
+	if _, parked := s.bridge.Parked(); parked {
+		return fmt.Errorf("the bridge is still parked after the return")
+	}
+	return nil
+}
+
+func (s *opBDD) noQueuedTurnFires() error { return s.turnNotQueuedForDJ() }
+
+func (s *opBDD) djReceivesZeroInjectedTurns() error {
+	if strings.Contains(s.view(), "parked turn") {
+		return fmt.Errorf("a parked-window turn replayed into the DJ")
+	}
+	return s.turnNotQueuedForDJ()
+}
+
+func (s *opBDD) viewerSendsConfirm() error {
+	s.rcQueue <- protocol.RCInbound{Kind: protocol.RCInConfirm, Approve: true, ConfirmID: "stale", Origin: "phone"}
+	if !waitFor(func() bool { return len(s.rcQueue) == 0 }, 2*time.Second) {
+		return fmt.Errorf("the bridge never polled the confirm")
+	}
+	time.Sleep(50 * time.Millisecond) // let the intercept settle before asserting the drop
+	return nil
+}
+
+func (s *opBDD) confirmDropped() error {
+	select {
+	case in := <-s.bridge.Inbound():
+		return fmt.Errorf("a parked confirm reached the host: %+v", in)
+	default:
+		return nil
+	}
+}
+
+func (s *opBDD) noToolRuns() error {
+	if s.model().agentPendingConfirm != nil {
+		return fmt.Errorf("a confirm is pending")
+	}
+	if strings.Contains(s.view(), "approved · running") {
+		return fmt.Errorf("a tool ran off a parked confirm")
+	}
+	return nil
+}
+
+func (s *opBDD) viewerAttachesRequestsBackfill() error {
+	s.rcQueue <- protocol.RCInbound{Kind: protocol.RCInBackfill, Viewer: "roadside", Origin: "roadside"}
+	if !waitFor(func() bool {
+		for _, f := range s.framesSnapshot() {
+			if f.Kind == protocol.RCKindBackfill && f.Viewer == "roadside" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second) {
+		return fmt.Errorf("no backfill frame was answered for the mid-handoff viewer")
+	}
+	return nil
+}
+
+func (s *opBDD) viewerReceivesTranscriptSnapshot() error {
+	for _, f := range s.framesSnapshot() {
+		if f.Kind == protocol.RCKindBackfill && f.Viewer == "roadside" && f.Text != "" {
+			return nil
+		}
+	}
+	return fmt.Errorf("the backfill answer carries no transcript snapshot")
+}
+
+func (s *opBDD) statusFrameDJBack() error {
+	if !waitFor(func() bool {
+		for _, f := range s.framesSnapshot() {
+			if f.Kind == protocol.RCKindStatus && strings.Contains(f.Text, "DJ is back") {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second) {
+		return fmt.Errorf("no 'DJ is back' status frame after the return")
+	}
+	return nil
+}
+
+func (s *opBDD) subsequentTurnInjectsLikeLocal() error {
+	const text = "status check from the road"
+	s.rcQueue <- protocol.RCInbound{Kind: protocol.RCInTurn, Text: text, Origin: "phone"}
+	select {
+	case in := <-s.bridge.Inbound():
+		s.update(remoteInboundMsg(in)) // the re-armed drain's round trip
+	case <-time.After(2 * time.Second):
+		return fmt.Errorf("the unparked bridge never delivered the turn")
+	}
+	if !strings.Contains(s.view(), text) {
+		return fmt.Errorf("the post-handoff turn did not inject into the DJ:\n%s", s.view())
+	}
+	return nil
+}
+
+func (s *opBDD) bridgeNotEnabled() error {
+	s.mutate(func(m *model) { m.rcBridge = nil })
+	if s.bridge != nil {
+		s.bridge.Stop()
+	}
+	s.framesMu.Lock()
+	s.frames = nil
+	s.framesMu.Unlock()
+	return nil
+}
+
+func (s *opBDD) noFrameEmitted() error {
+	time.Sleep(120 * time.Millisecond) // give a stray frame the chance to land
+	if got := s.framesSnapshot(); len(got) != 0 {
+		return fmt.Errorf("frames were emitted with no bridge: %+v", got)
+	}
+	return nil
+}
+
+func (s *opBDD) handoffProceedsNormally() error {
+	if len(s.execCmds) == 0 {
+		return fmt.Errorf("the handoff did not reach the exec")
+	}
+	return nil
+}
+
+func (s *opBDD) sessionRevokedDuringHandoff() error {
+	s.rc401.Store(true)
+	select {
+	case <-s.bridge.Done():
+		return nil
+	case <-time.After(3 * time.Second):
+		return fmt.Errorf("the 401'd bridge never stopped")
+	}
+}
+
+func (s *opBDD) unparkIsNoOp() error {
+	s.doReturn(nil) // Unpark on the dead bridge must be silent, never a panic
+	return nil
+}
+
+func (s *opBDD) deskSummaryStillRenders() error { return s.transcriptShows("had the mic for") }
+
+func (s *opBDD) protocolReservesFrameKind(name string) error {
+	if protocol.RCKindOperatorStatus != name {
+		return fmt.Errorf("RCKindOperatorStatus = %q, want %q", protocol.RCKindOperatorStatus, name)
+	}
+	return nil
+}
+
+func (s *opBDD) protocolReservesInboundKind(name string) error {
+	switch name {
+	case protocol.RCInOperatorHandoff, protocol.RCInOperatorRecall:
+		return nil
+	}
+	return fmt.Errorf("inbound kind %q is not reserved", name)
+}
+
+// reservedKindsNoBehavior EXECUTES the claim: each reserved inbound kind is fed through
+// the host's real dispatch (onRemoteInbound) and must change nothing - no turn, no queue,
+// no transcript, no confirm (the default case drops unknown kinds; viewers likewise
+// ignore unknown frame kinds by the wire contract).
+func (s *opBDD) reservedKindsNoBehavior() error {
+	before := s.view()
+	for _, kind := range []string{protocol.RCInOperatorHandoff, protocol.RCInOperatorRecall} {
+		s.update(remoteInboundMsg(protocol.RCInbound{Kind: kind, Text: "future-surface payload"}))
+		m := s.model()
+		if m.agentBusy || len(m.agentQueued) != 0 || m.agentPendingConfirm != nil {
+			return fmt.Errorf("reserved inbound kind %q triggered behavior in v1", kind)
+		}
+	}
+	if s.view() != before {
+		return fmt.Errorf("a reserved inbound kind changed the transcript in v1")
+	}
+	return nil
+}
+
+func (s *opBDD) handoffBeginsAndGuestWorks(name string) error {
+	if err := s.handoffBegins(name); err != nil {
+		return err
+	}
+	return s.proxyCallsCosts([]string{"0.01", "0"}) // the guest works the band a little
+}
+
+func (s *opBDD) noFrameCarriesGuestOutput() error {
+	for _, f := range s.framesSnapshot() {
+		if f.Kind != protocol.RCKindStatus {
+			return fmt.Errorf("a non-status frame leaked during the handoff: %+v", f)
+		}
+	}
+	return nil
+}
+
+// --- suite wiring ---------------------------------------------------------------------------
+
+// initializeOperatorScenarios registers every step of the founder-approved Phase 2 spec
+// set against the shared opBDD state.
+func initializeOperatorScenarios(t *testing.T, st *opBDD, sc *godog.ScenarioContext) {
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		st.reset(t)
+		return ctx, nil
+	})
+
+	// ── detection.feature (pure) ──────────────────────────────────────────────
+	sc.Step(`^the guest operator registry$`, st.theGuestOperatorRegistry)
+	sc.Step(`^the registry lists exactly "([^"]*)", "([^"]*)", "([^"]*)" in that order$`, st.registryListsExactly)
+	sc.Step(`^no registry entry is named "([^"]*)" or "([^"]*)"$`, st.noRegistryEntryNamed)
+	sc.Step(`^every entry carries a name, a PATH binary, a provider tag, an install hint, and a known-good version$`, st.everyEntryCarriesFields)
+	sc.Step(`^the "([^"]*)" entry uses the (scratch-config|scratch-home) strategy with known-good version "([^"]*)"$`,
+		func(name, strat, v string) error { return st.entryUsesStrategyWithVersion(name, strat, v) })
+	sc.Step(`^the "aider" entry uses the env-and-flags strategy with no config file at all$`, st.aiderEnvFlagsNoConfig)
+	sc.Step(`^LookPath resolves "([^"]*)" to "([^"]*)"$`, st.lookPathResolves)
+	sc.Step(`^LookPath fails for "([^"]*)" with "([^"]*)"$`, st.lookPathFails)
+	sc.Step(`^LookPath fails for every binary$`, st.lookPathFailsForEverything)
+	sc.Step(`^LookPath resolves every registry binary$`, st.lookPathResolvesEveryRegistryBinary)
+	sc.Step(`^the version probe answers "([^"]*)" with "([^"]*)"$`, st.probeAnswers)
+	sc.Step(`^the version probe fails for "([^"]*)" with "([^"]*)"$`, st.probeFails)
+	sc.Step(`^the version probe for "([^"]*)" blocks past its deadline$`, st.probeBlocksPastDeadline)
+	sc.Step(`^the desk is scanned( again)?$`, func(string) error { return st.deskScanned() })
+	sc.Step(`^the detections are "([^"]*)", "([^"]*)", "([^"]*)" in that order$`, st.detectionsInOrder)
+	sc.Step(`^the detections are exactly "([^"]*)"$`, st.detectionsExactly)
+	sc.Step(`^the detections are empty$`, st.detectionsEmpty)
+	sc.Step(`^no error is surfaced$`, st.noErrorSurfaced)
+	sc.Step(`^the detections include "([^"]*)"$`, st.detectionsInclude)
+	sc.Step(`^the detections do not include "([^"]*)"$`, st.detectionsDoNotInclude)
+	sc.Step(`^each detection records the resolved path$`, st.eachDetectionRecordsPath)
+	sc.Step(`^the "([^"]*)" detection has version "([^"]*)" and is verified$`, st.detectionVersionVerified)
+	sc.Step(`^the "([^"]*)" detection is unverified with an empty version$`, st.detectionUnverifiedEmptyVersion)
+	sc.Step(`^the "([^"]*)" detection is unverified$`, st.detectionUnverified)
+	sc.Step(`^the "([^"]*)" detection is unverified with version "([^"]*)"$`, st.detectionUnverifiedWithVersion)
+	sc.Step(`^the scan completes$`, st.scanCompletes)
+	sc.Step(`^the raw version output "([^"]*)" for "([^"]*)" is parsed$`, st.rawVersionParsed)
+	sc.Step(`^the parsed version is "([^"]*)"$`, st.parsedVersionIs)
+	sc.Step(`^no file was written anywhere$`, st.noFileWrittenAnywhere)
+	sc.Step(`^no request hit the local proxy$`, st.noRequestHitProxy)
+
+	// ── config_*.feature + config_isolation.feature (pure) ───────────────────
+	sc.Step(`^a live proxy session at "([^"]*)" with session key "([^"]*)" and band model "([^"]*)"$`, st.liveProxySession)
+	sc.Step(`^a session scratch dir$`, st.aSessionScratchDir)
+	sc.Step(`^the (opencode|hermes|aider) launch is materialized$`, st.materialize)
+	sc.Step(`^the (opencode|hermes|aider) launch is materialized and the guest exits$`, st.materializeAndExit)
+	sc.Step(`^the (opencode|hermes|aider) launch is materialized again$`, st.materializeAgain)
+	sc.Step(`^the aider launch is materialized for any band model$`, func() error { return st.materialize("aider") })
+	sc.Step(`^the scratch dir contains exactly one file "([^"]*)"$`, st.scratchContainsExactlyOneFile)
+	sc.Step(`^the scratch dir contains "([^"]*)"$`, st.scratchContains)
+	sc.Step(`^"([^"]*)" equals the golden artifact:$`, st.fileEqualsGolden)
+	sc.Step(`^the argv is exactly "([^"]*)"$`, st.argvIsExactly)
+	sc.Step(`^the argv (?:still )?pins "([^"]*)"$`, st.argvPins)
+	sc.Step(`^the argv contains "([^"]*)"$`, st.argvContains)
+	sc.Step(`^the env additions are exactly:$`, st.envAdditionsExactly)
+	sc.Step(`^the parent environment is otherwise inherited unmodified$`, st.parentEnvInherited)
+	sc.Step(`^no file under the scratch dir contains the string "([^"]*)"$`, st.noScratchFileContains)
+	sc.Step(`^no file on the entire scratch path contains "([^"]*)"$`, st.noScratchFileContains)
+	sc.Step(`^the launch workdir contains a project "opencode\.json" selecting model "([^"]*)"$`, st.workdirHasProjectConfig)
+	sc.Step(`^the project "opencode\.json" is not modified$`, st.projectConfigNotModified)
+	sc.Step(`^the band is re-tuned to model "([^"]*)" before the handoff$`, st.bandRetuned)
+	sc.Step(`^"([^"]*)" wires (?:default )?model "([^"]*)"$`, st.fileWiresModel)
+	sc.Step(`^the guest exits cleanly$`, st.guestExitsCleanly)
+	sc.Step(`^the guest crashes with exit 1$`, st.guestCrashesExit1)
+	sc.Step(`^the session scratch dir no longer exists$`, st.scratchDirGone)
+	sc.Step(`^the user has a real "([^"]*)"$`, st.userHasRealFile)
+	sc.Step(`^"([^"]*)" is byte-identical to before$`, st.realFileByteIdentical)
+	sc.Step(`^nothing was written under "([^"]*)"$`, st.nothingWrittenUnder)
+	sc.Step(`^"hermes-home/config\.yaml" contains a "providers:" section with an api_key reference$`, st.hermesConfigHasKeyedProviders)
+	sc.Step(`^no scratch dir exists for the session$`, st.noScratchDirForSession)
+	sc.Step(`^the parent environment already sets OPENAI_API_KEY to "([^"]*)"$`,
+		func(v string) error { return st.parentEnvSets("OPENAI_API_KEY", v) })
+	sc.Step(`^the child env sets ([A-Z_]+) to "([^"]*)"$`, st.childEnvSets)
+	sc.Step(`^a sentinel snapshot of the user's home and the launch workdir$`, st.sentinelSnapshot)
+	sc.Step(`^every written path is under the session scratch dir$`, st.everyWrittenPathUnderScratch)
+	sc.Step(`^the user's home matches the sentinel snapshot$`, st.homeMatchesSentinel)
+	sc.Step(`^the launch workdir matches the sentinel snapshot$`, st.workdirMatchesSentinel)
+	sc.Step(`^the session scratch dir has mode 0700$`, st.scratchDirMode0700)
+	sc.Step(`^the child working directory is the launch workdir$`, st.childWorkdirIsLaunchWorkdir)
+	sc.Step(`^the child working directory is not the session scratch dir$`, st.childWorkdirNotScratch)
+	sc.Step(`^no rogerai-operator scratch dir remains for this session$`, st.noOperatorScratchRemains)
+	sc.Step(`^the guest removed files inside the scratch dir before exiting$`, st.guestRemovedFilesInScratch)
+	sc.Step(`^cleanup still succeeds$`, st.cleanupStillSucceeds)
+	sc.Step(`^a leftover "([^"]*)" scratch dir older than 24 hours$`, st.leftoverScratchDirOld)
+	sc.Step(`^a fresh "([^"]*)" scratch dir from a running session$`, st.freshScratchDir)
+	sc.Step(`^"(rogerai-operator-[^"]*)" is removed$`, st.namedDirRemoved)
+	sc.Step(`^"(rogerai-operator-[^"]*)" is untouched$`, st.namedDirUntouched)
+	sc.Step(`^the second session scratch dir differs from the first$`, st.secondScratchDiffers)
+	sc.Step(`^only the second scratch dir exists$`, st.onlySecondScratchExists)
+	sc.Step(`^the child env contains ROGER_SESSION_KEY$`, st.childEnvContainsSessionKey)
+	sc.Step(`^the session budget is capped at the default session budget$`, st.budgetCappedAtDefault)
+
+	// ── operator_command.feature (TUI) ─────────────────────────────────────────
+	sc.Step(`^an AGENT session at the ask prompt$`, st.agentSessionAtPrompt)
+	sc.Step(`^the agent command registry contains "([^"]*)"$`, st.registryContains)
+	sc.Step(`^the registry stays sorted, lowercase, and duplicate-free$`, st.registrySortedLowercaseUnique)
+	sc.Step(`^the agent command registry does not contain "([^"]*)"$`, st.registryNotContains)
+	sc.Step(`^the user runs "([^"]*)"$`, st.userRuns)
+	sc.Step(`^the transcript does not show "([^"]*)"$`, st.transcriptDoesNotShow)
+	sc.Step(`^the user has typed "([^"]*)"$`, st.userHasTyped)
+	sc.Step(`^the suggestion strip includes "([^"]*)"$`, st.stripIncludes)
+	sc.Step(`^the suggestion strip never includes "([^"]*)" or "([^"]*)"$`, st.stripNeverIncludesAliases)
+	sc.Step(`^no guest operators are detected$`, st.noGuestsDetected)
+	sc.Step(`^detected guests "([^"]*)" and "([^"]*)"$`, st.detectedGuestsTwo)
+	sc.Step(`^detected guests "([^"]*)"$`, st.detectedGuests)
+	sc.Step(`^undetected registry guests "([^"]*)" and "([^"]*)"$`, st.undetectedGuestsTwo)
+	sc.Step(`^an undetected registry guest "([^"]*)"$`, st.undetectedGuest)
+	sc.Step(`^a detected guest "([^"]*)" that requires setup$`, st.detectedGuestRequiresSetup)
+	sc.Step(`^no picker opens$`, st.noPickerOpens)
+	sc.Step(`^the transcript notes "([^"]*)"$`, st.transcriptNotes)
+	sc.Step(`^the operator picker is open$`, st.pickerOpen)
+	sc.Step(`^the picker rows are "DJ", "([^"]*)", "([^"]*)"$`, st.pickerRowsAre)
+	sc.Step(`^the picker rows are "DJ", "([^"]*)" and one suggestion row$`, st.pickerRowsWithSuggestion)
+	sc.Step(`^the suggestion row shows an install hint$`, st.suggestionShowsInstallHint)
+	sc.Step(`^the user presses down past the last selectable row$`, st.pressDownPastLast)
+	sc.Step(`^the cursor stays on "([^"]*)"$`, st.cursorStaysOn)
+	sc.Step(`^the cursor is never on the suggestion row$`, st.cursorNeverOnSuggestion)
+	sc.Step(`^the user picks "([^"]*)"$`, st.userPicks)
+	sc.Step(`^the picker closes$`, st.pickerClosed)
+	sc.Step(`^the handoff to "([^"]*)" begins$`, st.handoffBegins)
+	sc.Step(`^the transcript shows the setup note for "([^"]*)"$`,
+		func(name string) error { return st.transcriptShows(name + " needs") })
+	sc.Step(`^no child process is launched$`, st.noChildLaunched)
+	sc.Step(`^the transcript notes the DJ keeps the mic$`, func() error { return st.transcriptShows("the DJ keeps the mic") })
+	sc.Step(`^the user presses esc$`, st.userPressesEsc)
+	sc.Step(`^the user presses "([^"]*)"$`, st.userPresses)
+	sc.Step(`^the picker is still open$`, st.pickerStillOpen)
+	sc.Step(`^the TUI did not switch modes$`, st.tuiDidNotSwitchModes)
+	sc.Step(`^"([^"]*)" appears on PATH$`, st.guestAppearsOnPath)
+	sc.Step(`^the picker rows include "([^"]*)"$`, st.pickerRowsInclude)
+	sc.Step(`^the transcript shows the install hint for "([^"]*)"$`, st.transcriptShowsInstallHint)
+	sc.Step(`^no chat turn is submitted$`, st.noChatTurnSubmitted)
+	sc.Step(`^the transcript notes the name is not a known operator$`, st.nameNotKnownOperator)
+
+	// ── handoff_lifecycle.feature (TUI) ────────────────────────────────────────
+	sc.Step(`^an AGENT session with a tuned band "([^"]*)" and a live proxy holder$`, st.agentSessionTuned)
+	sc.Step(`^a detected guest "([^"]*)"$`, st.detectedGuests)
+	sc.Step(`^the proxy holder is disconnected$`, st.holderDisconnected)
+	sc.Step(`^the transcript points at tuning in first$`, st.pointsAtTuningIn)
+	sc.Step(`^a DJ turn is in flight$`, st.djTurnInFlight)
+	sc.Step(`^the transcript notes the DJ is mid-turn$`, st.notesDJMidTurn)
+	sc.Step(`^a DJ turn is in flight and a prompt is queued$`, st.djTurnInFlightAndQueued)
+	sc.Step(`^the next paint shows "([^"]*)"$`, st.nextPaintShows)
+	sc.Step(`^it shows the mic-to line for "([^"]*)"$`, st.paintShowsMicTo)
+	sc.Step(`^it shows the on-band line for "([^"]*)"$`, st.paintShowsOnBand)
+	sc.Step(`^it shows the wire line "([^"]*)"$`, st.paintShowsWireLine)
+	sc.Step(`^only after that paint is the exec command issued$`, st.execOnlyAfterPaint)
+	sc.Step(`^the staged paint shows the live proxy BASE URL$`, st.paintShowsBaseURL)
+	sc.Step(`^the staged paint shows MODEL "([^"]*)"$`, st.paintShowsModel)
+	sc.Step(`^the band was re-tuned since the proxy first bound$`, st.bandRetunedSinceBind)
+	sc.Step(`^the child wiring carries the CURRENT band model and endpoint$`, st.childCarriesCurrentOptions)
+	sc.Step(`^never the options frozen at first bind$`, st.neverFrozenOptions)
+	sc.Step(`^the previous session spent "\$([0-9.]+)" of its budget$`, st.previousSessionSpent)
+	sc.Step(`^the holder budget is the default session budget$`, st.holderBudgetIsDefault)
+	sc.Step(`^the holder spend reads \$0\.00$`, st.holderSpendZero)
+	sc.Step(`^the holder call counter reads 0$`, st.holderCallsZero)
+	sc.Step(`^the child env carries the SAME session key the proxy enforces$`, st.childEnvCarriesSameKey)
+	sc.Step(`^the key was not rotated by the handoff$`, st.keyNotRotated)
+	sc.Step(`^the guest returns after (\d+) minutes, (\d+) calls, and \$([0-9.]+) spend with exit 0$`, st.guestReturnsAfter)
+	sc.Step(`^the terminal reset preamble ran: kitty keyboard popped, mouse modes off, bracketed paste exited$`, st.resetPreambleRan)
+	sc.Step(`^mouse cell motion is re-enabled because the user has the mouse on$`, st.mouseReenabled)
+	sc.Step(`^a balance refresh is requested$`, st.balanceRefreshRequested)
+	sc.Step(`^the transcript shows "([^"]*)"$`, st.transcriptShows)
+	sc.Step(`^the guest returns with exit (\d+)$`, st.guestReturnsExit)
+	sc.Step(`^the summary calls figure equals the holder call counter$`, st.summaryCallsEqualHolder)
+	sc.Step(`^the summary spend figure equals the holder Spent\(\)$`, st.summarySpendEqualsHolder)
+	sc.Step(`^the user disabled the mouse before the handoff$`, st.userMouseOff)
+	sc.Step(`^the defensive reset still disabled the guest's mouse modes$`, st.mouseModesDisabled)
+	sc.Step(`^mouse reporting is NOT re-enabled$`, st.mouseNotReenabled)
+	sc.Step(`^the note is calm, with no error styling escalation beyond the house red ✕$`, st.noteIsCalm)
+	sc.Step(`^the terminal restore and summary still run$`, st.restoreAndSummaryRan)
+	sc.Step(`^the terminal reset preamble ran$`, st.resetPreambleRan)
+	sc.Step(`^the scratch config was cleaned up$`, st.scratchConfigCleaned)
+	sc.Step(`^the guest is killed mid-session$`, st.guestKilled)
+	sc.Step(`^the summary line still renders with the accumulated calls and spend$`, st.summaryLineRenders)
+	sc.Step(`^the guest binary vanishes between detection and exec$`, st.binaryVanishes)
+	sc.Step(`^the TUI is painting again$`, st.tuiPaintingAgain)
+	sc.Step(`^the transcript shows an error note naming the launch failure$`, st.errorNoteNamesLaunchFailure)
+	sc.Step(`^no scratch dir remains$`, st.noOperatorScratchRemains)
+	sc.Step(`^the guest returns with any exit$`, st.guestReturnsAnyExit)
+	sc.Step(`^the guest spends up to the session budget during the handoff$`, st.guestSpendsToBudget)
+	sc.Step(`^the guest returns$`, st.guestReturnsPlain)
+	sc.Step(`^the summary notes the session budget was reached$`, st.summaryNotesBudgetReached)
+	sc.Step(`^the summary spend figure is at or just past the default session budget$`, st.summarySpendAtOrPastBudget)
+	sc.Step(`^the band goes off-air while the guest has the mic$`, st.bandGoesOffAir)
+	sc.Step(`^the summary shows the spend accumulated before the drop$`, st.summaryShowsSpendBeforeDrop)
+	sc.Step(`^the desk is fully usable for a re-tune$`, st.deskUsableForRetune)
+	sc.Step(`^the guest has the mic$`, st.guestHasTheMic)
+	sc.Step(`^no TUI key handling runs until the exec callback returns$`, st.noKeyHandlingDuringExec)
+	sc.Step(`^the guest returns after spending "\$([0-9.]+)"$`, st.guestReturnsAfterSpending)
+	sc.Step(`^the user immediately runs "/operator opencode" again$`, st.userRunsOperatorAgain)
+	sc.Step(`^the second handoff gets a fresh scratch dir$`, st.secondHandoffFreshScratch)
+	sc.Step(`^the holder spend reads \$0\.00 again$`, st.holderSpendZeroAgain)
+	sc.Step(`^the holder call counter reads 0 again$`, st.holderCallsZeroAgain)
+	sc.Step(`^the session key is unchanged$`, st.keyNotRotated)
+	sc.Step(`^a detected guest "([^"]*)" as well$`, st.detectedGuests)
+	sc.Step(`^the guest "([^"]*)" returns$`, st.namedGuestReturns)
+	sc.Step(`^the aider wiring carries no opencode artifacts$`, st.aiderCarriesNoOpencodeArtifacts)
+	sc.Step(`^the first session's scratch dir is already gone$`, st.firstScratchGone)
+
+	// ── rc_interlock.feature (TUI + a REAL bridge) ─────────────────────────────
+	sc.Step(`^a HOST agent session with an attached remote-control bridge$`, st.hostSessionWithBridge)
+	sc.Step(`^a tuned band and a detected guest "([^"]*)"$`, st.tunedBandAndDetectedGuest)
+	sc.Step(`^a frame of kind "status" is emitted before the exec$`, st.statusFrameEmittedBeforeExec)
+	sc.Step(`^the frame names the operator "([^"]*)"$`, st.frameNamesOperator)
+	sc.Step(`^the bridge is parked$`, st.bridgeIsParked)
+	sc.Step(`^parking happened before the exec command was returned$`, st.parkedBeforeExecReturned)
+	sc.Step(`^a viewer sends a turn "([^"]*)"$`, st.viewerSendsTurn)
+	sc.Step(`^the turn is not queued for the DJ$`, st.turnNotQueuedForDJ)
+	sc.Step(`^the viewers receive a status frame saying the guest has the mic$`, st.viewersReceiveGuestHasMicStatus)
+	sc.Step(`^no agent turn ever fires for "([^"]*)"$`, st.noAgentTurnFires)
+	sc.Step(`^viewers sent (\d+) turns during the handoff$`, st.viewersSentNTurns)
+	sc.Step(`^the guest returns and the bridge unparks$`, st.guestReturnsAndUnparks)
+	sc.Step(`^no queued turn fires$`, st.noQueuedTurnFires)
+	sc.Step(`^the DJ receives zero injected turns from the parked window$`, st.djReceivesZeroInjectedTurns)
+	sc.Step(`^a viewer sends a confirm approval$`, st.viewerSendsConfirm)
+	sc.Step(`^it is dropped$`, st.confirmDropped)
+	sc.Step(`^no tool runs$`, st.noToolRuns)
+	sc.Step(`^a new viewer attaches and requests backfill$`, st.viewerAttachesRequestsBackfill)
+	sc.Step(`^the viewer receives the transcript snapshot$`, st.viewerReceivesTranscriptSnapshot)
+	sc.Step(`^the viewer receives a status frame saying the guest has the mic$`, st.viewersReceiveGuestHasMicStatus)
+	sc.Step(`^a frame of kind "status" is emitted announcing the DJ is back$`, st.statusFrameDJBack)
+	sc.Step(`^a subsequent viewer turn injects into the DJ exactly like local typing$`, st.subsequentTurnInjectsLikeLocal)
+	sc.Step(`^the remote-control bridge is not enabled$`, st.bridgeNotEnabled)
+	sc.Step(`^no frame is emitted$`, st.noFrameEmitted)
+	sc.Step(`^the handoff proceeds normally$`, st.handoffProceedsNormally)
+	sc.Step(`^the remote session is revoked during the handoff$`, st.sessionRevokedDuringHandoff)
+	sc.Step(`^the unpark is a no-op$`, st.unparkIsNoOp)
+	sc.Step(`^the desk summary still renders$`, st.deskSummaryStillRenders)
+	sc.Step(`^the protocol reserves frame kind "([^"]*)"$`, st.protocolReservesFrameKind)
+	sc.Step(`^the protocol reserves inbound kind "([^"]*)"$`, st.protocolReservesInboundKind)
+	sc.Step(`^v1 attaches no behavior to any of them$`, st.reservedKindsNoBehavior)
+	sc.Step(`^the handoff to "([^"]*)" begins and the guest works for a while$`, st.handoffBeginsAndGuestWorks)
+	sc.Step(`^no frame carries any guest terminal output$`, st.noFrameCarriesGuestOutput)
+}

--- a/internal/tui/rc.go
+++ b/internal/tui/rc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rogerai-fyi/roger/internal/client"
 	"github.com/rogerai-fyi/roger/internal/glyphs"
 	"github.com/rogerai-fyi/roger/internal/harness"
 	"github.com/rogerai-fyi/roger/internal/protocol"
@@ -170,6 +171,14 @@ func (m model) onRemoteInbound(in protocol.RCInbound) (tea.Model, tea.Cmd) {
 	switch in.Kind {
 	case protocol.RCInTurn:
 		if strings.TrimSpace(in.Text) == "" {
+			return m, rearm
+		}
+		// Guest-operator staging guard (audit regression): from the moment a handoff is
+		// staged until the exec callback returns, a remote turn is dropped with the
+		// "guest has the mic" status auto-frame - the bridge itself parks only at exec
+		// time, so this covers the staging window. Never queued, never replayed.
+		if m.operatorHandoff != nil {
+			m.rcEmit(client.OperatorStatusFrame(m.operatorHandoff.det.Guest.Name))
 			return m, rearm
 		}
 		// Ensure the agent runtime exists (a remote turn can arrive before the local user

--- a/internal/tui/rc_test.go
+++ b/internal/tui/rc_test.go
@@ -17,6 +17,8 @@ type fakeBridge struct {
 	sid     string
 	ran     bool
 	stopped bool
+	parked  string // the guest-operator interlock ("" = unparked)
+	snap    string
 }
 
 func newFakeBridge() *fakeBridge {
@@ -29,6 +31,8 @@ func (b *fakeBridge) SessionID() string                  { return b.sid }
 func (b *fakeBridge) Disable() error                     { b.stop(); return nil }
 func (b *fakeBridge) Stop()                              { b.stop() }
 func (b *fakeBridge) Run()                               { b.ran = true }
+func (b *fakeBridge) Park(op, snapshot string)           { b.parked, b.snap = op, snapshot }
+func (b *fakeBridge) Unpark()                            { b.parked, b.snap = "", "" }
 func (b *fakeBridge) stop() {
 	if !b.stopped {
 		b.stopped = true

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -36,6 +36,7 @@ import (
 	"github.com/rogerai-fyi/roger/internal/detect"
 	"github.com/rogerai-fyi/roger/internal/glyphs"
 	"github.com/rogerai-fyi/roger/internal/node"
+	"github.com/rogerai-fyi/roger/internal/operator"
 	"github.com/rogerai-fyi/roger/internal/pricetier"
 	"github.com/rogerai-fyi/roger/internal/protocol"
 )
@@ -154,6 +155,12 @@ type RemoteBridge interface {
 	Disable() error // take the session off the air (revoke)
 	Stop()          // stop polling (session survives; used on quit)
 	Run()           // start the poll + event pumps
+	// Guest-operator interlock (Phase 2): while parked, inbound turns/confirms are
+	// dropped AT THE BRIDGE with a status auto-frame and backfill is answered from the
+	// snapshot - the host's event loop is suspended under tea.ExecProcess. Unpark on a
+	// dead/stopped bridge is a no-op.
+	Park(operator, snapshot string)
+	Unpark()
 }
 
 // RemoteInfo is what /remote-control prints once at enable.
@@ -683,15 +690,15 @@ type model struct {
 	// once (first tune-in) and re-pointed on every (re)tune via SetBand, keeping the stable
 	// per-session bearer key (proxyKey) so a running guest's config survives a re-tune; a
 	// disconnect flips it to "refuse - no band tuned". nil until the proxy is bound.
-	proxyHolder *client.ProxyOptionsHolder
-	proxyKey    string
-	confidentialOnly  bool
-	balance           float64
-	haveBal           bool
-	monthlyCap        float64 // per-account monthly spend cap ($); 0 = unlimited
-	monthlySpend      float64 // month-to-date captured spend ($)
-	status            string
-	alert             *alertBox
+	proxyHolder      *client.ProxyOptionsHolder
+	proxyKey         string
+	confidentialOnly bool
+	balance          float64
+	haveBal          bool
+	monthlyCap       float64 // per-account monthly spend cap ($); 0 = unlimited
+	monthlySpend     float64 // month-to-date captured spend ($)
+	status           string
+	alert            *alertBox
 	// pricing UX state
 	limits *LimitStore
 	bands  []band // offers grouped by model (the band list, 3.1)
@@ -811,6 +818,13 @@ type model struct {
 	agentPicker       bool     // the /model picker modal is open
 	agentPickerRows   []string // candidate models in the open picker
 	agentPickerCursor int      // selected row in the picker
+	// Guest Operators (Phase 2, THE DESK): the async desk-scan result, the /operator
+	// picker modal, and the live handoff state. See operator.go.
+	operatorDetections []operator.Detection // detected guest CLIs (registry order)
+	operatorPicker     bool                 // the /operator hand-the-mic modal is open
+	operatorRows       []operatorRow        // picker rows (DJ + detected + at most one suggestion)
+	operatorCursor     int                  // selected picker row (never the suggestion)
+	operatorHandoff    *operatorHandoff     // non-nil from staging until the exec returns
 	// `ask ›` slash-command autocomplete (agent.go: agentCommands / agentSlashStrip /
 	// the tab case in onAgentKey). agentTabPrefix is the typed prefix a live Tab
 	// completion cycle is stepping ("" = no cycle); agentTabIdx is the current pick
@@ -1499,6 +1513,12 @@ func (m model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case agentEventMsg:
 		return m.onAgentEvent(msg)
+	case operatorDetectedMsg: // an async desk scan landed (Guest Operators)
+		return m.onOperatorDetected(msg)
+	case operatorExecMsg: // the staged PATCHING paint elapsed - issue the exec
+		return m.onOperatorExec()
+	case operatorDoneMsg: // the guest returned the terminal (every child outcome)
+		return m.onOperatorDone(msg)
 	case remoteEnabledMsg:
 		return m.onRemoteEnabled(msg)
 	case remoteInboundMsg:


### PR DESCRIPTION
Implements Phase 2 of Guest Operators to GREEN against the founder-approved spec set (109 scenarios, features/operator/, approved 2026-07-06 with all 7 rulings). Design doc: rogerai-internal-docs/GUEST-OPERATORS.md.

## What ships
- **internal/operator** (new pure package): the guest registry (opencode / hermes / aider; claude + codex excluded v1), detection via injectable LookPath/Env seams with bounded version probes (UNVERIFIED never hidden), config materialization into a per-session 0700 scratch dir (golden-exact artifacts), cleanup + SweepStale crash sweep.
- **Config wiring per the approved rulings**: opencode = scratch opencode.json + OPENCODE_CONFIG + the argv `-m roger/<model>` pin (a user's project config can never silently re-route); hermes = HERMES_HOME scratch + the keyed providers schema with api_key env expansion (the model_aliases DirectAlias route 401s under proxy auth - pinned as a permanent regression); aider = pure env + flags incl. --no-auto-commits.
- **/operator command + picker** in the AGENT view (aliases /mic /guest /op typable-not-suggested), direct-jump, zero-guest note, r re-scan; modal cloned from the /model picker.
- **The handoff**: preconditions (tuned in, not mid-turn), one staged PATCHING YOU THROUGH frame, tea.ExecProcess with the composed env/config from the LIVE proxy options; per-handoff $2 budget + spend reset + call counter; on return: mouse re-enabled, defensive terminal reset preamble, balance refresh, the "back at the desk" summary line, honest exit-code semantics (130 = guest dropped off, not scary), config cleanup.
- **RC interlock**: park + DROP remote turns with a "guest has the mic" status frame (never queue/replay), confirms dropped safe, backfill answered with the placeholder, start/end status frames; reserved wire kinds operator_status / operator_handoff / operator_recall as documented no-behavior constants.
- **BrandPlate seam** (additive, data-only): each registry entry can carry a brand block + accent for the PATCHING screen; the final per-guest art lands as a follow-up data change per rogerai-internal-docs/GUEST-OPERATOR-PLATES.md ("one hue, one beat", founder-approved).

## Evidence
- RED baseline matched the approval gate (compile-RED internal/operator, assert-RED tui, 109 undefined godog scenarios) -> GREEN: all 109 scenarios + unit tables pass.
- make cover-gate PASS (every package >= 90% incl. the new internal/operator; no skip); go vet clean; -race green (operator/tui/client/protocol); pre-push cover-gate + claude-audit gate PASS on push (two audit minors fixed in follow-up commits: staged-handoff abort on leaving AGENT + the honest abort note).
- Live E2E on a free band through the hardened proxy: real opencode + hermes + aider one-shots completed model-rewritten + authed, billed $0, and the user's real configs verified untouched (before/after diff).

## Manual QA for the founder (needs a human terminal)
1. `[1]` tune into a band, `[0]` AGENT, `/operator` - picker lists your installed guests
2. Pick opencode - PATCHING YOU THROUGH plate, then opencode full-screen on the band
3. Ask it something tiny; exit - "back at the desk · opencode had the mic for Xm · N calls · $Y"
4. Check mouse still works in the TUI after return; re-run with ctrl-c inside the guest (should return clean, not kill RogerAI)
5. With the iOS app / a second surface attached via /remote-control: confirm it shows the guest-has-the-mic status during the handoff and no message burst on return

Phase 3 (THE DESK roster view, agent-ready band gating, the pre-launch plate) and the brand-plate art are deliberate follow-ups.