### PR TITLE
operator: Guest Operators Phase 2 - iteration-1 fix pass (5 validation findings)

### DIFF
--- a/features/operator/handoff_lifecycle.feature
+++ b/features/operator/handoff_lifecycle.feature
@@ -191,3 +191,27 @@ Feature: Handing the mic — suspend, exec, and the return to the desk
     And the user runs "/operator aider"
     Then the aider wiring carries no opencode artifacts
     And the first session's scratch dir is already gone
+
+  # ── iteration-1 fix-pass regressions (2026-07) ──────────────────────────────────
+
+  Scenario: The band dropping during the staging beat aborts at exec time
+    # Finding #3: startOperatorHandoff gates on Connected() but the exec callback only
+    # nil-checked the holder - a band drop inside the 450ms staging beat launched the
+    # guest into a wall of 502/503s. The channel precondition is re-checked at exec
+    # time, aborting with the same styling and an honest note.
+    Given the handoff to "opencode" is staged but not yet execed
+    When the band drops during the staging beat
+    And the staging beat elapses
+    Then no child process is launched
+    And the transcript notes "the channel dropped while patching"
+    And the desk is fully usable for a re-tune
+
+  Scenario: Bracketed paste is re-armed on every return from a guest
+    # Finding #2: the defensive reset preamble ends with ESC[?2004l and runs AFTER
+    # bubbletea's RestoreTerminal already re-enabled paste - so the first handoff killed
+    # bracketed paste for the rest of the radio session (multi-line pastes fired line by
+    # line as separate prompts). The radio always runs with paste on, so the return
+    # command set re-enables it unconditionally, after the defensive reset.
+    When the guest returns with exit 0
+    Then the terminal reset preamble ran
+    And bracketed paste is re-enabled in the return command set

--- a/features/operator/operator_command.feature
+++ b/features/operator/operator_command.feature
@@ -145,3 +145,25 @@ Feature: The /operator command and the hand-the-mic picker
     Given detected guests "opencode"
     When the user runs "/operator OpenCode"
     Then the handoff to "opencode" begins
+
+  # ── iteration-1 fix-pass regressions (2026-07) ──────────────────────────────────
+
+  Scenario: /operator <name> direct-jump to a guest that requires setup prints the setup note, no exec
+    # Finding #5: the picker enforced the NeedsSetup gate but the /operator <name>
+    # direct-jump went straight to the handoff. ONE gate now lives in
+    # startOperatorHandoff and covers both paths (the picker copy is deleted).
+    Given a detected guest "claudeish" that requires setup
+    When the user runs "/operator claudeish"
+    Then no handoff is staged and no child process was launched
+    And the transcript shows the setup note for "claudeish"
+
+  Scenario: /operator <name> direct-jump to an unverified guest carries the picker's unproven-version note
+    # Direct-jump parity with the picker row detail: the picker dims "version X
+    # unproven" for a guest whose version probe failed; the direct jump says the same
+    # honest thing in the transcript before handing off (it still hands off - unproven
+    # is a disclosure, not a block, exactly like the picker's enter).
+    Given a detected guest "opencode" whose version probe failed
+    When the user runs "/operator opencode"
+    And the handoff to "opencode" begins
+    And the guest returns
+    Then the transcript notes "version unknown unproven"

--- a/features/operator/rc_interlock.feature
+++ b/features/operator/rc_interlock.feature
@@ -112,3 +112,29 @@ Feature: While a guest has the mic, remote control parks — never deaf, never a
     # and the guest session is not the DJ loop). Only the status transitions are visible.
     When the handoff to "opencode" begins and the guest works for a while
     Then no frame carries any guest terminal output
+
+  Scenario: A remote-queued /operator never hands off the mic; it is answered as a chat turn
+    # Iteration-1 fix-pass finding #1 (MAJOR/SECURITY, 2026-07): a remote turn queued while
+    # the DJ was busy (rc.go) used to slash-dispatch at drain time (startQueuedPrompt), so
+    # "/operator opencode" sent from a phone could exec a guest on the HOST terminal the
+    # moment the turn ended - ruling 7 forbids any v1 remote handoff, and the IDLE path
+    # already treats a remote "/..." as a plain chat turn (submitAgentPrompt, never
+    # runAgentCommand). Queue entries now carry their origin; a remote-origin entry NEVER
+    # slash-dispatches. This also means a remote-queued /clear no longer clears the host -
+    # the asymmetry removal is intended (remote text is chat, local text is control).
+    Given a DJ turn is in flight
+    When a viewer sends a turn "/operator opencode" that the busy host queues
+    And the DJ turn finishes and the queue drains
+    Then no handoff is staged and no child process was launched
+    And "/operator opencode" was answered as a chat turn
+
+  Scenario: An exec-time abort tells viewers the DJ is back at the desk
+    # Iteration-1 fix-pass finding #4 (2026-07): during the staging beat a remote turn is
+    # answered "guest has the mic" (the staging guard, rc.go), but the exec-time abort
+    # paths emitted no corrective frame - the remote surface was stranded believing a
+    # guest held a mic it never took. Every abort branch now emits the DJ-back status
+    # frame (nil-safe: no bridge, no frame).
+    Given the handoff to "opencode" is staged but not yet execed
+    When a DJ turn slips in and the staging beat elapses
+    Then the handoff is aborted with no child process launched
+    And a frame of kind "status" is emitted announcing the DJ is back

