### PR TITLE
operator: enrich the guest-has-the-mic frame with model + live spend (build-and-hold)

### DIFF
--- a/features/operator/rc_enrichment.feature
+++ b/features/operator/rc_enrichment.feature
@@ -1,0 +1,131 @@
+# GUEST OPERATORS - deferred follow-up: OPERATOR FRAME ENRICHMENT (iteration 2 design).
+#
+# TODAY: the RC "guest has the mic" status frame (internal/client/rc.go OperatorStatusFrame)
+# carries only the guest NAME (RCFrame.Operator, additive since Phase 2). A remote viewer can
+# say WHO holds the mic but not WHAT they run on or HOW MUCH they have spent.
+#
+# THIS FOLLOW-UP adds two ADDITIVE, omitempty metadata fields to protocol.RCFrame -
+#   Model string  `json:"model,omitempty"`  the tuned band's public model identity
+#   Spend float64 `json:"spend,omitempty"`  the HOST's own session spend, in dollars
+# - populated from the LIVE proxy holder (client.ProxyOptionsHolder: Get().Model for the
+# model, Spent() for the spend) so a remote viewer (iOS / web / desktop) can render
+# "opencode has the mic on gpt-oss-120b · $0.19" instead of the bare name. The iOS app
+# (merged) already TOLERATES these fields (its decoder is lenient; its tests pin the
+# tolerance) - this spec makes the HOST populate them.
+#
+# ── FOUNDER RULINGS APPLIED (2026-07-07, delegated defaults) ────────────────────────────
+#   1. SPEND on frames: YES - the host's OWN money figure, to the host's OWN same-account
+#      paired devices (an RC viewer is same-account by construction).
+#   2. BAND: DROPPED for v1. There is NO Band field on RCFrame at all - the model conveys
+#      the station identity. CRITICAL INVARIANT: ProxyOptions.Freq is the private-band
+#      SECRET (hash-at-rest, rc_secrets.feature S1-S5) and must NEVER appear on ANY frame
+#      field. The scenarios below pin both: no band key ever rides the wire, and the raw
+#      Freq code never appears in any frame field.
+#   3. Display copy where enrichment renders: "<op> has the mic on <model> · $<spend>".
+#
+# ── CONTENT-BLIND INVARIANT (the RC money/privacy contract - NON-NEGOTIABLE) ────────────
+# Enrichment adds ONLY model/spend METADATA. The guest operator's prompts, terminal
+# output, tool I/O, and any assistant text MUST NEVER ride an RCFrame - the guest session is
+# NOT the DJ tee loop, and the broker relay stays content-blind (rc_content_blind.feature).
+#   * Model  - the tuned band's model id is ALREADY public (advertised via /discover /market).
+#              It is a station identity, not guest content. SAFE.
+#   * Spend  - the HOST's OWN money figure, shown to the HOST's OWN same-account paired
+#              devices. It is the same number the desk return-summary already prints
+#              locally. Metadata, not guest content.
+#
+# ── ADDITIVE / DEGRADE-CLEAN (the persistent-state lesson) ──────────────────────────────
+# Both fields are omitempty: an OLD viewer ignores unknown keys; an un-tuned / spend-0
+# state simply omits them from the wire - a viewer never sees a bogus "$0" or an empty
+# "on ". The DJ-back frame carries NONE of them (nothing runs; there is no operator) -
+# exactly as today. The frame KIND stays "status" (no new kind; the reserved operator_*
+# kinds stay behavior-free in v1, ruling 7).
+
+Feature: The guest-has-the-mic frame carries model/spend metadata - never guest content
+  A remote viewer watching a live BASE STATION handoff can see not just WHO holds the mic
+  but the public model they run on and the host's running spend, so the phone/web/
+  desktop can render "opencode has the mic on gpt-oss-120b · $0.19". The enrichment is
+  additive metadata only: no guest prompt, output, or tool I/O ever touches a frame, and
+  no frame field can ever carry the private-band frequency secret (there is no Band
+  field at all, per the v1 ruling).
+
+  Background:
+    Given a HOST agent session with an attached remote-control bridge
+    And a tuned band "gpt-oss-120b" and a detected guest "opencode"
+
+  # ── E1: the handoff-start frame is enriched, spend starts at zero ──────────────────────
+  Scenario: The handoff-start status frame carries the model and zero spend
+    When the handoff to "opencode" begins
+    Then a frame of kind "status" is emitted before the exec
+    And the frame names the operator "opencode"
+    And the frame carries the model "gpt-oss-120b"
+    And the frame carries a spend of $0.00
+    And no emitted frame's wire JSON carries a "band" key
+
+  # The spend accumulator is freshly reset at exec time (ResetSpend in onOperatorExec), so a
+  # start frame must never inherit a previous guest's total.
+  Scenario: The start frame's spend is the freshly-reset session total, not a stale one
+    Given a previous handoff left the spend accumulator at $4.20
+    When the handoff to "opencode" begins
+    Then the handoff-start frame carries a spend of $0.00
+
+  # ── E2: parked auto-frames carry the LIVE, updated spend ───────────────────────────────
+  Scenario: A parked-turn status frame reports the guest's spend so far
+    Given the guest has the mic
+    And the guest has spent $0.19 so far
+    When a viewer sends a turn "refactor the parser"
+    Then the viewers receive a status frame saying the guest has the mic
+    And that status frame carries a spend of $0.19
+    And that status frame carries the model "gpt-oss-120b"
+
+  Scenario: A backfill answered mid-handoff carries the live enriched status frame
+    Given the guest has the mic
+    And the guest has spent $1.05 so far
+    When a new viewer attaches and requests backfill
+    Then the viewer receives the transcript snapshot
+    And the viewer receives a status frame carrying a spend of $1.05
+
+  # ── E3: the DJ-back frame carries NO enrichment (nothing runs) ─────────────────────────
+  Scenario: The DJ-is-back status frame carries no operator, model, or spend
+    Given the guest has the mic
+    When the guest returns and the bridge unparks
+    Then a frame of kind "status" is emitted announcing the DJ is back
+    And that frame carries no operator, model, or spend
+    And its wire JSON omits the "operator", "model", and "spend" keys entirely
+
+  # ── E4: omitempty - additive, degrades cleanly for old viewers / un-tuned state ────────
+  Scenario: Empty enrichment fields are omitted from the wire, not sent as zero values
+    When an operator status frame is built with no model and zero spend
+    Then its wire JSON omits the "model" key
+    And its wire JSON omits the "spend" key
+    But its wire JSON still carries the "operator" and "kind" keys
+
+  Scenario: An open-market handoff with no private band still enriches model and spend
+    Given the tuned channel is the open market with no private band
+    When the handoff to "opencode" begins
+    Then the handoff-start frame carries the model "gpt-oss-120b"
+    And the handoff-start frame carries a spend of $0.00
+    And no emitted frame's wire JSON carries a "band" key
+
+  # ── E5: CONTENT-BLIND - the hard invariant ─────────────────────────────────────────────
+  Scenario: No enriched frame ever carries the guest's terminal output or prompts
+    When the handoff to "opencode" begins and the guest works for a while
+    Then every frame emitted during the handoff is a status frame
+    And no frame carries any guest terminal output, prompt, tool call, or assistant text
+    And each status frame carries only operator, model, and spend metadata
+
+  Scenario: The private-band frequency SECRET never appears on any frame field
+    # ProxyOptions.Freq is a hash-at-rest shared secret (rc_secrets.feature S1-S5). There
+    # is NO Band field to carry a band identity at all (v1 ruling), and the raw Freq code
+    # must never appear on any frame field - not Text, not Model, not anywhere.
+    Given the tuned band has the private frequency code "8F3K-9M2Q"
+    When the handoff to "opencode" begins
+    Then no emitted frame carries the text "8F3K-9M2Q" in any field
+    And the RCFrame wire type carries no band field at all
+
+  # ── E6: ONE shared constructor - host start-frame and bridge parked-frame never drift ──
+  Scenario: The handoff-start frame and the parked auto-frame are built the same way
+    Given the guest has the mic on "gpt-oss-120b"
+    And the guest has spent $0.50 so far
+    When the handoff-start frame and a parked-turn frame are compared
+    Then both carry the same operator and model
+    And both are kind "status" carrying the "guest has the mic" text

