### PR TITLE
operator: guest brand plates - ONE HUE, ONE BEAT (data-only on the Phase 2 seam)

### DIFF
--- a/internal/glyphs/fold_ellipsis_test.go
+++ b/internal/glyphs/fold_ellipsis_test.go
@@ -1,0 +1,21 @@
+package glyphs
+
+import "testing"
+
+// TestFoldEllipsis pins the GUEST-OPERATOR-PLATES.md §7 rule "all `…` fold to
+// `...` under ASCII per glyphs.Fold": the one-rune ellipsis expands to three
+// dots (asciiFold is rune-to-rune, so this is a string-level pre-pass), and
+// Fold stays byte-identical when ASCII mode is off.
+func TestFoldEllipsis(t *testing.T) {
+	t.Setenv("ROGERAI_ASCII", "1")
+	if got := Fold("patching opencode through on qwen3-32b-fp8…"); got != "patching opencode through on qwen3-32b-fp8..." {
+		t.Fatalf("… must fold to ... under ASCII, got %q", got)
+	}
+	if got := Fold("H E R M E S · nous research"); got != "H E R M E S . nous research" {
+		t.Fatalf("· folds to . under ASCII (lockup separators), got %q", got)
+	}
+	t.Setenv("ROGERAI_ASCII", "")
+	if got := Fold("PATCHING YOU THROUGH…"); got != "PATCHING YOU THROUGH…" {
+		t.Fatalf("Fold must be a no-op off ASCII, got %q", got)
+	}
+}