--- a/internal/operator/env_exec_test.go
+++ b/internal/operator/env_exec_test.go
@@ -241,6 +241,7 @@ func TestMaterializeRejectsUnsafeValues(t *testing.T) {
 		{"newline in base URL", func(s *Session) { s.BaseURL = "http://x/v1\napi_key: stolen" }},
 		{"backslash in model", func(s *Session) { s.Model = `m\"` }},
 		{"yaml colon-space in model", func(s *Session) { s.Model = "m: evil" }},
+		{"yaml comment hash in model", func(s *Session) { s.Model = "m #evil" }}, // " #" starts a YAML comment in a plain scalar
 		{"control byte in base URL", func(s *Session) { s.BaseURL = "http://x/v1\x07" }},
 	}
 	for _, tc := range cases {

--- a/internal/operator/env_exec_test.go
+++ b/internal/operator/env_exec_test.go
@@ -243,6 +243,9 @@ func TestMaterializeRejectsUnsafeValues(t *testing.T) {
 		{"yaml colon-space in model", func(s *Session) { s.Model = "m: evil" }},
 		{"yaml comment hash in model", func(s *Session) { s.Model = "m #evil" }}, // " #" starts a YAML comment in a plain scalar
 		{"leading hash in model", func(s *Session) { s.Model = "#evil" }},        // "default: #evil" comments the value out - the key silently nulls (audit finding)
+		{"leading anchor in model", func(s *Session) { s.Model = "&a" }},         // "default: &a" is a YAML anchor - value nulls (audit finding #2)
+		{"leading alias in model", func(s *Session) { s.Model = "*a" }},          // "default: *a" is a YAML alias - parse error or hijack
+		{"leading dash in base URL", func(s *Session) { s.BaseURL = "- http://x/v1" }}, // "- " is a block-sequence indicator
 		{"control byte in base URL", func(s *Session) { s.BaseURL = "http://x/v1\x07" }},
 	}
 	for _, tc := range cases {

--- a/internal/operator/env_exec_test.go
+++ b/internal/operator/env_exec_test.go
@@ -242,6 +242,7 @@ func TestMaterializeRejectsUnsafeValues(t *testing.T) {
 		{"backslash in model", func(s *Session) { s.Model = `m\"` }},
 		{"yaml colon-space in model", func(s *Session) { s.Model = "m: evil" }},
 		{"yaml comment hash in model", func(s *Session) { s.Model = "m #evil" }}, // " #" starts a YAML comment in a plain scalar
+		{"leading hash in model", func(s *Session) { s.Model = "#evil" }},        // "default: #evil" comments the value out - the key silently nulls (audit finding)
 		{"control byte in base URL", func(s *Session) { s.BaseURL = "http://x/v1\x07" }},
 	}
 	for _, tc := range cases {

--- a/internal/operator/materialize.go
+++ b/internal/operator/materialize.go
@@ -151,9 +151,10 @@ func Materialize(g Guest, s Session) (Launch, func() error, error) {
 
 // safeConfigValue reports whether v can be interpolated verbatim into the generated
 // JSON/YAML configs: no control bytes (incl. newlines), no quotes/backslashes/backticks,
-// and no YAML plain-scalar hazards (": " starts a mapping, " #" starts a comment).
+// and no YAML plain-scalar hazards (": " starts a mapping; " #" - or a LEADING "#",
+// audit finding - starts a comment, silently nulling the key: fail-open).
 func safeConfigValue(v string) bool {
-	if strings.Contains(v, ": ") || strings.Contains(v, " #") {
+	if strings.Contains(v, ": ") || strings.Contains(v, " #") || strings.HasPrefix(v, "#") {
 		return false
 	}
 	for _, r := range v {

--- a/internal/operator/materialize.go
+++ b/internal/operator/materialize.go
@@ -150,11 +150,20 @@ func Materialize(g Guest, s Session) (Launch, func() error, error) {
 }
 
 // safeConfigValue reports whether v can be interpolated verbatim into the generated
-// JSON/YAML configs: no control bytes (incl. newlines), no quotes/backslashes/backticks,
-// and no YAML plain-scalar hazards (": " starts a mapping; " #" - or a LEADING "#",
-// audit finding - starts a comment, silently nulling the key: fail-open).
+// JSON/YAML configs: it must START alphanumeric (a leading YAML indicator - "#" comment,
+// "&" anchor, "*" alias, "-" sequence, etc. - silently nulls or hijacks the key:
+// fail-open, the class two pre-push audits flagged), with no control bytes (incl.
+// newlines), no quotes/backslashes/backticks, and no in-value YAML plain-scalar hazards
+// (": " starts a mapping, " #" starts a comment). Broker band values (model slugs,
+// http(s) base URLs) always start alphanumeric.
 func safeConfigValue(v string) bool {
-	if strings.Contains(v, ": ") || strings.Contains(v, " #") || strings.HasPrefix(v, "#") {
+	if v == "" {
+		return false // Materialize rejects empties earlier; fail closed here too
+	}
+	if c := v[0]; !('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9') {
+		return false
+	}
+	if strings.Contains(v, ": ") || strings.Contains(v, " #") {
 		return false
 	}
 	for _, r := range v {

--- a/internal/operator/materialize.go
+++ b/internal/operator/materialize.go
@@ -151,9 +151,9 @@ func Materialize(g Guest, s Session) (Launch, func() error, error) {
 
 // safeConfigValue reports whether v can be interpolated verbatim into the generated
 // JSON/YAML configs: no control bytes (incl. newlines), no quotes/backslashes/backticks,
-// and no YAML ": " plain-scalar hazard.
+// and no YAML plain-scalar hazards (": " starts a mapping, " #" starts a comment).
 func safeConfigValue(v string) bool {
-	if strings.Contains(v, ": ") {
+	if strings.Contains(v, ": ") || strings.Contains(v, " #") {
 		return false
 	}
 	for _, r := range v {

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -502,7 +502,7 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.rcEmitLocalTurn(p)
 		}
 		if m.agentBusy {
-			m.agentQueued = append(m.agentQueued, p)
+			m.agentQueued = append(m.agentQueued, queuedPrompt{text: p})
 			m.agentLines = append(m.agentLines, stDim.Render("⏳ queued · ")+stDim.Render(clipLine(p)))
 			m.status = stDim.Render(plural(len(m.agentQueued), "queued msg") + " · sends when the turn finishes · esc cancels")
 			return m, nil
@@ -510,7 +510,7 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if strings.HasPrefix(p, "/") {
 			return m.runAgentCommand(p)
 		}
-		nm, cmd := m.submitAgentPrompt(p)
+		nm, cmd := m.submitAgentPrompt(queuedPrompt{text: p})
 		return nm, cmd
 	}
 	// Input stays typable even while a turn runs, so the user can compose + queue the next
@@ -521,15 +521,29 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, c
 }
 
-// submitAgentPrompt starts ONE agent turn for prompt p: it echoes the ask, re-resolves
+// queuedPrompt is one parked prompt plus its ORIGIN. Origin matters at drain time: a
+// LOCAL "/command" runs inline exactly as if typed when idle, but a REMOTE-queued "/..."
+// is ALWAYS submitted as a chat turn - the same treatment the idle path gives a remote
+// turn (rc.go injects via submitAgentPrompt, never runAgentCommand). Ruling 7: no v1
+// remote handoff or host-side control, and the busy queue must not be a back door to it
+// (iteration-1 finding #1: a remote-queued "/operator opencode" used to exec a guest on
+// the HOST terminal at drain).
+type queuedPrompt struct {
+	text   string
+	remote bool
+}
+
+// submitAgentPrompt starts ONE agent turn for prompt q: it echoes the ask, re-resolves
 // the model, flips the busy/streaming state, and launches the loop goroutine + the drain.
-// It assumes p is a chat turn (not a slash command - those are handled by the caller / by
+// It assumes q is a chat turn (not a slash command - those are handled by the caller / by
 // startQueuedPrompt). If a previous (force-stopped) turn's goroutine is still unwinding it
 // CANNOT start safely on the shared loop, so the prompt is re-queued to run when that
-// goroutine finally exits (agentDoneMsg) - this is what makes force-stop race-free.
-func (m model) submitAgentPrompt(p string) (model, tea.Cmd) {
+// goroutine finally exits (agentDoneMsg) - this is what makes force-stop race-free. The
+// re-queue keeps q's origin, so a re-queued remote "/..." still never slash-dispatches.
+func (m model) submitAgentPrompt(q queuedPrompt) (model, tea.Cmd) {
+	p := q.text
 	if m.agent != nil && m.agent.running.Load() {
-		m.agentQueued = append([]string{p}, m.agentQueued...) // jump the queue: it was next
+		m.agentQueued = append([]queuedPrompt{q}, m.agentQueued...) // jump the queue: it was next
 		m.agentLines = append(m.agentLines, stDim.Render("⏳ queued · ")+stDim.Render(clipLine(p))+stDim.Render(" (previous turn still wrapping up)"))
 		return m, nil
 	}
@@ -547,18 +561,20 @@ func (m model) submitAgentPrompt(p string) (model, tea.Cmd) {
 	return m, tea.Batch(m.startAgentTurn(p), m.waitAgentEvent())
 }
 
-// startQueuedPrompt sends one dequeued item: a slash-command runs inline (it starts no
-// turn), anything else starts a turn. Used by dequeueAgentPrompts so a queued /clear or
-// /model behaves the same as if typed when idle.
-func (m model) startQueuedPrompt(p string) (model, tea.Cmd) {
-	if strings.HasPrefix(p, "/") {
-		nm, c := m.runAgentCommand(p)
+// startQueuedPrompt sends one dequeued item: a LOCALLY-typed slash-command runs inline
+// (it starts no turn), anything else starts a turn - so a locally queued /clear or /model
+// behaves the same as if typed when idle. A REMOTE-origin entry NEVER slash-dispatches:
+// it is always submitted as a chat turn, matching the idle-path treatment of remote turns
+// (iteration-1 finding #1 - the busy queue must not remote-exec host commands).
+func (m model) startQueuedPrompt(q queuedPrompt) (model, tea.Cmd) {
+	if !q.remote && strings.HasPrefix(q.text, "/") {
+		nm, c := m.runAgentCommand(q.text)
 		if mm, ok := nm.(model); ok { // runAgentCommand always returns a model value
 			return mm, c
 		}
 		return m, c
 	}
-	return m.submitAgentPrompt(p)
+	return m.submitAgentPrompt(q)
 }
 
 // dequeueAgentPrompts drains queued prompts FIFO when a turn finishes: it runs leading

--- a/internal/tui/agent_freeze_test.go
+++ b/internal/tui/agent_freeze_test.go
@@ -130,8 +130,8 @@ func TestAgentQueueWhileBusy(t *testing.T) {
 	// Enter while busy queues the prompt and clears the input.
 	qm, _ := am.onAgentKey(tea.KeyMsg{Type: tea.KeyEnter})
 	am = asModel(qm)
-	if len(am.agentQueued) != 1 || am.agentQueued[0] != "hello there" {
-		t.Fatalf("enter-while-busy should queue the prompt, got %v", am.agentQueued)
+	if len(am.agentQueued) != 1 || am.agentQueued[0] != (queuedPrompt{text: "hello there"}) {
+		t.Fatalf("enter-while-busy should queue the prompt (local origin), got %v", am.agentQueued)
 	}
 	if am.agentIn.Value() != "" {
 		t.Errorf("queuing should clear the input, got %q", am.agentIn.Value())
@@ -187,12 +187,12 @@ func TestAgentSubmitWaitsForLingeringGoroutine(t *testing.T) {
 	am := agentSeed(t, "")
 	am.agent.running.Store(true) // a force-stopped turn's goroutine is still unwinding
 
-	nm, _ := am.submitAgentPrompt("do a thing")
+	nm, _ := am.submitAgentPrompt(queuedPrompt{text: "do a thing"})
 	if nm.agentBusy {
 		t.Error("submitting while the prior goroutine is alive must NOT start a racing turn")
 	}
-	if len(nm.agentQueued) != 1 || nm.agentQueued[0] != "do a thing" {
-		t.Errorf("the prompt should be re-queued, got %v", nm.agentQueued)
+	if len(nm.agentQueued) != 1 || nm.agentQueued[0] != (queuedPrompt{text: "do a thing"}) {
+		t.Errorf("the prompt should be re-queued with its origin kept, got %v", nm.agentQueued)
 	}
 }
 
@@ -202,8 +202,8 @@ func TestStartQueuedPromptRoutesCommands(t *testing.T) {
 	am := agentSeed(t, "")
 	am.agentLines = []string{"old line"}
 
-	// A slash command runs inline and starts NO turn (/clear wipes the transcript).
-	cm, _ := am.startQueuedPrompt("/clear")
+	// A LOCAL slash command runs inline and starts NO turn (/clear wipes the transcript).
+	cm, _ := am.startQueuedPrompt(queuedPrompt{text: "/clear"})
 	if cm.agentBusy {
 		t.Error("a queued slash command must not start a turn")
 	}
@@ -212,7 +212,7 @@ func TestStartQueuedPromptRoutesCommands(t *testing.T) {
 	}
 
 	// A plain prompt starts a turn.
-	pm, _ := am.startQueuedPrompt("do a thing")
+	pm, _ := am.startQueuedPrompt(queuedPrompt{text: "do a thing"})
 	if !pm.agentBusy {
 		t.Error("a queued chat prompt should start a turn")
 	}

--- a/internal/tui/base_station_test.go
+++ b/internal/tui/base_station_test.go
@@ -827,8 +827,8 @@ func TestOnRemoteInboundTurnPaths(t *testing.T) {
 	busy.agentBusy = true
 	nm, _ = busy.onRemoteInbound(protocol.RCInbound{Kind: protocol.RCInTurn, Text: "later please"})
 	gm := asModel(nm)
-	if len(gm.agentQueued) != 1 || gm.agentQueued[0] != "later please" {
-		t.Fatalf("a busy host must queue the turn, got %v", gm.agentQueued)
+	if len(gm.agentQueued) != 1 || gm.agentQueued[0] != (queuedPrompt{text: "later please", remote: true}) {
+		t.Fatalf("a busy host must queue the turn tagged remote, got %v", gm.agentQueued)
 	}
 
 	idle := m

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rogerai-fyi/roger/internal/client"
 	"github.com/rogerai-fyi/roger/internal/glyphs"
 	"github.com/rogerai-fyi/roger/internal/operator"
-	"github.com/rogerai-fyi/roger/internal/protocol"
 )
 
 // operator.go is the TUI glue for Guest Operators Phase 2 (THE DESK): the /operator
@@ -56,7 +55,8 @@ const operatorStaleAge = 24 * time.Hour
 // the mouse on (m.mouseOff is respected).
 const operatorResetSeq = "\x1b[<u" + // pop the kitty keyboard protocol
 	"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" + // all mouse reporting off
-	"\x1b[?2004l" // exit bracketed paste
+	"\x1b[?1004l" + // focus reporting off (a guest can leave it spraying ESC[I/ESC[O)
+	"\x1b[?2004l" // exit bracketed paste (re-armed via tea.EnableBracketedPaste after)
 
 // --- messages -------------------------------------------------------------------------
 
@@ -132,6 +132,16 @@ func (m model) runOperatorCommand(args []string) (tea.Model, tea.Cmd) {
 	want := strings.ToLower(args[0])
 	for _, d := range m.operatorDetections {
 		if strings.ToLower(d.Guest.Name) == want {
+			// Direct-jump parity with the picker row detail: an unverified guest gets
+			// the same dim unproven-version disclosure before the handoff (it still
+			// hands off - unproven is honesty, not a block, same as picker enter).
+			if d.Unverified {
+				v := d.Version
+				if v == "" {
+					v = "unknown"
+				}
+				m.rcNote(d.Guest.Name + " · version " + v + " unproven")
+			}
 			return m.startOperatorHandoff(d)
 		}
 	}
@@ -212,22 +222,13 @@ func (m model) onOperatorPickerKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		row := m.operatorRows[m.operatorCursor]
 		closePicker()
-		switch {
-		case row.isDJ:
+		if row.isDJ {
 			m.rcNote("the DJ keeps the mic")
 			return m, nil
-		case row.det.Guest.NeedsSetup:
-			// Installed-but-not-configured (reserved for the future claude row): a setup
-			// note, never an exec.
-			note := row.det.Guest.SetupNote
-			if note == "" {
-				note = row.label + " needs setup before it can take the mic"
-			}
-			m.rcNote(note)
-			return m, nil
-		default:
-			return m.startOperatorHandoff(row.det)
 		}
+		// The NeedsSetup gate lives in startOperatorHandoff (ONE gate for the picker
+		// AND the /operator <name> direct-jump - iteration-1 finding #5).
+		return m.startOperatorHandoff(row.det)
 	case "esc":
 		closePicker()
 		m.rcNote("the DJ keeps the mic")
@@ -323,6 +324,18 @@ func operatorRowDetail(row operatorRow) string {
 // startOperatorHandoff gates the handoff on the channel actually carrying it, then puts
 // up ONE staged PATCHING YOU THROUGH paint before the exec is issued (anti-blank).
 func (m model) startOperatorHandoff(d operator.Detection) (tea.Model, tea.Cmd) {
+	// Installed-but-not-configured (reserved for the future claude row): a setup note,
+	// never an exec. THE one NeedsSetup gate - it covers the picker's enter AND the
+	// /operator <name> direct-jump (iteration-1 finding #5: the direct-jump used to
+	// skip the picker's copy of this check).
+	if d.Guest.NeedsSetup {
+		note := d.Guest.SetupNote
+		if note == "" {
+			note = d.Guest.Name + " needs setup before it can take the mic"
+		}
+		m.rcNote(note)
+		return m, nil
+	}
 	// No band tuned: a disconnected proxy REFUSES to spend (Phase 1 ruling 5), so a
 	// launch now would only hand the guest a wall of 502s - block it at the desk.
 	if m.proxyHolder == nil || !m.proxyHolder.Connected() {
@@ -358,6 +371,7 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 	}
 	if m.proxyHolder == nil { // defensive: staging outlived the proxy
 		m.operatorHandoff = nil
+		m.rcEmitDJBack()
 		return m, nil
 	}
 	// Re-check the DJ-idle preconditions AT EXEC TIME (audit regression): the bridge
@@ -365,6 +379,9 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 	// and bill - under the suspended TUI, into the guest's freshly reset accumulator.
 	// The mode check covers global keys (ctrl+c quit-confirm, alt+m, a preset) pulling
 	// the TUI off AGENT mid-staging - never exec the guest under another modal.
+	// Every abort below rcEmitDJBack()s: the staging guard answered remote turns with
+	// "guest has the mic", so an abort must correct the record or the remote surface is
+	// stranded on a guest that never took the mic (iteration-1 finding #4).
 	if m.mode != modeAgent || m.agentBusy || (m.agent != nil && m.agent.running.Load()) || len(m.agentQueued) > 0 {
 		m.operatorHandoff = nil
 		if m.mode != modeAgent {
@@ -373,6 +390,19 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 			m.rcNote("handoff aborted - the DJ picked up a turn while patching · /operator again once it finishes")
 		}
 		m.status = stDim.Render("back at the desk · the DJ is standing by")
+		m.rcEmitDJBack()
+		return m, nil
+	}
+	// Re-check the CHANNEL at exec time too (iteration-1 finding #3): the desk gate ran
+	// before the 450ms staging beat, and a band drop inside it would launch the guest
+	// into a wall of 502/503s (a disconnected proxy refuses to spend - Phase 1 ruling 5).
+	if !m.proxyHolder.Connected() {
+		m.operatorHandoff = nil
+		m.agentLines = append(m.agentLines,
+			stRed.Render("✕ ")+stEmber.Render("the channel dropped while patching - no band to carry the guest"),
+			stDim.Render("· ")+stDim.Render("tune back in: press ")+stKey.Render("[1]")+stDim.Render(", ⏎ on a band opens the channel · then /operator again"))
+		m.status = stDim.Render("back at the desk · the DJ is standing by")
+		m.rcEmitDJBack()
 		return m, nil
 	}
 	// LIVE options at exec time - never the options frozen at first bind.
@@ -386,6 +416,7 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 		m.operatorHandoff = nil
 		m.agentLines = append(m.agentLines, stRed.Render("✕ ")+stEmber.Render("couldn't hand the mic off: "+err.Error()))
 		m.status = stDim.Render("back at the desk · the DJ is standing by")
+		m.rcEmitDJBack()
 		return m, nil
 	}
 	// Fresh money state per handoff (ruling 4): the $2 default budget, zero spend, zero
@@ -425,10 +456,14 @@ func (m model) onOperatorDone(msg operatorDoneMsg) (tea.Model, tea.Cmd) {
 	// revoke-all mid-handoff Stops the bridge; Unpark/Emit are no-ops then.
 	if m.rcBridge != nil {
 		m.rcBridge.Unpark()
-		m.rcEmit(protocol.RCFrame{Kind: protocol.RCKindStatus, Text: "the DJ is back at the desk"})
+		m.rcEmitDJBack()
 	}
 	guest := h.det.Guest.Name
-	cmds := []tea.Cmd{fetchBalance(m.broker, m.user)}
+	// The defensive reset just wrote ESC[?2004l AFTER bubbletea's RestoreTerminal had
+	// re-enabled paste, so bracketed paste must be re-armed here or it stays dead for
+	// the rest of the radio session (iteration-1 finding #2). The radio always runs
+	// with paste on - unconditional, unlike the m.mouseOff-gated mouse restore.
+	cmds := []tea.Cmd{fetchBalance(m.broker, m.user), tea.EnableBracketedPaste}
 	if !m.mouseOff {
 		cmds = append(cmds, tea.EnableMouseCellMotion)
 	}

--- a/internal/tui/operator_fixpass_test.go
+++ b/internal/tui/operator_fixpass_test.go
@@ -1,0 +1,170 @@
+package tui
+
+// operator_fixpass_test.go - permanent unit regressions for the Guest Operators Phase 2
+// iteration-1 validation findings (2026-07 fix pass), alongside the scenarios added to
+// features/operator/{rc_interlock,handoff_lifecycle,operator_command}.feature:
+//   #1 a remote-queued "/..." must NEVER slash-dispatch at drain (origin-tagged queue);
+//   #2 bracketed paste must be re-armed in the return cmd set (the defensive reset seq
+//      disables it AFTER bubbletea's RestoreTerminal re-enabled it);
+//   #3 the channel (Connected) is re-checked at exec time - a band drop during the
+//      450ms staging beat aborts instead of launching the guest into 502/503s;
+//   #4 every exec-time abort emits the DJ-back status frame so a remote surface told
+//      "guest has the mic" during staging is never stranded.
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// TestStartQueuedPromptOriginDispatch is the finding-#1 table: only a LOCAL slash entry
+// dispatches through runAgentCommand at drain; a REMOTE entry is always a chat turn -
+// matching the idle path - so no remote text can exec a guest (or /clear the host)
+// through the busy queue.
+func TestStartQueuedPromptOriginDispatch(t *testing.T) {
+	cases := []struct {
+		name     string
+		q        queuedPrompt
+		wantTurn bool   // a chat turn starts (agentBusy flips on)
+		wantMark string // a transcript marker proving which path ran
+	}{
+		{"local slash dispatches inline", queuedPrompt{text: "/clear"}, false, "session cleared"},
+		{"remote /operator is a chat turn, never a handoff", queuedPrompt{text: "/operator opencode", remote: true}, true, "▸ /operator opencode"},
+		{"remote /clear is a chat turn too (asymmetry removal intended)", queuedPrompt{text: "/clear", remote: true}, true, "▸ /clear"},
+		{"local chat text starts a turn", queuedPrompt{text: "hello there"}, true, "▸ hello there"},
+		{"remote chat text starts a turn", queuedPrompt{text: "hello there", remote: true}, true, "▸ hello there"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := agentSeed(t, "")
+			nm, _ := m.startQueuedPrompt(tc.q) // returned Cmd deliberately not run: no real turn goroutine
+			if nm.agentBusy != tc.wantTurn {
+				t.Fatalf("agentBusy = %v, want %v", nm.agentBusy, tc.wantTurn)
+			}
+			if got := stripANSI(strings.Join(nm.agentLines, "\n")); !strings.Contains(got, tc.wantMark) {
+				t.Fatalf("transcript lacks %q:\n%s", tc.wantMark, got)
+			}
+			if nm.operatorHandoff != nil {
+				t.Fatal("a drained queue entry staged a guest handoff")
+			}
+		})
+	}
+}
+
+// TestOperatorReturnReenablesBracketedPaste pins finding #2: the onOperatorDone cmd set
+// includes tea.EnableBracketedPaste UNCONDITIONALLY (the radio always runs with paste
+// on), for both mouse settings.
+func TestOperatorReturnReenablesBracketedPaste(t *testing.T) {
+	// Sandbox HOME: executing the return cmd set runs fetchBalance, which signs with the
+	// local user key (LoadOrCreateUserKey) - never touch (or slowly create under) the
+	// developer's real config.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	saveTerm := operatorTermOut
+	operatorTermOut = &bytes.Buffer{}
+	t.Cleanup(func() { operatorTermOut = saveTerm })
+	// A live stub broker: executing the return cmd set runs the fetchBalance leaf for
+	// real, and a dead address can hang for seconds in sandboxed environments.
+	balSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(balSrv.Close)
+	for _, mouseOff := range []bool{false, true} {
+		t.Run(fmt.Sprintf("mouseOff=%v", mouseOff), func(t *testing.T) {
+			m, _, _ := opRegressionSeed(t)
+			m.mouseOff = mouseOff
+			m.broker = balSrv.URL
+			var tm tea.Model
+			tm, _ = m.runAgentCommand("/operator opencode")
+			tm, _ = tm.Update(operatorExecMsg{})
+			_, cmd := tm.Update(operatorDoneMsg{})
+			found := false
+			for _, msg := range collectCmdMsgs(cmd) {
+				if strings.Contains(fmt.Sprintf("%T", msg), "enableBracketedPaste") {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatal("the return cmd set does not re-enable bracketed paste")
+			}
+		})
+	}
+}
+
+// TestExecRecheckAbortsOnBandDrop pins finding #3: a Disconnect() during the staging
+// beat means NO exec at exec time - the abort is honest and the desk stays usable.
+func TestExecRecheckAbortsOnBandDrop(t *testing.T) {
+	m, holder, execs := opRegressionSeed(t)
+	var tm tea.Model
+	tm, _ = m.runAgentCommand("/operator opencode")
+	holder.Disconnect() // the band drops inside the 450ms staging window
+	tm, _ = tm.Update(operatorExecMsg{})
+	got := asModel(tm)
+	if len(*execs) != 0 {
+		t.Fatalf("the exec was issued into a dropped band: %v", (*execs)[0].Args)
+	}
+	if got.operatorHandoff != nil {
+		t.Fatal("the aborted handoff is still staged")
+	}
+	if v := stripANSI(got.View()); !strings.Contains(v, "the channel dropped while patching") {
+		t.Fatalf("no honest abort note:\n%s", v)
+	}
+	if got.mode != modeAgent || got.agentBusy {
+		t.Fatal("the desk is not usable after the abort")
+	}
+}
+
+// djBackEmitted reports whether the fake bridge saw the corrective DJ-back status frame.
+func djBackEmitted(fb *fakeBridge) bool {
+	for _, f := range fb.emitted {
+		if f.Kind == protocol.RCKindStatus && strings.Contains(f.Text, "the DJ is back at the desk") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExecTimeAbortEmitsDJBackFrame pins finding #4 across both exec-time abort causes:
+// the staging guard may already have told a remote surface "guest has the mic", so every
+// abort must correct the record with the DJ-back status frame.
+func TestExecTimeAbortEmitsDJBackFrame(t *testing.T) {
+	t.Run("DJ picked up a turn during staging", func(t *testing.T) {
+		m, _, execs := opRegressionSeed(t)
+		fb := newFakeBridge()
+		m.rcBridge = fb
+		var tm tea.Model
+		tm, _ = m.runAgentCommand("/operator opencode")
+		// The staging guard answers a remote turn with the guest-has-the-mic frame.
+		tm, _ = tm.Update(remoteInboundMsg(protocol.RCInbound{Kind: protocol.RCInTurn, Text: "hi", Origin: "phone"}))
+		mm := asModel(tm)
+		mm.agentBusy = true // a DJ turn slips in during the staging beat
+		tm, _ = mm.Update(operatorExecMsg{})
+		if got := asModel(tm); got.operatorHandoff != nil || len(*execs) != 0 {
+			t.Fatal("the exec-time re-check did not abort")
+		}
+		if !djBackEmitted(fb) {
+			t.Fatalf("no corrective DJ-back frame after the abort (frames: %+v)", fb.emitted)
+		}
+	})
+	t.Run("band dropped during staging", func(t *testing.T) {
+		m, holder, execs := opRegressionSeed(t)
+		fb := newFakeBridge()
+		m.rcBridge = fb
+		var tm tea.Model
+		tm, _ = m.runAgentCommand("/operator opencode")
+		holder.Disconnect()
+		tm, _ = tm.Update(operatorExecMsg{})
+		if len(*execs) != 0 {
+			t.Fatal("the band-drop abort still execed")
+		}
+		if !djBackEmitted(fb) {
+			t.Fatalf("the band-drop abort emitted no DJ-back frame (frames: %+v)", fb.emitted)
+		}
+	})
+}

--- a/internal/tui/operator_steps_tui_test.go
+++ b/internal/tui/operator_steps_tui_test.go
@@ -613,7 +613,7 @@ func (s *opBDD) djTurnInFlight() error {
 func (s *opBDD) djTurnInFlightAndQueued() error {
 	s.mutate(func(m *model) {
 		m.agentBusy = true
-		m.agentQueued = append(m.agentQueued, "parked ask")
+		m.agentQueued = append(m.agentQueued, queuedPrompt{text: "parked ask"})
 	})
 	return nil
 }
@@ -862,7 +862,9 @@ func (s *opBDD) guestReturnsPlain() error {
 
 func (s *opBDD) resetPreambleRan() error {
 	got := s.resetBuf.String()
-	for _, seq := range []string{"\x1b[<u", "\x1b[?1000l", "\x1b[?1002l", "\x1b[?1003l", "\x1b[?1006l", "\x1b[?2004l"} {
+	// \x1b[?1004l (focus reporting off) joined the preamble in the iteration-1 fix pass:
+	// a guest can leave focus-event reporting on, spraying ESC[I/ESC[O into the prompt.
+	for _, seq := range []string{"\x1b[<u", "\x1b[?1000l", "\x1b[?1002l", "\x1b[?1003l", "\x1b[?1006l", "\x1b[?1004l", "\x1b[?2004l"} {
 		if !strings.Contains(got, seq) {
 			return fmt.Errorf("terminal reset preamble missing %q (got %q)", seq, got)
 		}
@@ -1511,6 +1513,110 @@ func (s *opBDD) noFrameCarriesGuestOutput() error {
 	return nil
 }
 
+// --- iteration-1 fix-pass steps (2026-07) ----------------------------------------------------
+
+// viewerTurnQueuedWhileBusy drives a REAL remote turn through the unparked bridge into
+// the busy host and pins that it landed on the DJ queue (the finding-#1 setup).
+func (s *opBDD) viewerTurnQueuedWhileBusy(text string) error {
+	s.rcQueue <- protocol.RCInbound{Kind: protocol.RCInTurn, Text: text, Origin: "phone"}
+	var in protocol.RCInbound
+	select {
+	case in = <-s.bridge.Inbound():
+	case <-time.After(2 * time.Second):
+		return fmt.Errorf("the bridge never delivered the remote turn")
+	}
+	s.update(remoteInboundMsg(in))
+	if got := len(s.model().agentQueued); got != 1 {
+		return fmt.Errorf("the busy host queued %d entries, want 1", got)
+	}
+	return nil
+}
+
+// djTurnFinishesQueueDrains delivers the turn-done message; the Update loop dequeues the
+// parked prompt exactly like production (dequeueAgentPrompts via agentDoneMsg).
+func (s *opBDD) djTurnFinishesQueueDrains() error {
+	s.update(agentDoneMsg{})
+	return nil
+}
+
+func (s *opBDD) noHandoffStagedNoChild() error {
+	if s.model().operatorHandoff != nil {
+		return fmt.Errorf("a handoff was staged")
+	}
+	return s.noChildLaunched()
+}
+
+func (s *opBDD) answeredAsChatTurn(text string) error {
+	m := s.model()
+	if !m.agentBusy {
+		return fmt.Errorf("no chat turn started for the drained remote text")
+	}
+	if !strings.Contains(s.view(), "▸ "+text) {
+		return fmt.Errorf("the transcript lacks the chat-turn echo for %q:\n%s", text, s.view())
+	}
+	return nil
+}
+
+// handoffStagedNotExeced opens the staging window (the PATCHING plate is up, the exec
+// tick has not fired) - the exact window findings #3 and #4 live in.
+func (s *opBDD) handoffStagedNotExeced(name string) error {
+	if err := s.userRuns("/operator " + name); err != nil {
+		return err
+	}
+	h := s.model().operatorHandoff
+	if h == nil || h.execing {
+		return fmt.Errorf("the handoff is not in the staging window")
+	}
+	return nil
+}
+
+func (s *opBDD) djSlipsInStagingElapses() error {
+	s.mutate(func(m *model) { m.agentBusy = true })
+	s.update(operatorExecMsg{})
+	return nil
+}
+
+func (s *opBDD) handoffAbortedNoChild() error {
+	if s.model().operatorHandoff != nil {
+		return fmt.Errorf("the handoff is still staged after the abort")
+	}
+	return s.noChildLaunched()
+}
+
+func (s *opBDD) bandDropsDuringStaging() error {
+	s.holder.Disconnect()
+	return nil
+}
+
+func (s *opBDD) stagingBeatElapses() error {
+	s.update(operatorExecMsg{})
+	return nil
+}
+
+func (s *opBDD) bracketedPasteReenabled() error {
+	for _, msg := range s.collected {
+		if strings.Contains(fmt.Sprintf("%T", msg), "enableBracketedPaste") {
+			return nil
+		}
+	}
+	return fmt.Errorf("bracketed paste was not re-enabled in the return cmd set (msgs: %v)", s.collectedTypes())
+}
+
+// detectedGuestUnverified seeds a desk detection whose version probe failed (Unverified,
+// empty version) - the picker dims "version unknown unproven" for it.
+func (s *opBDD) detectedGuestUnverified(name string) error {
+	g, err := registryGuest(name)
+	if err != nil {
+		return err
+	}
+	s.tuiPaths[g.Bin] = "/fake/" + g.Bin
+	s.mutate(func(m *model) {
+		m.operatorDetections = append(m.operatorDetections,
+			operator.Detection{Guest: g, Path: "/fake/" + g.Bin, Unverified: true})
+	})
+	return nil
+}
+
 // --- suite wiring ---------------------------------------------------------------------------
 
 // initializeOperatorScenarios registers every step of the founder-approved Phase 2 spec
@@ -1747,4 +1853,17 @@ func initializeOperatorScenarios(t *testing.T, st *opBDD, sc *godog.ScenarioCont
 	sc.Step(`^v1 attaches no behavior to any of them$`, st.reservedKindsNoBehavior)
 	sc.Step(`^the handoff to "([^"]*)" begins and the guest works for a while$`, st.handoffBeginsAndGuestWorks)
 	sc.Step(`^no frame carries any guest terminal output$`, st.noFrameCarriesGuestOutput)
+
+	// ── iteration-1 fix-pass regressions (2026-07) ─────────────────────────────
+	sc.Step(`^a viewer sends a turn "([^"]*)" that the busy host queues$`, st.viewerTurnQueuedWhileBusy)
+	sc.Step(`^the DJ turn finishes and the queue drains$`, st.djTurnFinishesQueueDrains)
+	sc.Step(`^no handoff is staged and no child process was launched$`, st.noHandoffStagedNoChild)
+	sc.Step(`^"([^"]*)" was answered as a chat turn$`, st.answeredAsChatTurn)
+	sc.Step(`^the handoff to "([^"]*)" is staged but not yet execed$`, st.handoffStagedNotExeced)
+	sc.Step(`^a DJ turn slips in and the staging beat elapses$`, st.djSlipsInStagingElapses)
+	sc.Step(`^the handoff is aborted with no child process launched$`, st.handoffAbortedNoChild)
+	sc.Step(`^the band drops during the staging beat$`, st.bandDropsDuringStaging)
+	sc.Step(`^the staging beat elapses$`, st.stagingBeatElapses)
+	sc.Step(`^bracketed paste is re-enabled in the return command set$`, st.bracketedPasteReenabled)
+	sc.Step(`^a detected guest "([^"]*)" whose version probe failed$`, st.detectedGuestUnverified)
 }

--- a/internal/tui/rc.go
+++ b/internal/tui/rc.go
@@ -187,10 +187,14 @@ func (m model) onRemoteInbound(in protocol.RCInbound) (tea.Model, tea.Cmd) {
 			m.agent = m.newAgentRuntime()
 		}
 		if m.agentBusy || m.agent.running.Load() {
-			m.agentQueued = append(m.agentQueued, in.Text) // FIFO, drained when the turn ends
+			// FIFO, drained when the turn ends. Tagged remote: at drain it is ALWAYS
+			// submitted as a chat turn, never slash-dispatched - a remote "/operator"
+			// (or /clear) must not control the host through the busy queue (ruling 7;
+			// iteration-1 finding #1), exactly matching the idle path directly below.
+			m.agentQueued = append(m.agentQueued, queuedPrompt{text: in.Text, remote: true})
 			return m, rearm
 		}
-		nm, cmd := m.submitAgentPrompt(in.Text)
+		nm, cmd := m.submitAgentPrompt(queuedPrompt{text: in.Text, remote: true})
 		return nm, tea.Batch(cmd, rearm)
 	case protocol.RCInConfirm:
 		// Answer the pending confirm through its own resp channel (mirrors onAgentKey). The
@@ -270,6 +274,13 @@ func (m model) rcEmitConfirmReq(c *agentConfirm, id string) {
 // doesn't dangle as an unanswered echo on their side).
 func (m model) rcEmitCleared() {
 	m.rcEmit(protocol.RCFrame{Kind: protocol.RCKindError, Text: "— host cleared the session —"})
+}
+
+// rcEmitDJBack tells viewers the DJ holds the mic again - after a guest-operator return
+// AND after any exec-time abort (the staging guard may have told a remote "guest has the
+// mic"; without this corrective frame an aborted handoff strands that surface). Nil-safe.
+func (m model) rcEmitDJBack() {
+	m.rcEmit(protocol.RCFrame{Kind: protocol.RCKindStatus, Text: "the DJ is back at the desk"})
 }
 
 // rcEmitConfirmDone tells viewers a confirm was answered and by whom.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -800,7 +800,7 @@ type model struct {
 	agentVP             viewport.Model // the AGENT transcript's independent scroll region (mirror of chatVP)
 	agentBusy           bool           // a turn is in flight (drives the working line)
 	agentCanceling      bool           // esc-cancel requested for the in-flight turn; a 2nd esc force-stops
-	agentQueued         []string       // prompts typed mid-turn, auto-sent FIFO when the turn finishes (Claude-style queue)
+	agentQueued         []queuedPrompt // prompts parked mid-turn, auto-sent FIFO when the turn finishes (Claude-style queue); each entry carries its origin - a remote entry never slash-dispatches at drain
 	agentLastEvent      time.Time      // last streamed event time; powers the receiving-vs-stalled working line (hung detection)
 	agentTurnState      agentPose      // the reactive corner-Ping pose (waiting/thinking/streaming/tool), derived from the harness event stream
 	agentStart          time.Time      // when the in-flight turn began (elapsed readout)


### PR DESCRIPTION
FIX PASS for the Guest Operators Phase 2 iteration-1 validation findings (5 findings, confirmed at d4d040bf). Spec-first: every behavior change landed as a `.feature` scenario + step defs first, ran RED against unmodified production code, then went GREEN. New unit regressions live in `internal/tui/operator_fixpass_test.go`.

## Finding -> fix

### 1. MAJOR/SECURITY - remote slash-dispatch via the busy queue
`internal/tui/rc.go` queued a remote turn's raw text into `m.agentQueued`; at drain, `startQueuedPrompt` slash-dispatched ANY queued `"/"` text via `runAgentCommand`. A remote sending `/operator opencode` while the DJ was busy exec'd a guest on the HOST terminal - ruling 7 forbids any v1 remote handoff, and it was asymmetric with the idle path (which submits remote text as a plain chat turn).

**Fix:** queue entries are origin-tagged (`queuedPrompt{text, remote}`). A remote-origin entry NEVER slash-dispatches - it is always submitted as a chat turn, matching the idle path. The origin also survives the force-stop re-queue path (`submitAgentPrompt` now takes the tagged entry).

**Asymmetry removal (intended):** a remote-queued `/clear` (or any `/command`) also stops slash-dispatching and is answered as a chat turn. Remote text is chat; local text is control. Deliberate, and documented in the scenario comment.

Spec: `rc_interlock.feature` "A remote-queued /operator never hands off the mic; it is answered as a chat turn" + table test `TestStartQueuedPromptOriginDispatch`.

### 2. MAJOR/UX - bracketed paste permanently dead after the first handoff
`operatorResetSeq` ends with `ESC[?2004l`, written in `onOperatorDone` AFTER bubbletea's RestoreTerminal had already re-enabled paste - nothing re-armed it, so multi-line pastes fired line-by-line for the rest of the session.

**Fix:** `tea.EnableBracketedPaste` is appended to the return cmd set unconditionally (the radio always runs with paste on).

Spec: `handoff_lifecycle.feature` "Bracketed paste is re-armed on every return from a guest" + `TestOperatorReturnReenablesBracketedPaste` (both mouse settings).

### 3. MINOR - no Connected() re-check at exec time
`startOperatorHandoff` gates on `Connected()` but `onOperatorExec` only nil-checked the holder; a band drop during the 450ms staging beat launched the guest into a wall of 502/503s.

**Fix:** `onOperatorExec` re-checks `!Connected()` and aborts with the same styling + an honest note ("the channel dropped while patching").

Spec: `handoff_lifecycle.feature` "The band dropping during the staging beat aborts at exec time" + `TestExecRecheckAbortsOnBandDrop`.

### 4. MINOR - staged-abort stranded the remote on "guest has the mic"
The staging guard answers remote turns with the guest-has-the-mic status frame, but the exec-time abort paths emitted no corrective frame.

**Fix:** every abort branch in `onOperatorExec` (DJ-busy/mode, band drop, materialize failure, defensive nil-holder) emits the DJ-back status frame via a new nil-safe `rcEmitDJBack()` helper (also reused by `onOperatorDone`, deduping the inline literal).

Spec: `rc_interlock.feature` "An exec-time abort tells viewers the DJ is back at the desk" + `TestExecTimeAbortEmitsDJBackFrame` (both abort causes).

### 5. MINOR - direct-jump skipped the NeedsSetup gate
The picker enforced `NeedsSetup`, but `/operator <name>` name-match went straight to `startOperatorHandoff`.

**Fix (minimization):** the gate moved INTO `startOperatorHandoff`; the picker's copy is deleted. One gate, both paths.

Spec: `operator_command.feature` "direct-jump to a guest that requires setup prints the setup note, no exec".

## Polish (same review, one-liners)

- `operatorResetSeq` now also emits `ESC[?1004l` (focus reporting off) - a guest can leave focus events spraying `ESC[I`/`ESC[O` into the prompt. Pinned by the strengthened reset-preamble step.
- `safeConfigValue` also denies `" #"` (starts a YAML comment in a plain scalar) - new case in `TestMaterializeRejectsUnsafeValues`. Two pre-push audit passes then flagged the LEADING-indicator siblings (`#evil` comments the value out; `&a` anchors it; both silently null the key, fail-open). Closed as a class in the follow-up commits: a generated-config value must START alphanumeric (band slugs and http(s) URLs always do), with RED cases for `#` / `&` / `*` / `- ` first.
- Direct-jump parity for UNVERIFIED guests: `/operator <name>` now prints the picker's dim "version X unproven" disclosure before handing off. Specced in `operator_command.feature`.

## Evidence

- RED: all 10 new/strengthened checks failed for the right reasons against unmodified production code (handoff staged off a remote-queued `/operator`, child exec issued into a dropped band, no DJ-back frame, missing `?1004l`, `" #"` accepted).
- GREEN: operator BDD suite 115 scenarios / 598 steps, 0 failed (5 new scenarios).
- `go test ./internal/tui ./internal/operator ./internal/client ./internal/protocol` - all ok.
- `go test -race ./internal/tui ./internal/operator` - ok.
- `go build ./...`, `go vet ./...` - clean.
- `make cover-gate` - PASS (total 92.3%, every package >=90%; tui 92.3%, operator 94.2%).
- Pre-push `claude-audit` - PASS on all three pushes ("All five claimed fixes are real, verified end to end"). Its minor findings (leading `#`, then leading `&`/indicator class) are fixed in the follow-up commits. The last remaining note (a value ENDING in `:` gives a loud YAML parse error) is explicitly fail-closed and unreachable with real broker values - left as-is per the audit's own "optionally".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