--- a/internal/client/rc.go
+++ b/internal/client/rc.go
@@ -276,6 +276,13 @@ type RCBridge struct {
 	parkMu       sync.Mutex
 	parkOperator string // "" = not parked; otherwise the guest at the desk
 	parkSnapshot string // the transcript snapshot backfill is answered with while parked
+	// Operator frame enrichment (rc_enrichment.feature): the public model the guest runs
+	// on and a LIVE spend reader (ProxyOptionsHolder.Spent), so the parked auto-frames
+	// report the guest's spend SO FAR at emit time, never a stale park-time snapshot.
+	// There is deliberately NO band label here (founder ruling 2): the private-band Freq
+	// code is a secret and must never ride a frame in any field.
+	parkModel string
+	parkSpend func() float64
 }
 
 // NewRCBridge builds a host bridge over an already-enabled session (its id + one-time
@@ -295,13 +302,17 @@ func NewRCBridge(broker, sessionID, hostToken string) *RCBridge {
 // Park engages the guest-operator interlock: called by the host BEFORE the exec command
 // is issued. operator names the guest for the status auto-frames; snapshot is the
 // transcript a mid-handoff backfill is answered with (the host cannot serve it itself -
-// its event loop is suspended). Nil-safe.
-func (rb *RCBridge) Park(operator, snapshot string) {
+// its event loop is suspended). model is the tuned band's public model identity and
+// spend a LIVE session-spend reader (may be nil => $0) - both enrich the parked status
+// auto-frames (rc_enrichment.feature): spend is read at EMIT time so a parked frame
+// reports the guest's spend so far, not the $0 the handoff started with. Nil-safe.
+func (rb *RCBridge) Park(operator, snapshot, model string, spend func() float64) {
 	if rb == nil {
 		return
 	}
 	rb.parkMu.Lock()
 	rb.parkOperator, rb.parkSnapshot = operator, snapshot
+	rb.parkModel, rb.parkSpend = model, spend
 	rb.parkMu.Unlock()
 }
 
@@ -314,6 +325,7 @@ func (rb *RCBridge) Unpark() {
 	}
 	rb.parkMu.Lock()
 	rb.parkOperator, rb.parkSnapshot = "", ""
+	rb.parkModel, rb.parkSpend = "", nil
 	rb.parkMu.Unlock()
 }
 
@@ -347,21 +359,37 @@ func (rb *RCBridge) parkIntercept(in protocol.RCInbound) bool {
 		snap := rb.parkSnapshot
 		rb.parkMu.Unlock()
 		rb.Emit(protocol.RCFrame{Kind: protocol.RCKindBackfill, Viewer: in.Viewer, Text: snap})
-		rb.Emit(OperatorStatusFrame(op))
+		rb.Emit(rb.parkedStatusFrame(op))
 	case protocol.RCInTurn:
-		rb.Emit(OperatorStatusFrame(op))
+		rb.Emit(rb.parkedStatusFrame(op))
 	}
 	return true // confirm/interrupt (and anything else) drop silently while parked
 }
 
+// parkedStatusFrame builds the enriched parked auto-frame through the ONE shared
+// constructor, reading the LIVE spend at emit time (rc_enrichment.feature E2).
+func (rb *RCBridge) parkedStatusFrame(op string) protocol.RCFrame {
+	rb.parkMu.Lock()
+	model, spendFn := rb.parkModel, rb.parkSpend
+	rb.parkMu.Unlock()
+	spend := 0.0
+	if spendFn != nil {
+		spend = spendFn()
+	}
+	return OperatorStatusFrame(op, model, spend)
+}
+
 // OperatorStatusFrame is the ONE constructor for the "guest has the mic" status frame:
-// plain RCKindStatus carrying the operator name additively (RCFrame.Operator) - old
-// viewers render or ignore it; the reserved operator_* kinds stay behavior-free in v1
-// (ruling 7). Exported so the TUI's handoff-start announcement and the bridge's parked
-// auto-frames can never drift apart.
-func OperatorStatusFrame(operator string) protocol.RCFrame {
+// plain RCKindStatus carrying the operator name plus the model/spend enrichment
+// additively (RCFrame.Operator/Model/Spend, all omitempty) - old viewers render or
+// ignore them; the reserved operator_* kinds stay behavior-free in v1 (ruling 7). The
+// Text stays the FIXED operator-only template: enrichment is metadata on the frame,
+// never interpolated into Text (and no band label exists at all - founder ruling 2:
+// the private-band Freq secret must never appear on any frame field). Exported so the
+// TUI's handoff-start announcement and the bridge's parked auto-frames can never drift.
+func OperatorStatusFrame(operator, model string, spend float64) protocol.RCFrame {
 	return protocol.RCFrame{
-		Kind: protocol.RCKindStatus, Operator: operator,
+		Kind: protocol.RCKindStatus, Operator: operator, Model: model, Spend: spend,
 		Text: "guest has the mic: " + operator + " - the DJ answers when the handoff ends",
 	}
 }

--- a/internal/client/rc_enrichment_test.go
+++ b/internal/client/rc_enrichment_test.go
@@ -1,0 +1,143 @@
+package client
+
+// rc_enrichment_test.go - RED unit table for the deferred OPERATOR FRAME ENRICHMENT
+// follow-up (features/operator/rc_enrichment.feature). Pins the ONE shared enriched
+// constructor + the additive omitempty wire fields on protocol.RCFrame:
+//
+//	Model string  `json:"model,omitempty"`  the tuned band's public model identity
+//	Spend float64 `json:"spend,omitempty"`  the HOST's own session spend, in dollars
+//
+// Founder ruling 2 (2026-07-07): the drafted Band field is DROPPED for v1 - RCFrame has
+// NO band field at all (the model conveys the station), and the private-band frequency
+// secret (ProxyOptions.Freq) must NEVER appear on any frame field. Pinned below.
+//
+// This test is RED by design: neither the enriched OperatorStatusFrame signature nor the
+// RCFrame.{Model,Spend} fields exist yet, so the package fails to COMPILE - the honest
+// "fields absent" red for the approval gate. Stdlib testing + encoding/json, no mocks.
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// TestOperatorStatusFrameEnriched pins the enriched constructor: it sets Operator/Model/
+// Spend, keeps Kind "status" and the exact "guest has the mic" template, and NEVER
+// interpolates enrichment (or any guest content) into Text.
+func TestOperatorStatusFrameEnriched(t *testing.T) {
+	cases := []struct {
+		name     string
+		operator string
+		model    string
+		spend    float64
+	}{
+		{"full enrichment", "opencode", "gpt-oss-120b", 0.19},
+		{"start frame, zero spend", "opencode", "gpt-oss-120b", 0},
+		{"open market", "aider", "qwen3-32b-fp8", 1.05},
+		{"no model yet", "hermes", "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// RED: this 3-arg form does not exist yet (today: OperatorStatusFrame(operator)).
+			f := OperatorStatusFrame(tc.operator, tc.model, tc.spend)
+
+			if f.Kind != protocol.RCKindStatus {
+				t.Fatalf("kind = %q, want status", f.Kind)
+			}
+			if f.Operator != tc.operator {
+				t.Fatalf("Operator = %q, want %q", f.Operator, tc.operator)
+			}
+			if f.Model != tc.model {
+				t.Fatalf("Model = %q, want %q", f.Model, tc.model)
+			}
+			if f.Spend != tc.spend {
+				t.Fatalf("Spend = %v, want %v", f.Spend, tc.spend)
+			}
+			// The text is the FIXED template naming the operator only - enrichment (and any
+			// guest content) must never be interpolated into it.
+			wantText := "guest has the mic: " + tc.operator +
+				" - the DJ answers when the handoff ends"
+			if f.Text != wantText {
+				t.Fatalf("Text = %q, want the fixed operator-only template %q", f.Text, wantText)
+			}
+			if tc.model != "" && strings.Contains(f.Text, tc.model) {
+				t.Fatalf("Text leaked the model into the fixed template: %q", f.Text)
+			}
+		})
+	}
+}
+
+// TestOperatorStatusFrameOmitempty pins the ADDITIVE/degrade-clean wire contract: an empty
+// model and zero spend are OMITTED from the JSON (an old viewer / un-tuned state sees no
+// bogus keys), while operator + kind always ride.
+func TestOperatorStatusFrameOmitempty(t *testing.T) {
+	// Empty model, zero spend -> the enrichment keys must be absent.
+	bare, err := json.Marshal(OperatorStatusFrame("opencode", "", 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{`"model"`, `"spend"`, `"band"`} {
+		if strings.Contains(string(bare), k) {
+			t.Fatalf("bare frame wire JSON must omit %s: %s", k, bare)
+		}
+	}
+	for _, k := range []string{`"operator"`, `"kind"`} {
+		if !strings.Contains(string(bare), k) {
+			t.Fatalf("bare frame wire JSON must carry %s: %s", k, bare)
+		}
+	}
+
+	// Fully enriched -> model + spend present; a band key still never exists (ruling 2).
+	full, err := json.Marshal(OperatorStatusFrame("opencode", "gpt-oss-120b", 0.19))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{`"model"`, `"spend"`} {
+		if !strings.Contains(string(full), k) {
+			t.Fatalf("enriched frame wire JSON must carry %s: %s", k, full)
+		}
+	}
+	if strings.Contains(string(full), `"band"`) {
+		t.Fatalf("no frame may ever carry a band key (ruling 2): %s", full)
+	}
+}
+
+// TestRCFrameHasNoBandOrFreqField pins founder ruling 2 structurally: protocol.RCFrame has
+// NO Band field (the model conveys the station) and no field whose name or JSON tag could
+// carry the private-band frequency secret (ProxyOptions.Freq is hash-at-rest; putting it on
+// a frame would leak a private-band secret to every paired device and the relay ring).
+func TestRCFrameHasNoBandOrFreqField(t *testing.T) {
+	rt := reflect.TypeOf(protocol.RCFrame{})
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		name := strings.ToLower(f.Name)
+		tag := strings.ToLower(f.Tag.Get("json"))
+		if strings.Contains(name, "band") || strings.Contains(tag, "band") {
+			t.Fatalf("RCFrame carries a band field (%s / json:%q) - dropped for v1 by founder ruling 2", f.Name, tag)
+		}
+		if strings.Contains(name, "freq") || strings.Contains(tag, "freq") {
+			t.Fatalf("RCFrame carries a frequency field (%s / json:%q) - the Freq secret must never ride a frame", f.Name, tag)
+		}
+	}
+}
+
+// TestDJBackFrameCarriesNoEnrichment pins that the DJ-back status frame (the corrective
+// frame the desk emits on return) carries NO operator/model/spend - nothing runs, so
+// the enrichment keys are all omitted, exactly as today.
+func TestDJBackFrameCarriesNoEnrichment(t *testing.T) {
+	// The DJ-back frame is constructed inline in the TUI (rcEmitDJBack): a plain status
+	// frame with only Text. Pin the wire contract of that shape here.
+	djBack := protocol.RCFrame{Kind: protocol.RCKindStatus, Text: "the DJ is back at the desk"}
+	raw, err := json.Marshal(djBack)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{`"operator"`, `"band"`, `"model"`, `"spend"`} {
+		if strings.Contains(string(raw), k) {
+			t.Fatalf("DJ-back frame must omit %s: %s", k, raw)
+		}
+	}
+}

--- a/internal/client/rc_park_test.go
+++ b/internal/client/rc_park_test.go
@@ -24,7 +24,7 @@ func TestBridgeParkStateMachine(t *testing.T) {
 	if op, parked := rb.Parked(); parked || op != "" {
 		t.Fatalf("a fresh bridge must be unparked, got (%q, %v)", op, parked)
 	}
-	rb.Park("opencode", "transcript snapshot")
+	rb.Park("opencode", "transcript snapshot", "gpt-oss-120b", nil)
 	if op, parked := rb.Parked(); !parked || op != "opencode" {
 		t.Fatalf("Parked = (%q, %v), want (opencode, true)", op, parked)
 	}
@@ -34,13 +34,13 @@ func TestBridgeParkStateMachine(t *testing.T) {
 	}
 	// Nil-safety: the exec return callback may race a dead/never-enabled bridge.
 	var nilRB *RCBridge
-	nilRB.Park("x", "y")
+	nilRB.Park("x", "y", "", nil)
 	nilRB.Unpark()
 	if op, parked := nilRB.Parked(); parked || op != "" {
 		t.Fatalf("nil bridge Parked = (%q, %v), want unparked", op, parked)
 	}
 	// Unpark on a STOPPED bridge is a no-op, not a panic (rc_interlock.feature).
-	rb.Park("opencode", "snap")
+	rb.Park("opencode", "snap", "", nil)
 	rb.Stop()
 	rb.Unpark()
 }
@@ -82,7 +82,11 @@ func TestParkIntercept(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			rb := NewRCBridge("http://127.0.0.1:1", "s1", "tok")
-			rb.Park("opencode", "the transcript so far")
+			// Enrichment (rc_enrichment.feature E2): the spend reader is LIVE - it moved
+			// from $0 after Park, and the auto-frame must carry the emit-time figure.
+			liveSpend := 0.0
+			rb.Park("opencode", "the transcript so far", "gpt-oss-120b", func() float64 { return liveSpend })
+			liveSpend = 0.19
 			if !rb.parkIntercept(tc.in) {
 				t.Fatalf("a parked bridge must consume every inbound")
 			}
@@ -99,6 +103,9 @@ func TestParkIntercept(t *testing.T) {
 				case protocol.RCKindStatus:
 					if f.Operator != "opencode" || !strings.Contains(f.Text, "guest has the mic") {
 						t.Fatalf("status frame must name the guest: %+v", f)
+					}
+					if f.Model != "gpt-oss-120b" || f.Spend != 0.19 {
+						t.Fatalf("status frame must carry the live model/spend enrichment: %+v", f)
 					}
 				case protocol.RCKindBackfill:
 					if f.Viewer != "v2" || f.Text != "the transcript so far" {

--- a/internal/protocol/rc.go
+++ b/internal/protocol/rc.go
@@ -62,6 +62,13 @@ type RCFrame struct {
 	Viewer    string `json:"viewer,omitempty"`     // backfill: the ONE addressed viewer id (others skip)
 	HostUp    *bool  `json:"host_up,omitempty"`    // status: host reachable? (pointer distinguishes unset)
 	Operator  string `json:"operator,omitempty"`   // status: the guest operator at the desk (Phase 2, additive; "" = the DJ)
+	// Operator frame enrichment (2026-07-07, additive + omitempty so old viewers and the
+	// un-tuned / spend-0 state degrade cleanly). A Band field was deliberately DROPPED for
+	// v1 (founder ruling 2): the model conveys the station, and the private-band frequency
+	// code (client ProxyOptions.Freq) is a hash-at-rest SECRET that must NEVER appear on
+	// any frame field (features/operator/rc_enrichment.feature pins this).
+	Model string  `json:"model,omitempty"` // status: the tuned band's public model identity (already public via /discover)
+	Spend float64 `json:"spend,omitempty"` // status: the HOST's own session spend in dollars (the desk summary's figure)
 }
 
 // RCInbound is what a remote surface (or the broker itself, for backfill) sends TO the host.

--- a/internal/tui/base_station_test.go
+++ b/internal/tui/base_station_test.go
@@ -483,9 +483,23 @@ func TestOnRemoteFrameKinds(t *testing.T) {
 		// and nothing when the frame carries neither (content-blind: only the guest name).
 		{"status names the operator", protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "opencode", Text: "guest has the mic: opencode - the DJ answers when the handoff ends"}, "guest has the mic: opencode", func(t *testing.T, gm model) {
 			// content-blind + tidy: the operator-aware line is the short handoff line, not
-			// the frame's full sentence (no band/model/spend rides the frame anyway).
+			// the frame's full sentence (a bare frame degrades to the pre-enrichment line).
 			if last := stripANSI(gm.rsLines[len(gm.rsLines)-1]); strings.Contains(last, "answers when the handoff ends") {
 				t.Errorf("the viewer line should be the short operator-aware line, got %q", last)
+			}
+		}},
+		// Operator frame enrichment (rc_enrichment.feature, founder ruling 3): with
+		// model/spend metadata the viewer renders "<op> has the mic on <model> · $<spend>",
+		// degrading piecewise (no model drops "on", zero spend drops "· $").
+		{"status enriched with model and spend", protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "opencode", Model: "gpt-oss-120b", Spend: 0.19, Text: "guest has the mic: opencode - the DJ answers when the handoff ends"}, "opencode has the mic on gpt-oss-120b · $0.19", nil},
+		{"status enriched model only (zero spend drops the money)", protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "opencode", Model: "gpt-oss-120b", Text: "guest has the mic: opencode - the DJ answers when the handoff ends"}, "opencode has the mic on gpt-oss-120b", func(t *testing.T, gm model) {
+			if last := stripANSI(gm.rsLines[len(gm.rsLines)-1]); strings.Contains(last, "$") {
+				t.Errorf("a zero-spend frame must not render a money figure, got %q", last)
+			}
+		}},
+		{"status enriched spend only (no model drops the on-clause)", protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "aider", Spend: 1.05, Text: "guest has the mic: aider - the DJ answers when the handoff ends"}, "aider has the mic · $1.05", func(t *testing.T, gm model) {
+			if last := stripANSI(gm.rsLines[len(gm.rsLines)-1]); strings.Contains(last, " on ") {
+				t.Errorf("a model-less frame must not render an on-clause, got %q", last)
 			}
 		}},
 		{"status DJ back has no operator", protocol.RCFrame{Kind: protocol.RCKindStatus, Text: "the DJ is back at the desk"}, "the DJ is back at the desk", nil},

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -724,8 +724,11 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 	// cmd is returned - inbound remote turns are dropped at the bridge with a status
 	// auto-frame (never queued, never replayed), backfill is answered from this snapshot.
 	if m.rcBridge != nil {
-		m.rcEmit(client.OperatorStatusFrame(h.det.Guest.Name))
-		m.rcBridge.Park(h.det.Guest.Name, m.agentTranscriptText())
+		// Enrichment from the LIVE holder (rc_enrichment.feature): the exec-time model and
+		// the freshly-reset spend ($0 - ResetSpend just ran); the bridge keeps the live
+		// Spent reader so parked auto-frames report the guest's spend so far at emit time.
+		m.rcEmit(client.OperatorStatusFrame(h.det.Guest.Name, opts.Model, m.proxyHolder.Spent()))
+		m.rcBridge.Park(h.det.Guest.Name, m.agentTranscriptText(), opts.Model, m.proxyHolder.Spent)
 	}
 	c := operator.Command(launch, h.det.Path, sess.Workdir, os.Environ())
 	return m, operatorExec(c, func(err error) tea.Msg { return operatorDoneMsg{err: err} })

--- a/internal/tui/operator_steps_enrichment_test.go
+++ b/internal/tui/operator_steps_enrichment_test.go
@@ -1,0 +1,415 @@
+package tui
+
+// operator_steps_enrichment_test.go - godog step definitions for the OPERATOR FRAME
+// ENRICHMENT follow-up (features/operator/rc_enrichment.feature): the "guest has the
+// mic" status frame carries the additive model/spend metadata, populated from the LIVE
+// ProxyOptionsHolder through the real money path (stub billing broker -> real hardened
+// proxy -> holder accumulator), relayed through a REAL client.RCBridge to the stub RC
+// broker. Founder rulings applied: spend YES; Band DROPPED (no field at all - the
+// private Freq secret must never appear on any frame field). No mocks.
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/client"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// --- Background -----------------------------------------------------------------------------
+
+// tunedBandModelAndDetectedGuest is the enrichment Background's 2-arg form: it re-tunes
+// the live holder to the named public model (the same SetBand a real re-tune performs;
+// the bridge + money servers from the host-session step stay attached) and detects the
+// guest. The model is what the enrichment must report.
+func (s *opBDD) tunedBandModelAndDetectedGuest(mdl, guest string) error {
+	s.holder.SetBand(client.ProxyOptions{Broker: s.brokerSrv.URL, User: "tester", Model: mdl})
+	return s.addDetected(guest)
+}
+
+// --- frame plumbing -------------------------------------------------------------------------
+
+// waitStatusFrame waits for a status frame satisfying ok and returns it.
+func (s *opBDD) waitStatusFrame(what string, ok func(protocol.RCFrame) bool) (protocol.RCFrame, error) {
+	var got protocol.RCFrame
+	if !waitFor(func() bool {
+		for _, f := range s.framesSnapshot() {
+			if f.Kind == protocol.RCKindStatus && ok(f) {
+				got = f
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second) {
+		return protocol.RCFrame{}, fmt.Errorf("no status frame %s (frames: %+v)", what, s.framesSnapshot())
+	}
+	return got, nil
+}
+
+// startFrame is the handoff-start status frame: the FIRST status frame on the wire (the
+// emit precedes the Park and the pump preserves order).
+func (s *opBDD) startFrame() (protocol.RCFrame, error) {
+	if _, err := s.waitStatusFrame("at all", func(protocol.RCFrame) bool { return true }); err != nil {
+		return protocol.RCFrame{}, err
+	}
+	for _, f := range s.framesSnapshot() {
+		if f.Kind == protocol.RCKindStatus {
+			return f, nil
+		}
+	}
+	return protocol.RCFrame{}, fmt.Errorf("no status frame on the wire")
+}
+
+// lastStatusFrame is the most recent status frame (the parked auto-frame just answered).
+func (s *opBDD) lastStatusFrame() (protocol.RCFrame, error) {
+	if _, err := s.waitStatusFrame("at all", func(protocol.RCFrame) bool { return true }); err != nil {
+		return protocol.RCFrame{}, err
+	}
+	frames := s.framesSnapshot()
+	for i := len(frames) - 1; i >= 0; i-- {
+		if frames[i].Kind == protocol.RCKindStatus {
+			return frames[i], nil
+		}
+	}
+	return protocol.RCFrame{}, fmt.Errorf("no status frame on the wire")
+}
+
+func spendEquals(got float64, want string) error {
+	w, err := strconv.ParseFloat(want, 64)
+	if err != nil {
+		return fmt.Errorf("bad spend literal %q: %v", want, err)
+	}
+	if math.Abs(got-w) > 1e-9 {
+		return fmt.Errorf("frame spend = %v, want $%s", got, want)
+	}
+	return nil
+}
+
+// --- E1: enriched handoff-start frame -------------------------------------------------------
+
+func (s *opBDD) frameCarriesModel(mdl string) error {
+	f, err := s.startFrame()
+	if err != nil {
+		return err
+	}
+	if f.Model != mdl {
+		return fmt.Errorf("start frame model = %q, want %q", f.Model, mdl)
+	}
+	return nil
+}
+
+func (s *opBDD) frameCarriesSpend(amount string) error {
+	f, err := s.startFrame()
+	if err != nil {
+		return err
+	}
+	return spendEquals(f.Spend, amount)
+}
+
+func (s *opBDD) noFrameWireJSONCarriesKey(key string) error {
+	for _, f := range s.framesSnapshot() {
+		raw, err := json.Marshal(f)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(raw), `"`+key+`"`) {
+			return fmt.Errorf("a frame's wire JSON carries a %q key: %s", key, raw)
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) previousHandoffLeftSpend(amount string) error {
+	// Accumulate REAL spend on the holder through the money path (a prior session's
+	// figure the fresh handoff must never inherit - ResetSpend runs at exec).
+	return s.proxyCallsCosts([]string{amount})
+}
+
+func (s *opBDD) startFrameCarriesSpend(amount string) error { return s.frameCarriesSpend(amount) }
+
+func (s *opBDD) startFrameCarriesModel(mdl string) error { return s.frameCarriesModel(mdl) }
+
+// --- E2: live spend on parked auto-frames ----------------------------------------------------
+
+func (s *opBDD) guestHasSpentSoFar(amount string) error {
+	// Drive real guest-shaped calls through the real proxy while the mic is handed off;
+	// the holder accumulator (the enrichment's source) moves to the billed figure.
+	return s.proxyCallsCosts([]string{amount})
+}
+
+func (s *opBDD) thatStatusFrameCarriesSpend(amount string) error {
+	f, err := s.lastStatusFrame()
+	if err != nil {
+		return err
+	}
+	return spendEquals(f.Spend, amount)
+}
+
+func (s *opBDD) thatStatusFrameCarriesModel(mdl string) error {
+	f, err := s.lastStatusFrame()
+	if err != nil {
+		return err
+	}
+	if f.Model != mdl {
+		return fmt.Errorf("parked status frame model = %q, want %q", f.Model, mdl)
+	}
+	return nil
+}
+
+func (s *opBDD) viewerReceivesStatusFrameWithSpend(amount string) error {
+	w, err := strconv.ParseFloat(amount, 64)
+	if err != nil {
+		return err
+	}
+	_, err = s.waitStatusFrame(fmt.Sprintf("carrying spend $%s", amount), func(f protocol.RCFrame) bool {
+		return math.Abs(f.Spend-w) <= 1e-9
+	})
+	return err
+}
+
+// --- E3: the DJ-back frame carries no enrichment ---------------------------------------------
+
+func (s *opBDD) djBackFrame() (protocol.RCFrame, error) {
+	return s.waitStatusFrame("announcing the DJ is back", func(f protocol.RCFrame) bool {
+		return strings.Contains(f.Text, "DJ is back")
+	})
+}
+
+func (s *opBDD) djBackFrameCarriesNoEnrichment() error {
+	f, err := s.djBackFrame()
+	if err != nil {
+		return err
+	}
+	if f.Operator != "" || f.Model != "" || f.Spend != 0 {
+		return fmt.Errorf("the DJ-back frame carries enrichment: %+v", f)
+	}
+	return nil
+}
+
+func (s *opBDD) djBackWireJSONOmitsKeys(k1, k2, k3 string) error {
+	f, err := s.djBackFrame()
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(f)
+	if err != nil {
+		return err
+	}
+	for _, k := range []string{k1, k2, k3} {
+		if strings.Contains(string(raw), `"`+k+`"`) {
+			return fmt.Errorf("the DJ-back wire JSON carries %q: %s", k, raw)
+		}
+	}
+	return nil
+}
+
+// --- E4: omitempty / degrade-clean -----------------------------------------------------------
+
+func (s *opBDD) statusFrameBuiltBare() error {
+	raw, err := json.Marshal(client.OperatorStatusFrame("opencode", "", 0))
+	if err != nil {
+		return err
+	}
+	s.builtFrameJSON = raw
+	return nil
+}
+
+func (s *opBDD) builtWireJSONOmitsKey(key string) error {
+	if strings.Contains(string(s.builtFrameJSON), `"`+key+`"`) {
+		return fmt.Errorf("the bare frame's wire JSON carries %q: %s", key, s.builtFrameJSON)
+	}
+	return nil
+}
+
+func (s *opBDD) builtWireJSONCarriesKeys(k1, k2 string) error {
+	for _, k := range []string{k1, k2} {
+		if !strings.Contains(string(s.builtFrameJSON), `"`+k+`"`) {
+			return fmt.Errorf("the bare frame's wire JSON must carry %q: %s", k, s.builtFrameJSON)
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) openMarketNoPrivateBand() error {
+	// The open market is the no-Freq tune: same model, no private frequency code.
+	s.holder.SetBand(client.ProxyOptions{Broker: s.brokerSrv.URL, User: "tester", Model: "gpt-oss-120b"})
+	if s.holder.Get().Freq != "" {
+		return fmt.Errorf("the open-market tune must carry no Freq")
+	}
+	return s.addDetected("opencode")
+}
+
+// --- E5: content-blind + the Freq secret ------------------------------------------------------
+
+func (s *opBDD) everyFrameIsStatus() error {
+	// Wait for the handoff-start frame (async pump), then sweep the whole wire.
+	if _, err := s.waitStatusFrame("at all", func(protocol.RCFrame) bool { return true }); err != nil {
+		return err
+	}
+	for _, f := range s.framesSnapshot() {
+		if f.Kind != protocol.RCKindStatus {
+			return fmt.Errorf("a non-status frame rode the wire during the handoff: %+v", f)
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) noFrameCarriesGuestContent() error {
+	for _, f := range s.framesSnapshot() {
+		if f.Tool != "" || f.Args != "" {
+			return fmt.Errorf("a frame carries tool traffic: %+v", f)
+		}
+		if f.Text != "" && !strings.Contains(f.Text, "guest has the mic") && !strings.Contains(f.Text, "DJ is back") {
+			return fmt.Errorf("a frame carries text beyond the fixed status templates: %+v", f)
+		}
+	}
+	return nil
+}
+
+// statusFramesCarryOnlyEnrichmentMetadata executes "each status frame carries only
+// operator, model, and spend metadata": beyond the envelope (Seq/TS/Kind/Text - the
+// fixed template), every other wire field is unset.
+func (s *opBDD) statusFramesCarryOnlyEnrichmentMetadata() error {
+	for _, f := range s.framesSnapshot() {
+		if f.Kind != protocol.RCKindStatus {
+			continue
+		}
+		if f.Origin != "" || f.Tool != "" || f.Args != "" || f.ConfirmID != "" ||
+			f.Approve != nil || f.Viewer != "" || f.HostUp != nil {
+			return fmt.Errorf("a status frame carries more than operator/model/spend metadata: %+v", f)
+		}
+	}
+	return nil
+}
+
+func (s *opBDD) tunedBandHasFreqCode(code string) error {
+	// A PRIVATE band tune: the frequency code rides ProxyOptions.Freq (the hash-at-rest
+	// secret) - and must never surface on any frame field.
+	s.holder.SetBand(client.ProxyOptions{Broker: s.brokerSrv.URL, User: "tester", Model: "gpt-oss-120b", Freq: code})
+	return nil
+}
+
+func (s *opBDD) noFrameCarriesText(secret string) error {
+	// Wait for the handoff-start frame to land (the bridge pump is async), THEN sweep
+	// every frame on the wire for the secret.
+	if _, err := s.waitStatusFrame("at all", func(protocol.RCFrame) bool { return true }); err != nil {
+		return err
+	}
+	for _, f := range s.framesSnapshot() {
+		raw, err := json.Marshal(f)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(raw), secret) {
+			return fmt.Errorf("a frame leaked the private frequency code: %s", raw)
+		}
+	}
+	return nil
+}
+
+// rcFrameCarriesNoBandField pins founder ruling 2 STRUCTURALLY: the wire type has no
+// band (or freq) field for a secret to ever ride.
+func (s *opBDD) rcFrameCarriesNoBandField() error {
+	rt := reflect.TypeOf(protocol.RCFrame{})
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		name, tag := strings.ToLower(f.Name), strings.ToLower(f.Tag.Get("json"))
+		if strings.Contains(name, "band") || strings.Contains(tag, "band") ||
+			strings.Contains(name, "freq") || strings.Contains(tag, "freq") {
+			return fmt.Errorf("RCFrame carries a band/freq field: %s (json:%q)", f.Name, tag)
+		}
+	}
+	return nil
+}
+
+// --- E6: one shared constructor ---------------------------------------------------------------
+
+func (s *opBDD) guestHasTheMicOn(mdl string) error {
+	if err := s.ensureHandoff("opencode"); err != nil {
+		return err
+	}
+	if got := s.holder.Get().Model; got != mdl {
+		return fmt.Errorf("the live band model is %q, want %q", got, mdl)
+	}
+	return nil
+}
+
+func (s *opBDD) compareStartAndParkedFrames() error {
+	start, err := s.startFrame()
+	if err != nil {
+		return err
+	}
+	if err := s.viewerSendsTurn("compare probe"); err != nil {
+		return err
+	}
+	parked, err := s.lastStatusFrame()
+	if err != nil {
+		return err
+	}
+	if start.Seq == parked.Seq && start.TS == parked.TS && start.Spend == parked.Spend {
+		// same frame twice would make the comparison vacuous
+		return fmt.Errorf("the parked auto-frame never arrived (only the start frame is on the wire)")
+	}
+	s.cmpStart, s.cmpParked = &start, &parked
+	return nil
+}
+
+func (s *opBDD) bothCarrySameOperatorAndModel() error {
+	if s.cmpStart == nil || s.cmpParked == nil {
+		return fmt.Errorf("no compared frames")
+	}
+	if s.cmpStart.Operator != s.cmpParked.Operator || s.cmpStart.Model != s.cmpParked.Model {
+		return fmt.Errorf("start %+v and parked %+v drifted on operator/model", s.cmpStart, s.cmpParked)
+	}
+	return nil
+}
+
+func (s *opBDD) bothAreStatusWithText(kind, text string) error {
+	for _, f := range []*protocol.RCFrame{s.cmpStart, s.cmpParked} {
+		if f == nil {
+			return fmt.Errorf("no compared frames")
+		}
+		if f.Kind != kind || !strings.Contains(f.Text, text) {
+			return fmt.Errorf("frame %+v is not kind %q carrying %q", f, kind, text)
+		}
+	}
+	return nil
+}
+
+// initializeEnrichmentSteps registers the rc_enrichment.feature steps (called from
+// initializeOperatorScenarios so the whole operator suite shares one opBDD state).
+func initializeEnrichmentSteps(st *opBDD, sc *godog.ScenarioContext) {
+	sc.Step(`^a tuned band "([^"]*)" and a detected guest "([^"]*)"$`, st.tunedBandModelAndDetectedGuest)
+	sc.Step(`^the frame carries the model "([^"]*)"$`, st.frameCarriesModel)
+	sc.Step(`^the frame carries a spend of \$([0-9.]+)$`, st.frameCarriesSpend)
+	sc.Step(`^no emitted frame's wire JSON carries a "([^"]*)" key$`, st.noFrameWireJSONCarriesKey)
+	sc.Step(`^a previous handoff left the spend accumulator at \$([0-9.]+)$`, st.previousHandoffLeftSpend)
+	sc.Step(`^the handoff-start frame carries a spend of \$([0-9.]+)$`, st.startFrameCarriesSpend)
+	sc.Step(`^the handoff-start frame carries the model "([^"]*)"$`, st.startFrameCarriesModel)
+	sc.Step(`^the guest has spent \$([0-9.]+) so far$`, st.guestHasSpentSoFar)
+	sc.Step(`^that status frame carries a spend of \$([0-9.]+)$`, st.thatStatusFrameCarriesSpend)
+	sc.Step(`^that status frame carries the model "([^"]*)"$`, st.thatStatusFrameCarriesModel)
+	sc.Step(`^the viewer receives a status frame carrying a spend of \$([0-9.]+)$`, st.viewerReceivesStatusFrameWithSpend)
+	sc.Step(`^that frame carries no operator, model, or spend$`, st.djBackFrameCarriesNoEnrichment)
+	sc.Step(`^its wire JSON omits the "([^"]*)", "([^"]*)", and "([^"]*)" keys entirely$`, st.djBackWireJSONOmitsKeys)
+	sc.Step(`^an operator status frame is built with no model and zero spend$`, st.statusFrameBuiltBare)
+	sc.Step(`^its wire JSON omits the "([^"]*)" key$`, st.builtWireJSONOmitsKey)
+	sc.Step(`^its wire JSON still carries the "([^"]*)" and "([^"]*)" keys$`, st.builtWireJSONCarriesKeys)
+	sc.Step(`^the tuned channel is the open market with no private band$`, st.openMarketNoPrivateBand)
+	sc.Step(`^every frame emitted during the handoff is a status frame$`, st.everyFrameIsStatus)
+	sc.Step(`^no frame carries any guest terminal output, prompt, tool call, or assistant text$`, st.noFrameCarriesGuestContent)
+	sc.Step(`^each status frame carries only operator, model, and spend metadata$`, st.statusFramesCarryOnlyEnrichmentMetadata)
+	sc.Step(`^the tuned band has the private frequency code "([^"]*)"$`, st.tunedBandHasFreqCode)
+	sc.Step(`^no emitted frame carries the text "([^"]*)" in any field$`, st.noFrameCarriesText)
+	sc.Step(`^the RCFrame wire type carries no band field at all$`, st.rcFrameCarriesNoBandField)
+	sc.Step(`^the guest has the mic on "([^"]*)"$`, st.guestHasTheMicOn)
+	sc.Step(`^the handoff-start frame and a parked-turn frame are compared$`, st.compareStartAndParkedFrames)
+	sc.Step(`^both carry the same operator and model$`, st.bothCarrySameOperatorAndModel)
+	sc.Step(`^both are kind "([^"]*)" carrying the "([^"]*)" text$`, st.bothAreStatusWithText)
+}

--- a/internal/tui/operator_steps_tui_test.go
+++ b/internal/tui/operator_steps_tui_test.go
@@ -102,6 +102,11 @@ type opBDD struct {
 	bridge   *client.RCBridge
 	framesMu sync.Mutex
 	frames   []protocol.RCFrame
+
+	// operator frame enrichment (rc_enrichment.feature)
+	builtFrameJSON []byte            // wire JSON of the constructor-built frame (E4)
+	cmpStart       *protocol.RCFrame // the handoff-start frame under comparison (E6)
+	cmpParked      *protocol.RCFrame // the parked-turn auto-frame under comparison (E6)
 }
 
 // seamExec is the recording exec seam: it captures the composed child command (and
@@ -1362,7 +1367,7 @@ func (s *opBDD) viewerAttached() error {
 // viewerReceivesOperatorStatus feeds the REAL guest-has-the-mic status frame (the ONE
 // constructor the host + bridge share) through the viewer's real onRemoteFrame.
 func (s *opBDD) viewerReceivesOperatorStatus(op string) error {
-	nm, _ := s.viewer.onRemoteFrame(remoteFrameMsg{gen: s.viewer.rsGen, f: client.OperatorStatusFrame(op)})
+	nm, _ := s.viewer.onRemoteFrame(remoteFrameMsg{gen: s.viewer.rsGen, f: client.OperatorStatusFrame(op, "", 0)})
 	s.viewer = asModel(nm)
 	return nil
 }
@@ -1958,4 +1963,7 @@ func initializeOperatorScenarios(t *testing.T, st *opBDD, sc *godog.ScenarioCont
 
 	// ── Phase 3: THE DESK view · band gate · pre-launch plate ─────────────────
 	initializePhase3Steps(st, sc)
+
+	// ── operator frame enrichment (rc_enrichment.feature) ─────────────────────
+	initializeEnrichmentSteps(st, sc)
 }

--- a/internal/tui/rc.go
+++ b/internal/tui/rc.go
@@ -178,7 +178,14 @@ func (m model) onRemoteInbound(in protocol.RCInbound) (tea.Model, tea.Cmd) {
 		// "guest has the mic" status auto-frame - the bridge itself parks only at exec
 		// time, so this covers the staging window. Never queued, never replayed.
 		if m.operatorHandoff != nil {
-			m.rcEmit(client.OperatorStatusFrame(m.operatorHandoff.det.Guest.Name))
+			// Staging window: the guest hasn't run yet (spend is $0 by definition - the
+			// accumulator is only reset at exec, so the live figure here could still be a
+			// PREVIOUS session's total and must not ride the frame). Model from the live holder.
+			mdl := ""
+			if m.proxyHolder != nil {
+				mdl = m.proxyHolder.Get().Model
+			}
+			m.rcEmit(client.OperatorStatusFrame(m.operatorHandoff.det.Guest.Name, mdl, 0))
 			return m, rearm
 		}
 		// A pre-launch plate is a LOCAL decision surface: a turn arriving while it is up
@@ -628,10 +635,22 @@ func (m model) onRemoteFrame(msg remoteFrameMsg) (tea.Model, tea.Cmd) {
 	case protocol.RCKindStatus:
 		// A guest-operator handoff (or the DJ-back return) - render it so the viewer never
 		// sees the stream go dead mid-handoff. Operator-aware + content-blind: only the guest
-		// name and the fixed line ride the frame (no band/model/spend), matching the web console.
+		// name plus the model/spend metadata ride the frame, matching the web console.
+		// Enriched copy (founder ruling 3): "<op> has the mic on <model> · $<spend>",
+		// degrading piecewise - no model drops "on <model>", zero spend drops "· $",
+		// neither degrades to the pre-enrichment line (an old host's frames).
 		line := f.Text
 		if f.Operator != "" {
 			line = glyphOnAir + " guest has the mic: " + f.Operator
+			if f.Model != "" || f.Spend > 0 {
+				line = glyphOnAir + " " + f.Operator + " has the mic"
+				if f.Model != "" {
+					line += " on " + f.Model
+				}
+				if f.Spend > 0 {
+					line += " · " + fmt.Sprintf("$%.2f", f.Spend)
+				}
+			}
 		}
 		if strings.TrimSpace(line) != "" {
 			m.rsLines = append(m.rsLines, stDim.Render(line))

--- a/internal/tui/rc_test.go
+++ b/internal/tui/rc_test.go
@@ -31,8 +31,10 @@ func (b *fakeBridge) SessionID() string                  { return b.sid }
 func (b *fakeBridge) Disable() error                     { b.stop(); return nil }
 func (b *fakeBridge) Stop()                              { b.stop() }
 func (b *fakeBridge) Run()                               { b.ran = true }
-func (b *fakeBridge) Park(op, snapshot string)           { b.parked, b.snap = op, snapshot }
-func (b *fakeBridge) Unpark()                            { b.parked, b.snap = "", "" }
+func (b *fakeBridge) Park(op, snapshot, _ string, _ func() float64) {
+	b.parked, b.snap = op, snapshot
+}
+func (b *fakeBridge) Unpark() { b.parked, b.snap = "", "" }
 func (b *fakeBridge) stop() {
 	if !b.stopped {
 		b.stopped = true

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -158,8 +158,10 @@ type RemoteBridge interface {
 	// Guest-operator interlock (Phase 2): while parked, inbound turns/confirms are
 	// dropped AT THE BRIDGE with a status auto-frame and backfill is answered from the
 	// snapshot - the host's event loop is suspended under tea.ExecProcess. Unpark on a
-	// dead/stopped bridge is a no-op.
-	Park(operator, snapshot string)
+	// dead/stopped bridge is a no-op. model + spend (a LIVE session-spend reader, may be
+	// nil) enrich the parked auto-frames (rc_enrichment.feature) - metadata only, never
+	// a band label (founder ruling 2: the private Freq secret stays off every frame).
+	Park(operator, snapshot, model string, spend func() float64)
 	Unpark()
 }
 

--- a/web/src/js/private.js
+++ b/web/src/js/private.js
@@ -40,10 +40,22 @@
       case "confirm_req": return { cls: "rc-confirm", text: "? " + (f.tool || "") + " - approve? (runs on the host)", confirm: f.confirm_id || "" };
       case "confirm_done": return { cls: "rc-tool", text: "✓ " + (f.approve ? "approved" : "denied") + " from " + (f.origin || "") };
       // A guest-operator handoff (or the DJ-back return): render it dim so the viewer never sees
-      // the stream go dead mid-handoff. Operator-aware + content-blind (only the guest name + the
-      // fixed line ride the frame - no band/model/spend); a status with neither renders nothing.
+      // the stream go dead mid-handoff. Operator-aware + content-blind (only the guest name plus
+      // the model/spend metadata ride the frame); a status with neither renders nothing.
+      // Enriched copy (founder ruling 3): "<op> has the mic on <model> · $<spend>" - spend
+      // formatted like the desk summary ($0.19); no model drops "on <model>", zero spend drops
+      // "· $", and a frame with neither degrades to the pre-enrichment line (an old host).
       case "status": {
-        var st = f.operator ? "◉ guest has the mic: " + f.operator : (f.text || "");
+        var st = f.text || "";
+        if (f.operator) {
+          st = "◉ guest has the mic: " + f.operator;
+          var spend = typeof f.spend === "number" ? f.spend : 0;
+          if (f.model || spend > 0) {
+            st = "◉ " + f.operator + " has the mic";
+            if (f.model) st += " on " + f.model;
+            if (spend > 0) st += " · $" + spend.toFixed(2);
+          }
+        }
         return st.trim() ? { cls: "rc-status", text: st } : null;
       }
       case "backfill": return f.text && f.text.trim() ? { cls: "rc-backfill", text: f.text } : null;

--- a/web/test/private.test.mjs
+++ b/web/test/private.test.mjs
@@ -85,3 +85,37 @@ test("frameLine: a status frame renders the handoff transition as a dim rc-statu
   assert.equal(V.frameLine({ kind: "status" }), null);
   assert.equal(V.frameLine({ kind: "status", text: "" }), null);
 });
+
+// Operator frame enrichment (rc_enrichment.feature, founder ruling 3): a status frame carrying
+// the additive model/spend metadata renders "<op> has the mic on <model> · $<spend>" (spend
+// formatted like the desk summary), degrading piecewise - zero spend drops the "· $" part, an
+// empty model drops "on <model>", and a bare frame stays exactly today's line (old hosts).
+// No band ever rides a frame (founder ruling 2 - the Freq secret stays off the wire).
+test("frameLine: an enriched status frame renders op/model/spend and degrades cleanly", () => {
+  const V = loadCore();
+  const fixed = "guest has the mic: opencode - the DJ answers when the handoff ends";
+  assert.deepEqual(
+    V.frameLine({ kind: "status", operator: "opencode", model: "gpt-oss-120b", spend: 0.19, text: fixed }),
+    { cls: "rc-status", text: "◉ opencode has the mic on gpt-oss-120b · $0.19" },
+  );
+  // zero spend -> no money figure at all
+  assert.deepEqual(
+    V.frameLine({ kind: "status", operator: "opencode", model: "gpt-oss-120b", spend: 0, text: fixed }),
+    { cls: "rc-status", text: "◉ opencode has the mic on gpt-oss-120b" },
+  );
+  // no model -> no on-clause
+  assert.deepEqual(
+    V.frameLine({ kind: "status", operator: "aider", spend: 1.05, text: fixed }),
+    { cls: "rc-status", text: "◉ aider has the mic · $1.05" },
+  );
+  // neither -> exactly the pre-enrichment line (degrade-clean for old hosts)
+  assert.deepEqual(
+    V.frameLine({ kind: "status", operator: "opencode", text: fixed }),
+    { cls: "rc-status", text: "◉ guest has the mic: opencode" },
+  );
+  // a malformed (non-numeric) spend never renders a bogus figure
+  assert.deepEqual(
+    V.frameLine({ kind: "status", operator: "opencode", spend: "0.19", text: fixed }),
+    { cls: "rc-status", text: "◉ guest has the mic: opencode" },
+  );
+});


### PR DESCRIPTION
## Operator frame enrichment (deferred Guest Operators follow-up)

The RC "guest has the mic" status frame now carries additive metadata so a remote viewer (desktop / web / iOS) can render **"opencode has the mic on gpt-oss-120b · $0.19"** instead of the bare name. Spec-first against `features/operator/rc_enrichment.feature` (10 scenarios, godog) + `internal/client/rc_enrichment_test.go`.

**Build-and-hold: do NOT merge.** Awaiting founder review of the delegated rulings below.

### The 3 rulings applied (delegated defaults - overrule welcome)

1. **SPEND on frames: YES.** `Spend float64 json:"spend,omitempty"` is the HOST's OWN session figure (the same number the desk return-summary prints), shown only to the host's own same-account paired devices (an RC viewer is same-account by construction). Read LIVE at emit time: the handoff-start frame is the freshly-reset $0 (never a previous guest's total - pinned by the $4.20 scenario) and parked auto-frames carry the guest's spend so far via a live `Spent()` reader held by the bridge.
2. **BAND: DROPPED for v1.** The drafted spec's `Band` field was NOT added - there is no band field on `RCFrame` at all; the model conveys the station. **CRITICAL INVARIANT kept and pinned:** `ProxyOptions.Freq` is the private-band SECRET (hash-at-rest, rc_secrets S1-S5) and must NEVER appear on any frame field. Pinned three ways: a godog scenario tunes a private band with a real code and sweeps every emitted frame's JSON for it; a reflection test asserts `RCFrame` has no band/freq field or tag; the omitempty tests assert no `"band"` key ever rides the wire. (The spec files were adjusted from the draft to apply this ruling - that is applying the approved ruling, not weakening the spec.)
3. **Display copy:** `"<op> has the mic on <model> · $<spend>"` where enrichment renders (desktop RC viewer + web console), spend formatted like the desk summary (`$0.19`). Degrades piecewise: zero spend drops the `· $` part, empty model drops `on <model>`, and a bare frame renders exactly today's `guest has the mic: <op>` line (old hosts).

### Wire contract (additive, degrade-clean)

- `protocol.RCFrame` gains `Model` + `Spend`, both `omitempty` - an old viewer ignores unknown keys; an un-tuned / spend-0 state omits them (no bogus `$0`, no empty `on `).
- ONE shared constructor `client.OperatorStatusFrame(operator, model, spend)` feeds both the TUI handoff-start emit and the bridge's parked auto-frames (turn-drop + backfill-answer paths), so they can never drift. The fixed `Text` template stays name-only - enrichment is never interpolated into `Text`.
- The DJ-back frame stays bare: no operator/model/spend keys on the wire (pinned via JSON marshal).
- Content-blind invariant unchanged: only status frames ride during a handoff; no guest prompt, terminal output, or tool I/O ever touches a frame.

### iOS compatibility

Zero iOS changes needed: the roger-ios decoder is lenient and already tolerates these fields (its tests pin the tolerance). This PR makes the HOST populate them; iOS picks them up for free.

### RED -> GREEN evidence

RED (before any production code):

```
vet: internal/client/rc_enrichment_test.go:45:42: too many arguments in call to OperatorStatusFrame
	have (string, string, float64)
	want (string)
internal/client/rc_enrichment_test.go:53:9: f.Model undefined (type protocol.RCFrame has no field or method Model)
internal/client/rc_enrichment_test.go:56:9: f.Spend undefined (type protocol.RCFrame has no field or method Spend)
FAIL	github.com/rogerai-fyi/roger/internal/client [build failed]

--- FAIL: TestGuestOperatorBDD  (all 10 rc_enrichment scenarios undefined, Strict godog)
    suite.go:640: step is undefined: no emitted frame's wire JSON carries a "band" key
    suite.go:640: step is undefined: the handoff-start frame carries a spend of $0.00
    ... (10 scenarios, each failing on its first undefined enrichment step)
```

GREEN:

```
ok  	github.com/rogerai-fyi/roger/internal/tui	(godog: 253 scenarios passed, incl. the 10 rc_enrichment)
ok  	github.com/rogerai-fyi/roger/internal/client
ok  	github.com/rogerai-fyi/roger/internal/protocol
ok  	github.com/rogerai-fyi/roger/internal/operator
go test -race ./internal/tui/ ./internal/client/   ok
go vet ./...                                        clean
web: node --test  65 pass / 0 fail · node build.mjs ok (24 pages)
```

### make cover-gate

```
ok    internal/client  95.7% (>=90%)
ok    internal/protocol  95.7% (>=90%)
ok    internal/tui  92.5% (>=90%)
ok    total 92.3% (>=90%)
[cover] gate PASS   (every package >= 90%)
```

Pre-push claude-audit: **PASS (high confidence)**; one pre-existing minor noted for follow-up (the CLI `roger remote` viewer has never rendered status frames at all - out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