--- a/internal/glyphs/glyphs.go
+++ b/internal/glyphs/glyphs.go
@@ -139,11 +139,13 @@ var asciiFold = map[rune]rune{
 // Fold replaces non-ASCII art/signal runes with ASCII stand-ins WHEN ASCII() is in
 // effect; otherwise it returns s unchanged. Used to keep the Ping beacon art legible
 // on a legacy Windows console without touching the (rune-exact) animation tables.
+// The one-rune ellipsis expands to three dots first (asciiFold is rune-to-rune, so
+// the 1->3 case is a string-level pre-pass; GUEST-OPERATOR-PLATES.md §7).
 func Fold(s string) string {
 	if !ASCII() {
 		return s
 	}
-	return foldASCII(s)
+	return foldASCII(strings.ReplaceAll(s, "…", "..."))
 }
 
 // foldASCII applies the asciiFold map to every rune of s. Exposed (unconditionally)

--- a/internal/operator/brand.go
+++ b/internal/operator/brand.go
@@ -1,0 +1,193 @@
+package operator
+
+// brand.go - the guest-operator BRAND PLATES as pure registry DATA
+// (rogerai-internal-docs/GUEST-OPERATOR-PLATES.md, founder-approved 2026-07-06).
+//
+// Policy: "ONE HUE, ONE BEAT." During the PATCHING YOU THROUGH transition ONLY,
+// the guest WORDMARK may carry its single canonical hue; everything else on the
+// plate stays mono + RogerAI red. THE DESK roster + /operator picker stay 100%
+// mono+red (no picker glyphs for any guest, §6). NO_COLOR / ROGERAI_ASCII
+// collapse per the doc's §7 fallback matrix; narrow widths SWAP to a one-line
+// text lockup - shipped brand art is never cropped or re-wrapped.
+//
+// Provenance: every art block is re-derived byte-exact from the guest's own
+// shipped artifacts (opencode --help wordmark v1.17.x · hermes banner.py 0.16.x
+// incl. their gradient hexes · pyfiglet small `aider` + logo.svg green · the
+// Claude Code 2.1.202 mascot + binary hue · codex has no shipped art, so a
+// shape-only `>_` motif). The only non-shipped values are the two derived
+// light-mode hexes #0E7A0E (aider) and #B85F41 (claude) - contrast-driven
+// darkenings of the canonical hue, flagged for founder taste (doc §8).
+//
+// This package stays render-free (zero lipgloss/bubbletea deps): inks are named
+// tokens + adaptive hex pairs; internal/tui maps them to the house styles.
+
+// Ink tokens: the house styles a span may reference (resolved by internal/tui).
+const (
+	InkDim     = "dim"     // stDim (cDim) - secondary / labels
+	InkBrand   = "brand"   // stBrand (cInk bold) - headline lettering
+	InkKey     = "key"     // stKey (cInk bold) - the load-bearing value
+	InkRed     = "red"     // cRed NON-BOLD - a glint (the opencode cursor stack)
+	InkRedBold = "redBold" // stRed (cRed bold) - the reserved red beat
+)
+
+// BrandInk is one named ink: either a house token (Token set) or a custom
+// adaptive hue (Dark/Light hex pair) with an optional Bold weight. The zero
+// value renders plain (unstyled).
+type BrandInk struct {
+	Token string // one of the Ink* tokens; "" = custom hue or plain
+	Dark  string // canonical hex on a dark terminal ("" with empty Token = plain)
+	Light string // light-terminal collapse/derivation ("" = reuse Dark)
+	Bold  bool
+}
+
+// BrandSpan styles the half-open rune-column range [From, To) of a row.
+type BrandSpan struct {
+	From, To int
+	Ink      BrandInk
+}
+
+// BrandRow is one art row: exact text plus either a whole-row Ink (Spans empty)
+// or per-segment Spans (columns not covered render plain - they are spaces in
+// every shipped plate).
+type BrandRow struct {
+	Text  string
+	Ink   BrandInk
+	Spans []BrandSpan
+}
+
+// BrandArt is one guest's finished plate: the full-color/unicode art rows, the
+// one-line text lockup (the §*c/§7 ASCII + narrow fallback), the wordmark width
+// that gates the narrow swap (full art renders whenever termWidth >= 2 + Width),
+// and whether the art itself survives a pure-ASCII terminal (aider only).
+type BrandArt struct {
+	Rows     []BrandRow
+	Width    int      // the wordmark width in cells (narrow threshold = 2 + Width)
+	Lockup   BrandRow // the one-line text lockup (ASCII mode + narrow widths)
+	ASCIIArt bool     // true = the art is pure ASCII by construction (no lockup swap in ASCII mode)
+}
+
+// The custom hues the doc registers (§8): dark canonical / light pair.
+var (
+	inkGold1 = BrandInk{Dark: "#FFD700", Light: "#B8860B", Bold: true} // hermes rows 1-2 (shipped step 1; light = their banner_dim)
+	inkGold2 = BrandInk{Dark: "#FFBF00", Light: "#B8860B"}             // hermes rows 3-4 (step 2)
+	inkGold3 = BrandInk{Dark: "#CD7F32", Light: "#B8860B"}             // hermes rows 5-6 (step 3)
+	inkGreen = BrandInk{Dark: "#14B014", Light: "#0E7A0E"}             // aider logo.svg green (light derived)
+	inkClay  = BrandInk{Dark: "#D97757", Light: "#B85F41"}             // claude binary hue (light derived)
+	inkClayB = BrandInk{Dark: "#D97757", Light: "#B85F41", Bold: true} // claude wordmark
+)
+
+// BrandArts returns all five doc plates keyed by guest name. opencode, hermes
+// and aider are wired into Registry(); claude and codex are the doc's shim-era
+// DRAFTS kept here as DORMANT data only - the registry deliberately has no home
+// for a non-detectable guest, and adding a row would change detection/picker
+// behavior (this pass is data-only). Returned fresh per call (the Registry()
+// idiom) so callers can never corrupt the shared art.
+func BrandArts() map[string]*BrandArt {
+	return map[string]*BrandArt{
+		// §1 opencode - the exact wordmark `opencode --help` prints (v1.17.x),
+		// leading braille-blank U+2800 kept on row 1 for character-exactness.
+		// Two-tone: `open` cDim / `code` cInk - their real grey/white brand mapped
+		// to the house ink ramp (the "honestly mono two-tone" policy line). The
+		// ONE red is the block-cursor glint at col 41 (▄/█/▀, cRed NON-bold).
+		"opencode": {
+			Rows: []BrandRow{
+				{Text: "⠀                                ▄", // the d ascender, col 33
+					Spans: []BrandSpan{{From: 33, To: 34, Ink: BrandInk{Token: InkBrand}}}},
+				{Text: "█▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█  ▄", Spans: opencodeLetterSpans()},
+				{Text: "█  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀  █", Spans: opencodeLetterSpans()},
+				{Text: "▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀  ▀", Spans: opencodeLetterSpans()},
+			},
+			Width: 42,
+			Lockup: BrandRow{Text: "opencode _", Spans: []BrandSpan{ // §1c: the honest ASCII cursor
+				{From: 0, To: 4, Ink: BrandInk{Token: InkDim}},
+				{From: 4, To: 8, Ink: BrandInk{Token: InkKey}},
+				{From: 9, To: 10, Ink: BrandInk{Token: InkRedBold}},
+			}},
+		},
+		// §2 hermes - the 51-col ANSI Shadow HERMES (their full HERMES-AGENT lockup
+		// is 101 cols and busts the 96-col budget), top-lit 3-step gold exactly as
+		// banner.py maps it; light terminals collapse to their own #B8860B dim-gold
+		// via the adaptive pairs. Byline right-aligned like a signature (cols 38-50).
+		"hermes": {
+			Rows: []BrandRow{
+				{Text: "██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗", Ink: inkGold1},
+				{Text: "██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝", Ink: inkGold1},
+				{Text: "███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗", Ink: inkGold2},
+				{Text: "██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║", Ink: inkGold2},
+				{Text: "██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║", Ink: inkGold3},
+				{Text: "╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝", Ink: inkGold3},
+				{Text: "                                      nous research",
+					Spans: []BrandSpan{{From: 38, To: 51, Ink: BrandInk{Token: InkDim}}}},
+			},
+			Width: 51,
+			Lockup: BrandRow{Text: "H E R M E S · nous research", Spans: []BrandSpan{
+				{From: 0, To: 11, Ink: inkGold1},
+				{From: 11, To: 27, Ink: BrandInk{Token: InkDim}},
+			}},
+		},
+		// §3 aider - figlet `small` lowercase, pure ASCII by construction (its own
+		// ASCII fallback). One hue, no gradient, NO cursor glint (explicit ruling:
+		// adding red here would double the accents). Tagline reads as a sentence.
+		"aider": {
+			Rows: []BrandRow{
+				{Text: "      _    _", Ink: inkGreen},
+				{Text: " __ _(_)__| |___ _ _", Ink: inkGreen},
+				{Text: "/ _` | / _` / -_) '_|", Ink: inkGreen},
+				{Text: "\\__,_|_\\__,_\\___|_|", Ink: inkGreen},
+				{Text: "ai pair programming in your terminal", Ink: BrandInk{Token: InkDim}},
+			},
+			Width:    21, // the wordmark (the doc sets the narrow threshold at 23, not the tagline's 38)
+			Lockup:   BrandRow{Text: "aider", Ink: inkGreen},
+			ASCIIArt: true,
+		},
+		// §4 claude - shim-era DRAFT (dormant until the /v1/messages shim lands):
+		// the SHIPPED Claude Code mascot pose, mascot + wordmark one lockup, one hue.
+		"claude": {
+			Rows: []BrandRow{
+				{Text: "  ▗   ▖", Ink: inkClay},
+				{Text: " ▐▛███▜▌", Ink: inkClay},
+				{Text: "▝▜█████▛▘   claude", Spans: []BrandSpan{
+					{From: 0, To: 9, Ink: inkClay},
+					{From: 12, To: 18, Ink: inkClayB},
+				}},
+				{Text: "  ▘▘ ▝▝", Ink: inkClay},
+			},
+			Width:  18,
+			Lockup: BrandRow{Text: "* claude", Ink: inkClay}, // ✻ pre-folded to * (house asciiFold idiom)
+		},
+		// §5 codex - shim-era DRAFT (shape-only): no shipped terminal art exists and
+		// OpenAI's brand is hueless, so 100% mono + the red beat - their `>_` motif
+		// as a chunky half-block chevron, the ▄▄▄▄ underscore IS a cursor (stRed).
+		"codex": {
+			Rows: []BrandRow{
+				{Text: "█▄", Spans: []BrandSpan{{From: 0, To: 2, Ink: BrandInk{Token: InkBrand}}}},
+				{Text: " ▀█▄     codex", Spans: []BrandSpan{
+					{From: 1, To: 4, Ink: BrandInk{Token: InkBrand}},
+					{From: 9, To: 14, Ink: BrandInk{Token: InkKey}},
+				}},
+				{Text: " ▄█▀     openai", Spans: []BrandSpan{
+					{From: 1, To: 4, Ink: BrandInk{Token: InkBrand}},
+					{From: 9, To: 15, Ink: BrandInk{Token: InkDim}},
+				}},
+				{Text: "█▀ ▄▄▄▄", Spans: []BrandSpan{
+					{From: 0, To: 2, Ink: BrandInk{Token: InkBrand}},
+					{From: 3, To: 7, Ink: BrandInk{Token: InkRedBold}},
+				}},
+			},
+			Width:  15,
+			Lockup: BrandRow{Text: ">_ codex · openai"}, // plain: no hue, honestly
+		},
+	}
+}
+
+// opencodeLetterSpans is the §1a per-row style table for rows 2-4: `open` cols
+// 0-18 in cDim, `code` cols 20-38 in cInk(stBrand), and the red cursor glint at
+// col 41 in cRed NON-BOLD (a glint, not a surface - never stRed). A fresh slice
+// per row keeps BrandArts() free of shared mutable state.
+func opencodeLetterSpans() []BrandSpan {
+	return []BrandSpan{
+		{From: 0, To: 19, Ink: BrandInk{Token: InkDim}},
+		{From: 20, To: 39, Ink: BrandInk{Token: InkBrand}},
+		{From: 41, To: 42, Ink: BrandInk{Token: InkRed}},
+	}
+}

--- a/internal/operator/brand_test.go
+++ b/internal/operator/brand_test.go
@@ -1,0 +1,304 @@
+package operator
+
+// brand_test.go - golden pins for the guest-operator BRAND PLATES
+// (rogerai-internal-docs/GUEST-OPERATOR-PLATES.md, founder-approved 2026-07-06,
+// "ONE HUE, ONE BEAT"). The art below is transcribed byte-exact from the doc's
+// code blocks (span boundaries machine-verified against the doc before landing);
+// these tests exist so a stray edit can never corrupt a shipped wordmark: every
+// row's exact bytes, every span boundary, every hue pair, and the §6 "no picker
+// glyphs" ruling are pinned here. Data-only against the Phase 2 BrandPlate seam -
+// transition logic is untouched and untested here (handoff specs own it).
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The doc's hue registrations (§8): dark canonical / light collapse pairs.
+var (
+	wantGold1 = BrandInk{Dark: "#FFD700", Light: "#B8860B", Bold: true} // hermes rows 1-2
+	wantGold2 = BrandInk{Dark: "#FFBF00", Light: "#B8860B"}             // hermes rows 3-4
+	wantGold3 = BrandInk{Dark: "#CD7F32", Light: "#B8860B"}             // hermes rows 5-6
+	wantGreen = BrandInk{Dark: "#14B014", Light: "#0E7A0E"}             // aider
+	wantClay  = BrandInk{Dark: "#D97757", Light: "#B85F41"}             // claude
+	wantClayB = BrandInk{Dark: "#D97757", Light: "#B85F41", Bold: true} // claude wordmark
+)
+
+// TestBrandArtsExactBytes pins EVERY art row of EVERY plate character-exact to the
+// approved doc (§1a, §2a, §3a, §4a, §5a) plus each one-line lockup (§1c-§5c).
+func TestBrandArtsExactBytes(t *testing.T) {
+	arts := BrandArts()
+	cases := []struct {
+		name   string
+		rows   []string
+		lockup string
+	}{
+		{
+			name: "opencode",
+			rows: []string{
+				"⠀                                ▄",
+				"█▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█  ▄",
+				"█  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀  █",
+				"▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀  ▀",
+			},
+			lockup: "opencode _",
+		},
+		{
+			name: "hermes",
+			rows: []string{
+				"██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗",
+				"██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝",
+				"███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗",
+				"██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║",
+				"██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║",
+				"╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝",
+				"                                      nous research",
+			},
+			lockup: "H E R M E S · nous research",
+		},
+		{
+			name: "aider",
+			rows: []string{
+				"      _    _",
+				" __ _(_)__| |___ _ _",
+				"/ _` | / _` / -_) '_|",
+				"\\__,_|_\\__,_\\___|_|",
+				"ai pair programming in your terminal",
+			},
+			lockup: "aider",
+		},
+		{
+			name: "claude",
+			rows: []string{
+				"  ▗   ▖",
+				" ▐▛███▜▌",
+				"▝▜█████▛▘   claude",
+				"  ▘▘ ▝▝",
+			},
+			lockup: "* claude",
+		},
+		{
+			name: "codex",
+			rows: []string{
+				"█▄",
+				" ▀█▄     codex",
+				" ▄█▀     openai",
+				"█▀ ▄▄▄▄",
+			},
+			lockup: ">_ codex · openai",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			art := arts[tc.name]
+			if art == nil {
+				t.Fatalf("BrandArts() must carry %q", tc.name)
+			}
+			if len(art.Rows) != len(tc.rows) {
+				t.Fatalf("%s: %d rows, want %d", tc.name, len(art.Rows), len(tc.rows))
+			}
+			for i, want := range tc.rows {
+				if art.Rows[i].Text != want {
+					t.Fatalf("%s row %d corrupted:\n got %q\nwant %q", tc.name, i+1, art.Rows[i].Text, want)
+				}
+			}
+			if art.Lockup.Text != tc.lockup {
+				t.Fatalf("%s lockup: got %q, want %q", tc.name, art.Lockup.Text, tc.lockup)
+			}
+		})
+	}
+	if len(arts) != 5 {
+		t.Fatalf("BrandArts() carries exactly the five doc plates, got %d", len(arts))
+	}
+}
+
+// TestBrandArtWidths pins each plate's narrow-swap width (§7: full art renders
+// whenever termWidth >= 2 + artWidth; opencode 42, hermes 51, aider 21 (the figlet
+// wordmark, NOT the longer tagline - the doc sets aider's threshold at 23), claude
+// 18, codex 15).
+func TestBrandArtWidths(t *testing.T) {
+	want := map[string]int{"opencode": 42, "hermes": 51, "aider": 21, "claude": 18, "codex": 15}
+	arts := BrandArts()
+	for name, w := range want {
+		if got := arts[name].Width; got != w {
+			t.Fatalf("%s width: got %d, want %d", name, got, w)
+		}
+	}
+}
+
+// TestBrandOpencodeSpans pins §1a's per-row style table: `open` cDim cols 0-18,
+// `code` cInk(stBrand) cols 20-38, the red block-cursor glint at col 41 in cRed
+// NON-BOLD (a glint, not stRed), row 1's d-ascender at col 33 in stBrand, and the
+// §1c lockup spans (open dim / code key / `_` stRed).
+func TestBrandOpencodeSpans(t *testing.T) {
+	art := BrandArts()["opencode"]
+	if got, want := art.Rows[0].Spans, []BrandSpan{{From: 33, To: 34, Ink: BrandInk{Token: InkBrand}}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("row 1 spans: got %+v, want %+v", got, want)
+	}
+	wantLetterRows := []BrandSpan{
+		{From: 0, To: 19, Ink: BrandInk{Token: InkDim}},
+		{From: 20, To: 39, Ink: BrandInk{Token: InkBrand}},
+		{From: 41, To: 42, Ink: BrandInk{Token: InkRed}}, // the ONE red: non-bold cursor glint
+	}
+	for i := 1; i <= 3; i++ {
+		if !reflect.DeepEqual(art.Rows[i].Spans, wantLetterRows) {
+			t.Fatalf("row %d spans: got %+v, want %+v", i+1, art.Rows[i].Spans, wantLetterRows)
+		}
+	}
+	wantLockup := []BrandSpan{
+		{From: 0, To: 4, Ink: BrandInk{Token: InkDim}},
+		{From: 4, To: 8, Ink: BrandInk{Token: InkKey}},
+		{From: 9, To: 10, Ink: BrandInk{Token: InkRedBold}},
+	}
+	if !reflect.DeepEqual(art.Lockup.Spans, wantLockup) {
+		t.Fatalf("lockup spans: got %+v, want %+v", art.Lockup.Spans, wantLockup)
+	}
+	if art.ASCIIArt {
+		t.Fatal("opencode half-blocks do not survive ASCII - must swap to the lockup")
+	}
+}
+
+// TestBrandHermesGradient pins §2a: rows 1-2 bold #FFD700, rows 3-4 #FFBF00, rows
+// 5-6 #CD7F32, ALL collapsing to #B8860B on light terminals (rows 1-2 keep bold),
+// and the byline `nous research` right-aligned cols 38-50 in stDim.
+func TestBrandHermesGradient(t *testing.T) {
+	art := BrandArts()["hermes"]
+	wantInks := []BrandInk{wantGold1, wantGold1, wantGold2, wantGold2, wantGold3, wantGold3}
+	for i, want := range wantInks {
+		if got := art.Rows[i].Ink; got != want {
+			t.Fatalf("row %d ink: got %+v, want %+v", i+1, got, want)
+		}
+		if len(art.Rows[i].Spans) != 0 {
+			t.Fatalf("row %d: the gradient is whole-row ink, not spans", i+1)
+		}
+	}
+	wantByline := []BrandSpan{{From: 38, To: 51, Ink: BrandInk{Token: InkDim}}}
+	if !reflect.DeepEqual(art.Rows[6].Spans, wantByline) {
+		t.Fatalf("byline spans: got %+v, want %+v", art.Rows[6].Spans, wantByline)
+	}
+	wantLockup := []BrandSpan{
+		{From: 0, To: 11, Ink: wantGold1},
+		{From: 11, To: 27, Ink: BrandInk{Token: InkDim}},
+	}
+	if !reflect.DeepEqual(art.Lockup.Spans, wantLockup) {
+		t.Fatalf("lockup spans: got %+v, want %+v", art.Lockup.Spans, wantLockup)
+	}
+	if art.ASCIIArt {
+		t.Fatal("hermes box runes are non-ASCII - must swap to the lockup")
+	}
+}
+
+// TestBrandAiderInks pins §3a: the whole wordmark in one hue #14B014 (light
+// #0E7A0E, derived), the tagline in stDim, NO cursor glint anywhere (the doc's
+// explicit "do not add" ruling), and §3c: the art IS its own ASCII fallback.
+func TestBrandAiderInks(t *testing.T) {
+	art := BrandArts()["aider"]
+	for i := 0; i < 4; i++ {
+		if got := art.Rows[i].Ink; got != wantGreen {
+			t.Fatalf("row %d ink: got %+v, want %+v", i+1, got, wantGreen)
+		}
+	}
+	if got := art.Rows[4].Ink; got != (BrandInk{Token: InkDim}) {
+		t.Fatalf("tagline ink: got %+v, want stDim", got)
+	}
+	for i, row := range art.Rows {
+		for _, sp := range row.Spans {
+			if sp.Ink.Token == InkRed || sp.Ink.Token == InkRedBold {
+				t.Fatalf("row %d: no red glint on the aider plate (doc §3a)", i+1)
+			}
+		}
+	}
+	if !art.ASCIIArt {
+		t.Fatal("aider is pure ASCII by construction - the full plate survives ROGERAI_ASCII")
+	}
+	if got := art.Lockup.Ink; got != wantGreen {
+		t.Fatalf("narrow lockup keeps the phosphor green, got %+v", got)
+	}
+}
+
+// TestBrandClaudeLockupSpans pins §4a: mascot rows in #D97757 (#B85F41 light),
+// row 3 = art cols 0-8 + bold wordmark cols 12-17, and the §4c `* claude` lockup
+// (the ✻ spark pre-folded to * per the house asciiFold idiom).
+func TestBrandClaudeLockupSpans(t *testing.T) {
+	art := BrandArts()["claude"]
+	for _, i := range []int{0, 1, 3} {
+		if got := art.Rows[i].Ink; got != wantClay {
+			t.Fatalf("row %d ink: got %+v, want %+v", i+1, got, wantClay)
+		}
+	}
+	wantRow3 := []BrandSpan{
+		{From: 0, To: 9, Ink: wantClay},
+		{From: 12, To: 18, Ink: wantClayB},
+	}
+	if !reflect.DeepEqual(art.Rows[2].Spans, wantRow3) {
+		t.Fatalf("row 3 spans: got %+v, want %+v", art.Rows[2].Spans, wantRow3)
+	}
+	if got := art.Lockup.Ink; got != wantClay {
+		t.Fatalf("lockup ink: got %+v, want %+v", got, wantClay)
+	}
+	if art.ASCIIArt {
+		t.Fatal("quadrant blocks do not survive ASCII - must swap to the lockup")
+	}
+}
+
+// TestBrandCodexSpans pins §5a: the chevron in stBrand, wordmark stKey, credit
+// stDim, and the `▄▄▄▄` underscore as the plate's ONE red beat in stRed - plus the
+// plain-text §5c lockup (no ink: OpenAI's brand is honestly hueless).
+func TestBrandCodexSpans(t *testing.T) {
+	art := BrandArts()["codex"]
+	want := [][]BrandSpan{
+		{{From: 0, To: 2, Ink: BrandInk{Token: InkBrand}}},
+		{{From: 1, To: 4, Ink: BrandInk{Token: InkBrand}}, {From: 9, To: 14, Ink: BrandInk{Token: InkKey}}},
+		{{From: 1, To: 4, Ink: BrandInk{Token: InkBrand}}, {From: 9, To: 15, Ink: BrandInk{Token: InkDim}}},
+		{{From: 0, To: 2, Ink: BrandInk{Token: InkBrand}}, {From: 3, To: 7, Ink: BrandInk{Token: InkRedBold}}},
+	}
+	for i, w := range want {
+		if !reflect.DeepEqual(art.Rows[i].Spans, w) {
+			t.Fatalf("row %d spans: got %+v, want %+v", i+1, art.Rows[i].Spans, w)
+		}
+	}
+	if art.Lockup.Ink != (BrandInk{}) || len(art.Lockup.Spans) != 0 {
+		t.Fatalf("codex lockup is plain text, got ink %+v spans %+v", art.Lockup.Ink, art.Lockup.Spans)
+	}
+}
+
+// TestRegistryCarriesBrandArts: the three MVP guests carry their plate as registry
+// data; claude and codex stay DORMANT in BrandArts() only - the doc's shim-era
+// drafts have no Registry() row (adding one would change detection/picker behavior,
+// and this pass is data-only).
+func TestRegistryCarriesBrandArts(t *testing.T) {
+	arts := BrandArts()
+	byName := map[string]Guest{}
+	for _, g := range Registry() {
+		byName[g.Name] = g
+	}
+	for _, name := range []string{"opencode", "hermes", "aider"} {
+		g, ok := byName[name]
+		if !ok || g.Brand == nil {
+			t.Fatalf("%s must carry its BrandArt in the registry", name)
+		}
+		if !reflect.DeepEqual(g.Brand, arts[name]) {
+			t.Fatalf("%s registry plate must equal BrandArts()[%q]", name, name)
+		}
+	}
+	for _, name := range []string{"claude", "codex"} {
+		if _, inRegistry := byName[name]; inRegistry {
+			t.Fatalf("%s stays a dormant draft - BrandArts() data only, no registry row", name)
+		}
+		if arts[name] == nil {
+			t.Fatalf("the %s shim-era draft must be present as dormant data", name)
+		}
+	}
+}
+
+// TestNoPickerGlyphs pins §6, on the record: NO per-guest brand glyphs in THE DESK
+// roster or the /operator picker - the BrandGlyph seam stays EMPTY for all guests
+// (the desk is the host's furniture; identity gets its moment on the PATCHING
+// plate - one hue, one beat, once).
+func TestNoPickerGlyphs(t *testing.T) {
+	for _, g := range Registry() {
+		if g.BrandGlyph != "" {
+			t.Fatalf("%s: the picker stays mono - no brand glyph (doc §6), got %q", g.Name, g.BrandGlyph)
+		}
+	}
+}

--- a/internal/operator/registry.go
+++ b/internal/operator/registry.go
@@ -48,7 +48,13 @@ type Guest struct {
 	// house default.
 	BrandPlate  string // multi-line ASCII wordmark for the PATCHING YOU THROUGH screen
 	BrandAccent string // accent color (hex like "#fab387" or ANSI-256 index) for plate + glyph
-	BrandGlyph  string // single-cell picker-row glyph
+	BrandGlyph  string // single-cell picker-row glyph - stays "" for EVERY guest (plates doc §6)
+
+	// Brand is the finished per-row plate the design pass landed (brand.go, from
+	// GUEST-OPERATOR-PLATES.md): styled spans, adaptive hues, the ASCII/narrow
+	// lockup. nil = the text-only house default. Supersedes the single-accent
+	// BrandPlate string above (kept for seam compatibility, unused by the registry).
+	Brand *BrandArt
 }
 
 // Registry is the ONE source of who can ever appear at the desk (MVP set, design doc §4/§6).
@@ -56,24 +62,28 @@ type Guest struct {
 // wire, and a naive launch silently falls back to the user's REAL Anthropic account - the
 // exact failure §4 measured. Order is the desk display order.
 func Registry() []Guest {
+	plates := BrandArts() // the §1-§3 plates ride as data; claude/codex stay dormant in BrandArts()
 	return []Guest{
 		{
 			Name: "opencode", Bin: "opencode", Provider: "openai",
 			InstallHint: "curl -fsSL https://opencode.ai/install | bash",
 			KnownGood:   "1.17.11", // proven end-to-end on the dev box, 2026-07-06
 			Strategy:    StrategyScratchConfig,
+			Brand:       plates["opencode"],
 		},
 		{
 			Name: "hermes", Bin: "hermes", Provider: "openai",
 			InstallHint: "pip install hermes-agent",
 			KnownGood:   "0.16.0", // proven end-to-end on the dev box, 2026-07-06
 			Strategy:    StrategyScratchHome,
+			Brand:       plates["hermes"],
 		},
 		{
 			Name: "aider", Bin: "aider", Provider: "openai",
 			InstallHint: "uv tool install aider-chat",
 			KnownGood:   "0.86.2", // verified at GREEN stage (founder ruling 6): installed + run live 2026-07-06
 			Strategy:    StrategyEnvFlags,
+			Brand:       plates["aider"],
 		},
 	}
 }

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -321,6 +321,9 @@ func operatorBrandRow(row operator.BrandRow) string {
 		// data is golden-pinned in range, but a hand-edited plate must degrade to
 		// plain text - never panic the PATCHING screen.
 		from, to := sp.From, sp.To
+		if from < 0 {
+			from = 0
+		}
 		if from > len(runes) {
 			from = len(runes)
 		}

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -268,10 +268,14 @@ func (m model) operatorPickerView(w int) string {
 	return b.String()
 }
 
-// operatorBrandBlock renders a guest's optional ASCII wordmark for the PATCHING screen,
-// each line width-clamped and tinted with the brand accent (house key style when unset).
+// operatorBrandBlock renders a guest's optional brand plate for the PATCHING screen.
+// The finished plates ride the Guest.Brand data seam (GUEST-OPERATOR-PLATES.md,
+// "ONE HUE, ONE BEAT"); the legacy single-accent BrandPlate string stays supported.
 // "" when the registry carries no plate - the seam costs nothing until the art lands.
 func operatorBrandBlock(g operator.Guest, w int) string {
+	if g.Brand != nil {
+		return operatorBrandArtBlock(*g.Brand, w)
+	}
 	if g.BrandPlate == "" {
 		return ""
 	}
@@ -281,6 +285,82 @@ func operatorBrandBlock(g operator.Guest, w int) string {
 		b.WriteString(truncVisible("  "+st.Render(line), w) + "\n")
 	}
 	return b.String()
+}
+
+// operatorBrandArtBlock renders a BrandArt plate per the doc's §7 fallback matrix:
+// full styled art on a capable terminal; the one-line text lockup under
+// ROGERAI_ASCII (never a folded/garbled wordmark - aider's pure-ASCII plate is the
+// one that survives intact) or when the terminal is too narrow (shipped brand art
+// is never cropped or re-wrapped, it is SWAPPED). NO_COLOR needs no branch here:
+// lipgloss strips the SGR from the same art.
+func operatorBrandArtBlock(art operator.BrandArt, w int) string {
+	if (glyphs.ASCII() && !art.ASCIIArt) || w < art.Width+2 {
+		lockup := art.Lockup
+		lockup.Text = glyphs.Fold(lockup.Text) // · and … fold rune-for-rune; spans stay column-true
+		return truncVisible("  "+operatorBrandRow(lockup), w) + "\n"
+	}
+	var b strings.Builder
+	for _, row := range art.Rows {
+		b.WriteString(truncVisible("  "+operatorBrandRow(row), w) + "\n")
+	}
+	return b.String()
+}
+
+// operatorBrandRow inks one plate row: whole-row Ink when it has no spans,
+// otherwise each [From,To) rune span in its ink with uncovered columns plain
+// (they are spaces in every shipped plate).
+func operatorBrandRow(row operator.BrandRow) string {
+	if len(row.Spans) == 0 {
+		return operatorInkStyle(row.Ink).Render(row.Text)
+	}
+	runes := []rune(row.Text)
+	var b strings.Builder
+	col := 0
+	for _, sp := range row.Spans {
+		to := sp.To
+		if to > len(runes) {
+			to = len(runes)
+		}
+		if sp.From > col {
+			b.WriteString(string(runes[col:sp.From]))
+		}
+		b.WriteString(operatorInkStyle(sp.Ink).Render(string(runes[sp.From:to])))
+		col = to
+	}
+	if col < len(runes) {
+		b.WriteString(string(runes[col:]))
+	}
+	return b.String()
+}
+
+// operatorInkStyle maps a registry ink to a house style: named tokens hit the
+// shared palette (InkRed is deliberately cRed NON-bold - a glint, not a surface),
+// custom hues become adaptive dark/light pairs, the zero ink renders plain.
+func operatorInkStyle(ink operator.BrandInk) lipgloss.Style {
+	switch ink.Token {
+	case operator.InkDim:
+		return stDim
+	case operator.InkBrand:
+		return stBrand
+	case operator.InkKey:
+		return stKey
+	case operator.InkRed:
+		return lipgloss.NewStyle().Foreground(cRed)
+	case operator.InkRedBold:
+		return stRed
+	}
+	if ink.Dark == "" {
+		return lipgloss.NewStyle()
+	}
+	light := ink.Light
+	if light == "" {
+		light = ink.Dark
+	}
+	st := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: light, Dark: ink.Dark})
+	if ink.Bold {
+		st = st.Bold(true)
+	}
+	return st
 }
 
 // operatorBrandStyle maps a registry accent to a render style (the house stKey when "").
@@ -496,6 +576,14 @@ func (m model) operatorPatchView(w int) string {
 	mdl := ""
 	if m.proxyHolder != nil {
 		mdl = m.proxyHolder.Get().Model
+	}
+	// The windowshade keeps the handoff to ONE static line (plates doc §1b: compact
+	// is prefers-reduced-motion; at one line the guest's name IS the brand). Shared
+	// template for every guest; truncVisible clamps so the band name truncates first.
+	if m.compact {
+		line := "  " + stRed.Render(beaconDot()) + " " + stDim.Render("patching ") +
+			stKey.Render(h.det.Guest.Name) + stDim.Render(glyphs.Fold(" through on "+mdl+"…"))
+		return truncVisible(line, w) + "\n"
 	}
 	var b strings.Builder
 	b.WriteString("  " + stSelBar.Render("▌") + " " + stBrand.Render("AGENT") + stDim.Render(" · handing off") +

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -317,15 +317,24 @@ func operatorBrandRow(row operator.BrandRow) string {
 	var b strings.Builder
 	col := 0
 	for _, sp := range row.Spans {
-		to := sp.To
+		// Clamp BOTH bounds (defense in depth, pre-push audit minor): the shipped
+		// data is golden-pinned in range, but a hand-edited plate must degrade to
+		// plain text - never panic the PATCHING screen.
+		from, to := sp.From, sp.To
+		if from > len(runes) {
+			from = len(runes)
+		}
 		if to > len(runes) {
 			to = len(runes)
 		}
-		if sp.From > col {
-			b.WriteString(string(runes[col:sp.From]))
+		if from > col {
+			b.WriteString(string(runes[col:from]))
+			col = from
 		}
-		b.WriteString(operatorInkStyle(sp.Ink).Render(string(runes[sp.From:to])))
-		col = to
+		if to > from {
+			b.WriteString(operatorInkStyle(sp.Ink).Render(string(runes[from:to])))
+			col = to
+		}
 	}
 	if col < len(runes) {
 		b.WriteString(string(runes[col:]))

--- a/internal/tui/operator_plates_test.go
+++ b/internal/tui/operator_plates_test.go
@@ -1,0 +1,343 @@
+package tui
+
+// operator_plates_test.go - render pins for the guest-operator BRAND PLATES
+// (rogerai-internal-docs/GUEST-OPERATOR-PLATES.md, "ONE HUE, ONE BEAT", founder-
+// approved 2026-07-06) against the Phase 2 BrandArt seam. Every assertion is
+// self-computing (expected segments are composed with the SAME house styles the
+// renderer uses, the voicebooth TestBadgeRenderSitesNotRed idiom) so no escape
+// codes are hard-coded. Covers the doc's §7 fallback matrix: color/full,
+// NO_COLOR (plain), ROGERAI_ASCII (lockup swap - never a folded wordmark),
+// narrow (swap-to-lockup, never crop), and the compact windowshade one-liner.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/rogerai-fyi/roger/internal/operator"
+)
+
+// colorOn forces a TrueColor profile + a chosen background so lipgloss emits SGR
+// (off a TTY every style strips to plain), restoring both on cleanup.
+func colorOn(t *testing.T, dark bool) {
+	t.Helper()
+	r := lipgloss.DefaultRenderer()
+	oldP, oldD := r.ColorProfile(), r.HasDarkBackground()
+	r.SetColorProfile(termenv.TrueColor)
+	r.SetHasDarkBackground(dark)
+	t.Cleanup(func() { r.SetColorProfile(oldP); r.SetHasDarkBackground(oldD) })
+}
+
+// plateGuest fetches a live registry entry by name (the REAL shipped data).
+func plateGuest(t *testing.T, name string) operator.Guest {
+	t.Helper()
+	for _, g := range operator.Registry() {
+		if g.Name == name {
+			return g
+		}
+	}
+	t.Fatalf("%s not in registry", name)
+	return operator.Guest{}
+}
+
+// dormantGuest wraps a dormant BrandArts() draft (claude/codex) in a Guest so the
+// render seam can be exercised without a registry row.
+func dormantGuest(t *testing.T, name string) operator.Guest {
+	t.Helper()
+	art := operator.BrandArts()[name]
+	if art == nil {
+		t.Fatalf("%s draft missing from BrandArts()", name)
+	}
+	return operator.Guest{Name: name, Brand: art}
+}
+
+// plainLines strips ANSI + the trailing newline and splits a rendered block.
+func plainLines(block string) []string {
+	return strings.Split(strings.TrimRight(stripANSI(block), "\n"), "\n")
+}
+
+// TestPlateOpencodeExactBytesAndStyles: §1a - the shipped wordmark renders byte-
+// exact (2-space indent), `open` in stDim, `code` in stBrand, and the ONE red on
+// the plate is the block-cursor glint in cRed NON-BOLD (a glint, not stRed).
+func TestPlateOpencodeExactBytesAndStyles(t *testing.T) {
+	colorOn(t, true)
+	block := operatorBrandBlock(plateGuest(t, "opencode"), 120)
+	want := []string{
+		"  ⠀                                ▄",
+		"  █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█  ▄",
+		"  █  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀  █",
+		"  ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀  ▀",
+	}
+	if got := plainLines(block); !equalLines(got, want) {
+		t.Fatalf("opencode plate bytes corrupted:\n got %q\nwant %q", got, want)
+	}
+	cursorRed := lipgloss.NewStyle().Foreground(cRed) // non-bold: a glint, not a surface
+	wantRow2 := "  " + stDim.Render("█▀▀█ █▀▀█ █▀▀█ █▀▀▄") + " " + stBrand.Render("█▀▀▀ █▀▀█ █▀▀█ █▀▀█") + "  " + cursorRed.Render("▄")
+	if !strings.Contains(block, wantRow2) {
+		t.Fatalf("row 2 styling must be dim/brand/red-non-bold:\nwant segment %q\nin block %q", wantRow2, block)
+	}
+	if strings.Contains(block, stRed.Render("█")) {
+		t.Fatal("the cursor stack must NOT use bold stRed - cRed non-bold only (doc §1a)")
+	}
+	if !strings.Contains(block, stBrand.Render("▄")) {
+		t.Fatal("row 1's d-ascender at col 33 renders in stBrand")
+	}
+}
+
+// TestPlateHermesGradientAndByline: §2a - rows 1-2 bold #FFD700, rows 3-4 #FFBF00,
+// rows 5-6 #CD7F32, byline `nous research` right-aligned in stDim.
+func TestPlateHermesGradientAndByline(t *testing.T) {
+	colorOn(t, true)
+	art := operator.BrandArts()["hermes"]
+	block := operatorBrandBlock(plateGuest(t, "hermes"), 120)
+	gold1 := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B8860B", Dark: "#FFD700"}).Bold(true)
+	gold2 := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B8860B", Dark: "#FFBF00"})
+	gold3 := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B8860B", Dark: "#CD7F32"})
+	for i, st := range []lipgloss.Style{gold1, gold1, gold2, gold2, gold3, gold3} {
+		if !strings.Contains(block, "  "+st.Render(art.Rows[i].Text)) {
+			t.Fatalf("hermes row %d must carry its shipped gradient step", i+1)
+		}
+	}
+	if !strings.Contains(block, stDim.Render("nous research")) {
+		t.Fatal("the byline signs off in stDim")
+	}
+	if lines := plainLines(block); lines[6] != "  "+strings.Repeat(" ", 38)+"nous research" {
+		t.Fatalf("byline must right-align ending art col 50 (starts 38), got %q", lines[6])
+	}
+}
+
+// TestPlateHermesLightCollapse: §2a - on a light background ALL six rows collapse
+// to the single #B8860B dim-gold (their own ramp token); rows 1-2 keep bold. The
+// 3-step ramp is a dark-room effect and #FFD700 on paper is unreadable.
+func TestPlateHermesLightCollapse(t *testing.T) {
+	colorOn(t, false)
+	block := operatorBrandBlock(plateGuest(t, "hermes"), 120)
+	if !strings.Contains(block, "184;134;11") { // #B8860B
+		t.Fatal("light terminals must collapse the gradient to #B8860B")
+	}
+	for _, banned := range []string{"255;215;0", "255;191;0", "205;127;50"} { // FFD700 FFBF00 CD7F32
+		if strings.Contains(block, banned) {
+			t.Fatalf("no dark-ramp step may leak onto a light terminal (found %s)", banned)
+		}
+	}
+}
+
+// TestPlateAiderGreenAndTagline: §3a - the whole wordmark in #14B014 on dark
+// (#0E7A0E light), tagline in stDim, and NO red glint anywhere on the plate.
+func TestPlateAiderGreenAndTagline(t *testing.T) {
+	colorOn(t, true)
+	art := operator.BrandArts()["aider"]
+	block := operatorBrandBlock(plateGuest(t, "aider"), 120)
+	green := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#0E7A0E", Dark: "#14B014"})
+	for i := 0; i < 4; i++ {
+		if !strings.Contains(block, "  "+green.Render(art.Rows[i].Text)) {
+			t.Fatalf("aider row %d must render in the phosphor green", i+1)
+		}
+	}
+	if !strings.Contains(block, stDim.Render("ai pair programming in your terminal")) {
+		t.Fatal("the tagline reads as a dim sentence under the art")
+	}
+	if strings.Contains(stripANSI(block), "▄") || strings.Contains(block, "255;68;56") { // cRed dark #FF4438
+		t.Fatal("no cursor glint on the aider plate (doc §3a ruling)")
+	}
+}
+
+// TestPlateClaudeCodexDormantDrafts: §4a/§5a - the shim-era drafts render through
+// the same seam when given a Guest wrapper: claude's mascot+wordmark lockup in one
+// hue (#D97757, bold wordmark), codex's mono chevron with the stRed underscore beat.
+func TestPlateClaudeCodexDormantDrafts(t *testing.T) {
+	colorOn(t, true)
+	clay := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B85F41", Dark: "#D97757"})
+	clayB := clay.Bold(true)
+	claude := operatorBrandBlock(dormantGuest(t, "claude"), 120)
+	if got, want := plainLines(claude), []string{
+		"    ▗   ▖",
+		"   ▐▛███▜▌",
+		"  ▝▜█████▛▘   claude",
+		"    ▘▘ ▝▝",
+	}; !equalLines(got, want) {
+		t.Fatalf("claude mascot bytes corrupted:\n got %q\nwant %q", got, want)
+	}
+	if !strings.Contains(claude, clay.Render("▝▜█████▛▘")) || !strings.Contains(claude, clayB.Render("claude")) {
+		t.Fatal("claude: art in #D97757, wordmark same hue bold")
+	}
+	codex := operatorBrandBlock(dormantGuest(t, "codex"), 120)
+	if got, want := plainLines(codex), []string{
+		"  █▄",
+		"   ▀█▄     codex",
+		"   ▄█▀     openai",
+		"  █▀ ▄▄▄▄",
+	}; !equalLines(got, want) {
+		t.Fatalf("codex chevron bytes corrupted:\n got %q\nwant %q", got, want)
+	}
+	if !strings.Contains(codex, stBrand.Render("▀█▄")) || !strings.Contains(codex, stKey.Render("codex")) ||
+		!strings.Contains(codex, stDim.Render("openai")) || !strings.Contains(codex, stRed.Render("▄▄▄▄")) {
+		t.Fatal("codex: chevron stBrand · wordmark stKey · credit stDim · underscore stRed")
+	}
+}
+
+// TestPlateNoColorPlain: the NO_COLOR column of §7's matrix - the same art,
+// uncolored, byte-exact. No substitute art, no dropped rows.
+func TestPlateNoColorPlain(t *testing.T) {
+	r := lipgloss.DefaultRenderer()
+	oldP := r.ColorProfile()
+	r.SetColorProfile(termenv.Ascii) // what NO_COLOR resolves to
+	t.Cleanup(func() { r.SetColorProfile(oldP) })
+	for _, name := range []string{"opencode", "hermes", "aider"} {
+		g := plateGuest(t, name)
+		block := operatorBrandBlock(g, 120)
+		if strings.Contains(block, "\x1b[") {
+			t.Fatalf("%s: NO_COLOR must strip every SGR sequence", name)
+		}
+		for i, row := range g.Brand.Rows {
+			if want := "  " + row.Text; plainLines(block)[i] != want {
+				t.Fatalf("%s row %d must survive mono byte-exact:\n got %q\nwant %q", name, i+1, plainLines(block)[i], want)
+			}
+		}
+	}
+}
+
+// TestPlateASCIILockups: the ROGERAI_ASCII column of §7's matrix - half-blocks and
+// box runes NEVER render folded/garbled: opencode and hermes (and the dormant
+// drafts) swap to their one-line text lockups; aider keeps its full plate (it is
+// pure ASCII by construction). Non-ASCII lockup separators fold per glyphs.Fold.
+func TestPlateASCIILockups(t *testing.T) {
+	t.Setenv("ROGERAI_ASCII", "1")
+	cases := []struct {
+		guest operator.Guest
+		want  []string
+	}{
+		{plateGuest(t, "opencode"), []string{"  opencode _"}},
+		{plateGuest(t, "hermes"), []string{"  H E R M E S . nous research"}},
+		{plateGuest(t, "aider"), []string{
+			"        _    _",
+			"   __ _(_)__| |___ _ _",
+			"  / _` | / _` / -_) '_|",
+			"  \\__,_|_\\__,_\\___|_|",
+			"  ai pair programming in your terminal",
+		}},
+		{dormantGuest(t, "claude"), []string{"  * claude"}},
+		{dormantGuest(t, "codex"), []string{"  >_ codex . openai"}},
+	}
+	for _, tc := range cases {
+		got := plainLines(operatorBrandBlock(tc.guest, 120))
+		if !equalLines(got, tc.want) {
+			t.Fatalf("%s ASCII fallback:\n got %q\nwant %q", tc.guest.Name, got, tc.want)
+		}
+	}
+}
+
+// TestPlateASCIILockupStyles: §1c - under ASCII (color kept) the opencode lockup
+// carries open/code/cursor as stDim/stKey/stRed; §2d - hermes keeps gold bold caps.
+func TestPlateASCIILockupStyles(t *testing.T) {
+	t.Setenv("ROGERAI_ASCII", "1")
+	colorOn(t, true)
+	oc := operatorBrandBlock(plateGuest(t, "opencode"), 120)
+	if !strings.Contains(oc, stDim.Render("open")+stKey.Render("code")+" "+stRed.Render("_")) {
+		t.Fatalf("opencode lockup styling must be dim/key + the honest stRed ASCII cursor, got %q", oc)
+	}
+	gold1 := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B8860B", Dark: "#FFD700"}).Bold(true)
+	hm := operatorBrandBlock(plateGuest(t, "hermes"), 120)
+	if !strings.Contains(hm, gold1.Render("H E R M E S")) || !strings.Contains(hm, stDim.Render(" . nous research")) {
+		t.Fatalf("hermes lockup: letter-spaced caps in gold bold, credit stDim, got %q", hm)
+	}
+}
+
+// TestPlateNarrowSwap pins §7's narrow rule per guest: full art renders whenever
+// termWidth >= 2 + artWidth; ONE column below, the art block is REPLACED by the
+// lockup line - shipped brand art is never cropped or re-wrapped.
+func TestPlateNarrowSwap(t *testing.T) {
+	cases := []struct {
+		guest     operator.Guest
+		threshold int    // the doc's 2+artWidth
+		artProbe  string // a byte only the full art contains
+		lockup    string
+	}{
+		{plateGuest(t, "opencode"), 44, "█▀▀█", "opencode _"},
+		{plateGuest(t, "hermes"), 53, "██╗", "H E R M E S · nous research"},
+		{plateGuest(t, "aider"), 23, "__ _(_)__", "aider"},
+		{dormantGuest(t, "claude"), 20, "▐▛███▜▌", "* claude"},
+		// codex's full lockup (19 cells with indent) is itself clamped at width 16,
+		// so the probe is the un-cropped head of the lockup.
+		{dormantGuest(t, "codex"), 17, "▀█▄", ">_ codex"},
+	}
+	for _, tc := range cases {
+		full := stripANSI(operatorBrandBlock(tc.guest, tc.threshold))
+		if !strings.Contains(full, tc.artProbe) {
+			t.Fatalf("%s: at width %d the full art must render", tc.guest.Name, tc.threshold)
+		}
+		narrow := stripANSI(operatorBrandBlock(tc.guest, tc.threshold-1))
+		if strings.Contains(narrow, tc.artProbe) {
+			t.Fatalf("%s: below width %d the art must be dropped, never cropped", tc.guest.Name, tc.threshold)
+		}
+		if !strings.Contains(narrow, tc.lockup) {
+			t.Fatalf("%s: narrow swaps to the text lockup %q, got %q", tc.guest.Name, tc.lockup, narrow)
+		}
+	}
+}
+
+// TestPatchViewCarriesPlate: integration - the real opencode registry plate sits on
+// the PATCHING YOU THROUGH screen between the header and the mic-to line (the §1a
+// frame idiom), through the untouched Phase 2 transition.
+func TestPatchViewCarriesPlate(t *testing.T) {
+	m := asModel(agentReady(t))
+	m.operatorHandoff = &operatorHandoff{det: operator.Detection{Guest: plateGuest(t, "opencode"), Path: "/fake/opencode"}}
+	view := stripANSI(m.operatorPatchView(120))
+	head := strings.Index(view, "PATCHING YOU THROUGH")
+	plate := strings.Index(view, "█▀▀█ █▀▀█ █▀▀█ █▀▀▄")
+	mic := strings.Index(view, "mic to")
+	if head < 0 || plate < 0 || mic < 0 || !(head < plate && plate < mic) {
+		t.Fatalf("plate must sit between the header and the wire plate (head=%d plate=%d mic=%d):\n%s", head, plate, mic, view)
+	}
+}
+
+// TestPatchViewCompactOneLiner: §1b - the windowshade renders ONE static line,
+// `(•) patching <guest> through on <band>…`, beacon in stRed, name in stKey, no
+// art (at one line the guest's name IS the brand); ASCII folds to `(*) … ...`.
+func TestPatchViewCompactOneLiner(t *testing.T) {
+	m := asModel(agentReady(t))
+	m.compact = true
+	m.operatorHandoff = &operatorHandoff{det: operator.Detection{Guest: plateGuest(t, "opencode"), Path: "/fake/opencode"}}
+	view := stripANSI(m.operatorPatchView(120))
+	if lines := strings.Split(strings.TrimRight(view, "\n"), "\n"); len(lines) != 1 {
+		t.Fatalf("compact is ONE line, got %d: %q", len(lines), lines)
+	}
+	if !strings.Contains(view, "(•) patching opencode through on") || !strings.HasSuffix(strings.TrimRight(view, "\n"), "…") {
+		t.Fatalf("compact line must read `(•) patching opencode through on <band>…`, got %q", view)
+	}
+	if strings.Contains(view, "█") || strings.Contains(view, "PATCHING YOU THROUGH") {
+		t.Fatalf("no art and no full header at one line, got %q", view)
+	}
+	t.Setenv("ROGERAI_ASCII", "1")
+	av := stripANSI(m.operatorPatchView(120))
+	if !strings.Contains(av, "(*) patching opencode through on") || !strings.HasSuffix(strings.TrimRight(av, "\n"), "...") {
+		t.Fatalf("ASCII compact folds the beacon and the ellipsis, got %q", av)
+	}
+}
+
+// TestPatchViewCompactStyles: the compact line's styling contract (§1b): beacon
+// stRed · verb stDim · guest name stKey.
+func TestPatchViewCompactStyles(t *testing.T) {
+	colorOn(t, true)
+	m := asModel(agentReady(t))
+	m.compact = true
+	m.operatorHandoff = &operatorHandoff{det: operator.Detection{Guest: plateGuest(t, "opencode"), Path: "/fake/opencode"}}
+	view := m.operatorPatchView(120)
+	if !strings.Contains(view, stRed.Render("(•)")) || !strings.Contains(view, stDim.Render("patching ")) || !strings.Contains(view, stKey.Render("opencode")) {
+		t.Fatalf("compact styling must be stRed beacon · stDim verb · stKey name, got %q", view)
+	}
+}
+
+// equalLines is a tiny slice comparison (no reflect import churn).
+func equalLines(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/operator_plates_test.go
+++ b/internal/tui/operator_plates_test.go
@@ -338,6 +338,9 @@ func TestBrandRowOutOfRangeSpansSafe(t *testing.T) {
 		{Text: "ok", Spans: []operator.BrandSpan{{From: 5, To: 9, Ink: operator.BrandInk{Token: operator.InkDim}}}},
 		{Text: "ok", Spans: []operator.BrandSpan{{From: 0, To: 99, Ink: operator.BrandInk{Token: operator.InkDim}}}},
 		{Text: "ok", Spans: []operator.BrandSpan{{From: 1, To: 1, Ink: operator.BrandInk{Token: operator.InkDim}}}},
+		{Text: "ok", Spans: []operator.BrandSpan{{From: -3, To: 1, Ink: operator.BrandInk{Token: operator.InkDim}}}},
+		{Text: "ok", Spans: []operator.BrandSpan{{From: -2, To: -1, Ink: operator.BrandInk{Token: operator.InkDim}}}},
+		{Text: "ok", Spans: []operator.BrandSpan{{From: 2, To: 0, Ink: operator.BrandInk{Token: operator.InkDim}}}},
 	}
 	for i, row := range rows {
 		got := stripANSI(operatorBrandRow(row))

--- a/internal/tui/operator_plates_test.go
+++ b/internal/tui/operator_plates_test.go
@@ -329,6 +329,24 @@ func TestPatchViewCompactStyles(t *testing.T) {
 	}
 }
 
+// TestBrandRowOutOfRangeSpansSafe: defense in depth (pre-push audit minor) - a
+// span pointing past the row's runes must clamp, never panic, and never drop the
+// row's text. Unreachable with the shipped golden-pinned data; pinned so a future
+// hand-edited plate can't crash the PATCHING screen.
+func TestBrandRowOutOfRangeSpansSafe(t *testing.T) {
+	rows := []operator.BrandRow{
+		{Text: "ok", Spans: []operator.BrandSpan{{From: 5, To: 9, Ink: operator.BrandInk{Token: operator.InkDim}}}},
+		{Text: "ok", Spans: []operator.BrandSpan{{From: 0, To: 99, Ink: operator.BrandInk{Token: operator.InkDim}}}},
+		{Text: "ok", Spans: []operator.BrandSpan{{From: 1, To: 1, Ink: operator.BrandInk{Token: operator.InkDim}}}},
+	}
+	for i, row := range rows {
+		got := stripANSI(operatorBrandRow(row))
+		if got != "ok" {
+			t.Fatalf("case %d: out-of-range spans must clamp and keep the text, got %q", i, got)
+		}
+	}
+}
+
 // equalLines is a tiny slice comparison (no reflect import churn).
 func equalLines(got, want []string) bool {
 	if len(got) != len(want) {


### PR DESCRIPTION
## Guest-operator BRAND PLATES - data-only on the Phase 2 seam

Lands the founder-approved plates from `GUEST-OPERATOR-PLATES.md` (2026-07-06, **"ONE HUE, ONE BEAT"**) as registry DATA against the Phase 2 `BrandPlate` seam (d4d040b). Transition logic (staging, exec, return, interlock) is untouched.

### Doc-to-code fidelity

Every art row was extracted from the doc's code blocks by script (not retyped) and embedded byte-exact; span boundaries were machine-verified against the doc's style tables before the tests were written. `internal/operator/brand_test.go` pins every row's exact bytes, every span boundary, every hue pair, each lockup, and each narrow threshold - a stray edit to any plate fails the suite.

### The seam extension (minimal, additive)

The Phase 2 seam (`BrandPlate string` + one accent) cannot express per-ROW gradients (hermes' 3-step gold), the opencode two-tone + non-bold cRed cursor stack, or the light-terminal collapses. Added, additive-only, in `internal/operator/brand.go` (the package stays render-free - no lipgloss/bubbletea):

- `BrandInk` - a house token (`dim`/`brand`/`key`/`red` non-bold/`redBold`) OR a custom adaptive `Dark`/`Light` hex pair + optional bold. Light-mode collapse is pure data (hermes' three dark steps all carry `Light: #B8860B`).
- `BrandRow` - exact text + whole-row ink or `[]BrandSpan` ({from,to,ink} styled segments).
- `BrandArt` - rows + wordmark `Width` (narrow swap gate = 2 + width) + one-line `Lockup` row + `ASCIIArt` (aider: the art IS its own ASCII fallback).
- `Guest.Brand *BrandArt` - new optional field; the legacy `BrandPlate`/`BrandAccent`/`BrandGlyph` string seam is kept working (its tests untouched).
- `internal/tui/operator.go` maps inks to the existing house styles and renders rows/lockups; plus the §1b compact windowshade one-liner in `operatorPatchView` (shared template, not per-guest).
- `glyphs.Fold` now also expands `…` to `...` under ASCII (the doc's §7 rule; it was a string-level gap since `asciiFold` is rune-to-rune).

### claude + codex: dormant data (the noted choice)

The shim-era drafts are INCLUDED as data in `BrandArts()` (all five plates live there) but get **no `Registry()` row**: the registry IS the detect set, and adding a row would change detection/picker behavior - not data-only. When the `/v1/messages` shim lands, wiring them is one field.

### Fallback matrix coverage (doc §7, all tested)

| mode | behavior | pinned by |
|---|---|---|
| color · full | styled art, per-doc spans/gradients | `TestPlate*ExactBytesAndStyles`, `TestPlateHermesGradientAndByline`, `TestPlateAiderGreenAndTagline`, `TestPlateClaudeCodexDormantDrafts` |
| light terminal | hermes collapses to #B8860B (rows 1-2 keep bold); aider #0E7A0E; claude #B85F41 | `TestPlateHermesLightCollapse` + ink-pair pins |
| NO_COLOR | same art, plain, byte-exact - no substitute art | `TestPlateNoColorPlain` |
| ROGERAI_ASCII | swap to text lockup (never a folded wordmark); aider keeps its pure-ASCII plate | `TestPlateASCIILockups`, `TestPlateASCIILockupStyles` |
| narrow | full art at termWidth >= 2+artWidth (44/53/23/20/17), ONE column below swaps to the lockup - never crops | `TestPlateNarrowSwap` |
| compact windowshade | one static line `(•) patching <guest> through on <band>…`, ASCII folds to `(*) … ...` | `TestPatchViewCompactOneLiner`, `TestPatchViewCompactStyles` |
| picker / roster | stays 100% mono+red - NO brand glyphs for any guest (§6) | `TestNoPickerGlyphs` |

The two derived light hexes (#0E7A0E aider, #B85F41 claude) are the only non-shipped values, flagged for founder taste per the doc.

---

## The plates (rendered through the real seam, 256-color captures)

### opencode - the full PATCHING YOU THROUGH frame (flagship)

```ansi
  [38;5;203m▌[0m [1;38;5;230mAGENT[0m[38;5;102m · handing off[0m      [1;38;5;203m((•))[0m  [1;38;5;230mPATCHING YOU THROUGH…[0m

  ⠀                                [1;38;5;230m▄[0m
  [38;5;102m█▀▀█ █▀▀█ █▀▀█ █▀▀▄[0m [1;38;5;230m█▀▀▀ █▀▀█ █▀▀█ █▀▀█[0m  [38;5;203m▄[0m
  [38;5;102m█  █ █  █ █▀▀▀ █  █[0m [1;38;5;230m█    █  █ █  █ █▀▀▀[0m  [38;5;203m█[0m
  [38;5;102m▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀[0m [1;38;5;230m▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀[0m  [38;5;203m▀[0m

  [1;38;5;203m◉[0m [38;5;102mmic to  [0m[1;38;5;230mopencode[0m[38;5;102m  (guest operator)[0m
  [1;38;5;203m◉[0m [38;5;102mon band [0m[1;38;5;230mqwen3-32b-fp8[0m[38;5;102m  your open channel · usual relay pricing[0m
  [1;38;5;203m◉[0m [38;5;102mwire    [0m[1;38;5;230mconfig generated in a scratch dir[0m[38;5;102m  your own setup is untouched[0m

      [38;5;102mBASE URL [0m[1;38;5;230mhttp://127.0.0.1:44017/v1[0m
      [38;5;102mMODEL    [0m[1;38;5;230mqwen3-32b-fp8[0m

  [38;5;102mthe radio steps aside while the guest is on the mic · exit the guest to come back[0m
```

### hermes (dark)

```ansi
  [1;38;5;220m██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗[0m
  [1;38;5;220m██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝[0m
  [38;5;214m███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗[0m
  [38;5;214m██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║[0m
  [38;5;173m██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║[0m
  [38;5;173m╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝[0m
                                        [38;5;102mnous research[0m
```

hermes on a light terminal (gradient collapses to their #B8860B dim-gold, rows 1-2 keep bold):

```ansi
  [1;38;5;136m██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗[0m
  [1;38;5;136m██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝[0m
  [38;5;136m███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗[0m
  [38;5;136m██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║[0m
  [38;5;136m██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║[0m
  [38;5;136m╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝[0m
                                        [38;5;59mnous research[0m
```

### aider (dark)

```ansi
  [38;5;34m      _    _[0m
  [38;5;34m __ _(_)__| |___ _ _[0m
  [38;5;34m/ _` | / _` / -_) '_|[0m
  [38;5;34m\__,_|_\__,_\___|_|[0m
  [38;5;102mai pair programming in your terminal[0m
```

### claude - dormant shim-era draft (dark)

```ansi
  [38;5;173m  ▗   ▖[0m
  [38;5;173m ▐▛███▜▌[0m
  [38;5;173m▝▜█████▛▘[0m   [1;38;5;173mclaude[0m
  [38;5;173m  ▘▘ ▝▝[0m
```

### codex - dormant shim-era draft (mono + the red underscore beat)

```ansi
  [1;38;5;230m█▄[0m
   [1;38;5;230m▀█▄[0m     [1;38;5;230mcodex[0m
   [1;38;5;230m▄█▀[0m     [38;5;102mopenai[0m
  [1;38;5;230m█▀[0m [1;38;5;203m▄▄▄▄[0m
```

### compact windowshade one-liner (+ ASCII fold)

```ansi
  [1;38;5;203m(•)[0m [38;5;102mpatching [0m[1;38;5;230mopencode[0m[38;5;102m through on qwen3-32b-fp8…[0m
```

```text
  (*) patching opencode through on qwen3-32b-fp8...
```

### NO_COLOR (same art, plain - opencode shown)

```text
  ⠀                                ▄
  █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█  ▄
  █  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀  █
  ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀  ▀
```

### ROGERAI_ASCII lockups (never a garbled wordmark; aider keeps its plate)

```ansi
  [38;5;102mopen[0m[1;38;5;230mcode[0m [1;38;5;203m_[0m
```

```ansi
  [1;38;5;220mH E R M E S[0m[38;5;102m . nous research[0m
```

```ansi
  [38;5;173m* claude[0m
```

```text
  >_ codex . openai
```

```ansi
  [38;5;34m      _    _[0m
  [38;5;34m __ _(_)__| |___ _ _[0m
  [38;5;34m/ _` | / _` / -_) '_|[0m
  [38;5;34m\__,_|_\__,_\___|_|[0m
  [38;5;102mai pair programming in your terminal[0m
```

### narrow swap (opencode at 43 cols - one below its 44-col threshold)

```ansi
  [38;5;102mopen[0m[1;38;5;230mcode[0m [1;38;5;203m_[0m
```

---

## Verification

- `go build ./...` + `go vet` clean
- full suites green including `-race` on `internal/operator`, `internal/tui`, `internal/glyphs`
- `make cover-gate` PASS (output tail below)
- no existing test weakened; the legacy string-seam tests still pass untouched
- pre-push claude-audit: PASS (high confidence) on every push; its minor defense-in-depth findings (clamp `sp.From` too, then negative/inverted bounds - all unreachable with the shipped golden-pinned data) are fixed in the two follow-up commits, pinned by `TestBrandRowOutOfRangeSpansSafe`

```text
[cover] starting throwaway Postgres (podman) for the store money path…
[cover] running full suite with coverage…
ok    cmd/rogerai  92.0% (>=90%)
ok    cmd/rogerai-broker  90.7% (>=90%)
ok    cmd/tokenizer-sidecar  94.7% (>=90%)
ok    internal/agent  92.7% (>=90%)
ok    internal/audio  90.3% (>=90%)
ok    internal/client  95.7% (>=90%)
ok    internal/detect  91.5% (>=90%)
ok    internal/glyphs  100.0% (>=90%)
ok    internal/harness  99.6% (>=90%)
ok    internal/node  98.5% (>=90%)
ok    internal/onair  97.2% (>=90%)
ok    internal/operator  94.3% (>=90%)
ok    internal/pricetier  100.0% (>=90%)
ok    internal/protocol  95.7% (>=90%)
ok    internal/store  91.9% (>=90%)
ok    internal/tokenizer  98.1% (>=90%)
ok    internal/tui  92.3% (>=90%)
ok    internal/update  98.9% (>=90%)
ok    internal/webui  95.2% (>=90%)
ok    total 92.3% (>=90%)
[cover] gate PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
