### PR TITLE
AGENT [0] entry redesign: seamless start, auto-tune, beautiful operator picker, capability badges, spam-kill

### DIFF
--- a/features/operator/auto_tune.feature
+++ b/features/operator/auto_tune.feature
@@ -89,6 +89,28 @@ Feature: The AGENT [0] silent auto-tune (pickAutoBand + runAutoTune)
     Then the transcript shows "no station on air right now"
     And no channel is open
 
+  # Audit finding [MAJOR - R1 money-safety]: pick.cheapest is the min-PRICE station across
+  # ALL stations of a band, but pick.free is a BAND-level flag (ANY station FreeNow). A band
+  # mixing a FreeNow-promo station (nonzero nominal price) with a CHEAPER paid station is
+  # flagged free, yet cheapest points at the PAID station - so binding cheapest would SILENTLY
+  # spend on a paid station labelled "(free)". Auto-tune must bind the genuinely-free station
+  # (FreeNow, or zero-priced), NEVER cheapest-across-all. R1: only a $0 station is silent-bound.
+  Scenario: A band mixing a free station and a cheaper paid station tunes to the FREE one, never spends
+    Given a fresh AGENT session with a band mixing a free station and a cheaper paid station
+    When the desk auto-tunes
+    Then the bound station is genuinely free
+    And a channel is open
+    And no cost confirm is shown
+
+  # Defensive: a free-FLAGGED band that carries no genuinely-free station (a stale/mixed
+  # signal, or only paid stations) must bind NOTHING and land on the honest paid state - never
+  # a silent spend on the strength of the stale flag alone.
+  Scenario: A free-flagged band with no actually-free station binds nothing and shows the honest paid state
+    Given a fresh AGENT session with a free-flagged band whose stations are all paid
+    When the desk auto-tunes
+    Then no channel is open
+    And the transcript shows "no free band on air"
+
   Scenario: A parked prompt is sent once a free band lands
     Given a fresh AGENT session with a free band "gpt-oss-20b" on air
     When the user submits the prompt "hello"

--- a/features/operator/auto_tune.feature
+++ b/features/operator/auto_tune.feature
@@ -103,6 +103,19 @@ Feature: The AGENT [0] silent auto-tune (pickAutoBand + runAutoTune)
     And the desk auto-tunes
     Then the transcript shows "summarize the readme"
 
+  # Audit finding [MAJOR]: /clear dropped agentQueued but NOT agentPending, and never
+  # disarmed the in-flight auto-tune. A prompt parked before /clear then fired as a phantom
+  # turn (its echo already wiped by the clear) when the auto-tune landed. /clear must disarm
+  # the auto-tune and drop the parked prompt too - a fresh session is genuinely fresh.
+  Scenario: A prompt parked before /clear never fires when the auto-tune lands
+    Given a fresh AGENT session with a free band "gpt-oss-20b" on air
+    When the user submits the prompt "leftover ask"
+    And the session is cleared with "/clear"
+    And the desk auto-tunes
+    Then no chat turn is submitted
+    And the transcript no longer shows "leftover ask"
+    And the auto-tune did not arm
+
   # ── sticky + no-op ───────────────────────────────────────────────────────────
 
   Scenario: Sticky — a last-tuned band still on air is reused, not re-picked

--- a/features/operator/auto_tune.feature
+++ b/features/operator/auto_tune.feature
@@ -1,0 +1,95 @@
+# AGENT [0] DESK ENTRY REDESIGN — the silent auto-tune (design R1/R6).
+#
+# When the AGENT lands with nothing tuned in, a SILENT auto-tune finds a band for the DJ.
+# pickAutoBand is PURE + deterministic and runAutoTune folds the outcome into the model:
+#
+#   R1 (NEVER auto-spend): only a FREE band is ever silently connected ($0, no confirm). A
+#     PAID band is offered ONLY when logged in, and even then the model lands on the honest
+#     "no free band on air - [1] picks a paid band" state instead of spending. A logged-out
+#     user with no free band lands on an honest empty state, never a named paid band.
+#   R6 (agent-ready first): a coding handoff must not dead-end, so agent-ready bands (window
+#     unknown or >=16k) sort before KNOWN-small ones; within a partition FREE precedes paid,
+#     free sorts by signal desc (the iOS order), paid by cheapest out-price.
+#
+# There is NO retry loop: a single empty scan lands on the honest empty state (the founder's
+# "spams no station on air" regression). Grounding: pickAutoBand / runAutoTune (tui.go).
+
+Feature: The AGENT [0] silent auto-tune (pickAutoBand + runAutoTune)
+  The desk finds a FREE band for the DJ with no spend and no confirm, prefers windows a
+  coding agent can use, and is honest - never a paid auto-spend, never a retry storm.
+
+  # ── pickAutoBand ordering (the pure function) ────────────────────────────────
+
+  Scenario: Free by signal — the strongest free band wins
+    Given the market has a free band "free-hi" at signal 90
+    And the market has a free band "free-lo" at signal 40
+    Then pickAutoBand logged in picks "free-hi"
+
+  Scenario: Logged out is free-only — a paid-only market picks nothing
+    Given the market has a paid band "paid" out 0.30
+    Then pickAutoBand logged out picks nothing
+
+  Scenario: Logged in falls back to the cheapest paid band
+    Given the market has a paid band "cheap" out 0.20
+    And the market has a paid band "dear" out 0.90
+    Then pickAutoBand logged in picks "cheap"
+
+  Scenario: Agent-ready first — a 16k+ free band beats a stronger known-small free band
+    Given the market has a free band "small-strong" at signal 99 window 8192
+    And the market has a free band "big-weak" at signal 30 window 32768
+    Then pickAutoBand logged in picks "big-weak"
+
+  Scenario: An unknown window is treated as agent-ready (never dead-ended)
+    Given the market has a free band "unknown" at signal 50 window 0
+    And the market has a free band "small" at signal 80 window 8192
+    Then pickAutoBand logged in picks "unknown"
+
+  Scenario: Free beats paid regardless of signal
+    Given the market has a free band "free-weak" at signal 10
+    And the market has a paid band "paid-any" out 0.10
+    Then pickAutoBand logged in picks "free-weak"
+
+  Scenario: An empty market picks nothing
+    Given the market is empty
+    Then pickAutoBand logged in picks nothing
+
+  # ── runAutoTune outcomes (the model folds the decision) ──────────────────────
+
+  Scenario: A free band is connected silently, at $0, no confirm
+    Given a fresh AGENT session with a free band "gpt-oss-20b" on air
+    When the desk auto-tunes
+    Then the agent runs on "gpt-oss-20b"
+    And a channel is open
+    And no cost confirm is shown
+
+  Scenario: Logged in with paid-only lands on the honest paid state, never a spend
+    Given a fresh AGENT session logged in with only a paid band on air
+    When the desk auto-tunes
+    Then the transcript shows "no free band on air"
+    And no channel is open
+
+  Scenario: Logged out with paid-only lands on an honest empty state, never a paid band
+    Given a fresh AGENT session logged out with only a paid band on air
+    When the desk auto-tunes
+    Then the transcript shows "no free band on air"
+    And the transcript points at logging in
+    And no channel is open
+
+  Scenario: An empty market lands on the honest empty state (no retry loop)
+    Given a fresh AGENT session with an empty market
+    When the desk auto-tunes
+    Then the transcript shows "no station on air right now"
+    And no channel is open
+
+  Scenario: A parked prompt is sent once a free band lands
+    Given a fresh AGENT session with a free band "gpt-oss-20b" on air
+    When the user submits the prompt "hello"
+    And the desk auto-tunes
+    Then the agent runs on "gpt-oss-20b"
+
+  # ── sticky + no-op ───────────────────────────────────────────────────────────
+
+  Scenario: Sticky — a last-tuned band still on air is reused, not re-picked
+    Given an AGENT session whose last band "llama-3.3-70b-instruct" is still on air
+    Then the agent runs on "llama-3.3-70b-instruct"
+    And the auto-tune did not arm

--- a/features/operator/auto_tune.feature
+++ b/features/operator/auto_tune.feature
@@ -49,6 +49,14 @@ Feature: The AGENT [0] silent auto-tune (pickAutoBand + runAutoTune)
     And the market has a paid band "paid-any" out 0.10
     Then pickAutoBand logged in picks "free-weak"
 
+  # A CONNECTABLE ($0 free) band must win even when it is known-small and the only
+  # agent-ready band is PAID (never silently connectable, R1) - else auto-tune would
+  # report "no free band on air" and drop into a dead ask box while a free band is up.
+  Scenario: A known-small FREE band still beats an agent-ready PAID band
+    Given the market has a free band "free-small" at signal 50 window 8192
+    And the market has a paid band "paid-big" out 0.20
+    Then pickAutoBand logged in picks "free-small"
+
   Scenario: An empty market picks nothing
     Given the market is empty
     Then pickAutoBand logged in picks nothing
@@ -86,6 +94,14 @@ Feature: The AGENT [0] silent auto-tune (pickAutoBand + runAutoTune)
     When the user submits the prompt "hello"
     And the desk auto-tunes
     Then the agent runs on "gpt-oss-20b"
+
+  # The prompt was echoed + parked WHILE the "finding a band" beat was still up; clearing
+  # the beat must not eat the echo (the review's echo-eating regression).
+  Scenario: A prompt typed before the auto-tune resolves survives in the transcript
+    Given a fresh AGENT session with a free band "gpt-oss-20b" on air
+    When the user submits the prompt "summarize the readme"
+    And the desk auto-tunes
+    Then the transcript shows "summarize the readme"
 
   # ── sticky + no-op ───────────────────────────────────────────────────────────
 

--- a/features/operator/desk_entry.feature
+++ b/features/operator/desk_entry.feature
@@ -154,6 +154,19 @@ Feature: THE DESK takes focus on the AGENT [0] landing
     Then THE DESK does not have focus
     And the ask box has focus
 
+  # Audit finding: leaving AGENT (esc to BROWSE) during a COLD auto-tune left it armed with
+  # a prompt parked; the async result then landed OUTSIDE AGENT - binding a channel and
+  # firing the parked turn. The esc-exit must disarm the auto-tune and drop the parked
+  # prompt, and a stray auto-tune that resolves after the exit must be a no-op.
+  Scenario: Leaving AGENT during a cold auto-tune binds no channel and fires no turn
+    Given a fresh AGENT session with a free band "gpt-oss-20b" on air
+    When the user submits the prompt "mid-flight ask"
+    And the user presses the escape key
+    And the desk auto-tunes
+    Then no channel is open
+    And no chat turn is submitted
+    And the auto-tune did not arm
+
   # ── an ALREADY-CONNECTED auto-tune must not steal focus either ────────────────
 
   # Audit finding: the free-pick branch already guards focus (f6c5be7), but the
@@ -188,6 +201,17 @@ Feature: THE DESK takes focus on the AGENT [0] landing
     And the broker is unreachable during the cold auto-tune
     Then the transcript shows "couldn't reach the broker to find a band" exactly once
     And no chat turn is submitted
+
+  # Audit finding: ANY errMsg disarmed the auto-tune - a NON-unreachable errMsg (e.g.
+  # fetchBalance's errMsg("") landing in the cold-fetch window) killed a tune whose
+  # /discover then succeeds, and wrongly noted "couldn't reach the broker". The disarm must
+  # be scoped to broker-unreachable errors only.
+  Scenario: A non-unreachable error during the cold auto-tune does not disarm it
+    Given a fresh AGENT session with nothing tuned in
+    When the user submits the prompt "still coming"
+    And a non-unreachable error arrives during the cold auto-tune
+    Then the auto-tune is still armed
+    And the transcript no longer shows "couldn't reach the broker to find a band"
 
   # ── the landing DESK collapses once the transcript fills (Phase 3 preserved) ──
 

--- a/features/operator/desk_entry.feature
+++ b/features/operator/desk_entry.feature
@@ -1,0 +1,139 @@
+# AGENT [0] DESK ENTRY REDESIGN — the focused landing (design R3, spam-kill, auto-tune).
+#
+# Founder live-test pain: [0] AGENT dropped into a DEAD ask box and spammed "no station on
+# air" on every turn. The redesign, on a FRESH session (nothing ever tuned in - no proxy
+# holder bound):
+#
+#   * a SILENT background auto-tune (R1/R6) finds a FREE band, at $0, no confirm;
+#   * when the async desk scan lands GUESTS, THE DESK takes focus as a selectable operator
+#     picker (R3) - arrows move the cursor, Enter on the DJ hands focus to the ask box,
+#     Enter on a guest opens the pre-launch plate; ANY printable rune falls through to the
+#     ask box and de-focuses the desk (the DJ-still-types-through path);
+#   * the honest "no station / no free band / no model" states render AT MOST ONCE per
+#     state change (noteOnce), never a per-turn pile-up.
+#
+# A GENUINELY FRESH session has no proxy holder; a session that has tuned in (a live
+# holder) keeps the ask box focused and the static desk preview (desk_view.feature) - those
+# bytes are unchanged. Grounding: enterAgent / onAgentKey / onOperatorDetected
+# (internal/tui/agent.go, operator.go); deskFocused / deskCursor state (tui.go).
+
+Feature: THE DESK takes focus on the AGENT [0] landing
+  A newcomer who opens [0] with nothing tuned in lands on a live, selectable desk that
+  auto-tunes a free band in the background - never a dead ask box that spams "no station".
+
+  # ── focus lands on the DESK, not the ask box ─────────────────────────────────
+
+  Scenario: A fresh landing with a detected guest gives THE DESK focus
+    Given a fresh AGENT session with nothing tuned in
+    When the desk scan lands guest "opencode"
+    Then THE DESK has focus
+    And the ask box is not focused
+    And the desk cursor is on the DJ row
+
+  Scenario: A fresh landing with NO guests keeps the ask box focused (zero-guest invariant)
+    Given a fresh AGENT session with nothing tuned in
+    When the desk scan lands no guests
+    Then THE DESK does not have focus
+    And the ask box has focus
+
+  Scenario: A tuned-in session (a live holder) never steals focus to the desk
+    Given an AGENT session at the ask prompt
+    When the desk scan lands guest "opencode"
+    Then THE DESK does not have focus
+    And the ask box has focus
+
+  # ── arrows move the desk cursor ──────────────────────────────────────────────
+
+  Scenario: Down moves the desk cursor off the DJ onto the first guest
+    Given a fresh AGENT session with nothing tuned in
+    And the desk scan lands guest "opencode"
+    When the user presses "down"
+    Then the desk cursor is on "opencode"
+
+  Scenario: The desk cursor never runs past the last operator
+    Given a fresh AGENT session with nothing tuned in
+    And the desk scan lands guest "opencode"
+    When the user presses "down"
+    And the user presses "down"
+    And the user presses "down"
+    Then the desk cursor is on "opencode"
+
+  Scenario: Up from the DJ row stays on the DJ row
+    Given a fresh AGENT session with nothing tuned in
+    And the desk scan lands guest "opencode"
+    When the user presses "up"
+    Then the desk cursor is on the DJ row
+
+  # ── type-through: any printable rune falls to the ask box ────────────────────
+
+  Scenario: Typing a printable rune de-focuses the desk and lands in the ask box
+    Given a fresh AGENT session with nothing tuned in
+    And the desk scan lands guest "opencode"
+    When the user types "h"
+    Then THE DESK does not have focus
+    And the ask box has focus
+    And the ask box echoes "h"
+
+  Scenario: A vim-style j does NOT navigate — it types through
+    Given a fresh AGENT session with nothing tuned in
+    And the desk scan lands guest "opencode"
+    When the user types "j"
+    Then THE DESK does not have focus
+    And the ask box echoes "j"
+
+  # ── Enter on the DJ vs a guest ───────────────────────────────────────────────
+
+  Scenario: Enter on the DJ row hands focus to the ask box
+    Given a fresh AGENT session with nothing tuned in
+    And the desk scan lands guest "opencode"
+    When the user presses "enter"
+    Then the ask box has focus
+    And THE DESK does not have focus
+    And no child process is launched
+
+  Scenario: Enter on a guest row opens the pre-launch plate (auto-tuning a free band first)
+    Given a fresh AGENT session with a free band "gpt-oss-20b" on air
+    And the desk scan lands guest "opencode"
+    When the user presses "down"
+    And the user presses "enter"
+    Then the pre-launch plate is shown for "opencode"
+
+  Scenario: Enter on a guest with no free band to auto-tune is refused once
+    Given a fresh AGENT session with only a paid band on air
+    And the desk scan lands guest "opencode"
+    When the user presses "down"
+    And the user presses "enter"
+    Then no pre-launch plate is shown
+    And the transcript notes "no channel to patch into"
+
+  # ── the spam regression: the honest state renders at most once ───────────────
+
+  Scenario: The honest empty state renders exactly once (noteOnce)
+    Given a fresh AGENT session with an empty market
+    When the desk auto-tunes
+    And the desk auto-tunes
+    Then the transcript shows "no station on air right now" exactly once
+
+  Scenario: A doomed turn parks instead of spamming "no station on air"
+    Given a fresh AGENT session with an empty market
+    When the user submits the prompt "hello"
+    And the desk auto-tunes
+    Then the transcript shows "no station on air" at most once
+    And no chat turn is submitted
+
+  # ── auto-tune never overrides a deliberate tune ──────────────────────────────
+
+  Scenario: A deliberately-tuned band is never overridden by auto-tune
+    Given a fresh AGENT session with a free band "gpt-oss-20b" on air
+    And a channel is opened on "llama-3.3-70b-instruct" before the scan lands
+    When the desk auto-tunes
+    Then the agent runs on "llama-3.3-70b-instruct"
+    And no honest "no band" note appears
+
+  # ── the landing DESK collapses once the transcript fills (Phase 3 preserved) ──
+
+  Scenario: The focused desk collapses once the transcript has lines
+    Given a fresh AGENT session with nothing tuned in
+    And the desk scan lands guest "opencode"
+    And the transcript already has lines
+    Then the AGENT landing renders no desk roster

--- a/features/operator/desk_entry.feature
+++ b/features/operator/desk_entry.feature
@@ -108,7 +108,9 @@ Feature: THE DESK takes focus on the AGENT [0] landing
 
   # ── the spam regression: the honest state renders at most once ───────────────
 
-  Scenario: The honest empty state renders exactly once (noteOnce)
+  # A repeated auto-tune trigger does NOT re-spam the honest state (the single-shot guard
+  # + noteOnce). The tail-compare dedup itself is pinned by TestNoteOnceDedup.
+  Scenario: A repeated auto-tune trigger renders the honest empty state exactly once
     Given a fresh AGENT session with an empty market
     When the desk auto-tunes
     And the desk auto-tunes
@@ -120,6 +122,15 @@ Feature: THE DESK takes focus on the AGENT [0] landing
     And the desk auto-tunes
     Then the transcript shows "no station on air" at most once
     And no chat turn is submitted
+
+  # ── the background auto-tune must not steal focus from an active picker ───────
+
+  Scenario: A guest scan then a free-band auto-tune keeps the DESK focused (no focus-steal)
+    Given a fresh AGENT session with a free band "gpt-oss-20b" on air
+    And the desk scan lands guest "opencode"
+    When the desk auto-tunes
+    Then THE DESK has focus
+    And the agent runs on "gpt-oss-20b"
 
   # ── auto-tune never overrides a deliberate tune ──────────────────────────────
 

--- a/features/operator/desk_entry.feature
+++ b/features/operator/desk_entry.feature
@@ -141,6 +141,54 @@ Feature: THE DESK takes focus on the AGENT [0] landing
     Then the agent runs on "llama-3.3-70b-instruct"
     And no honest "no band" note appears
 
+  # ── esc-exit clears the desk focus (no dual-focus owner on re-entry) ─────────
+
+  # Audit finding: deskFocused was never cleared on the esc-exit path, so re-entering
+  # AGENT yielded a DUAL-focus state (the ask box focused AND the desk focused). Leaving
+  # AGENT must reset it so a re-entry has exactly ONE focus owner.
+  Scenario: Re-entering AGENT after an esc-exit has exactly one focus owner
+    Given a fresh AGENT session with nothing tuned in
+    And the desk scan lands guest "opencode"
+    When the user presses the escape key
+    And the user re-enters AGENT
+    Then THE DESK does not have focus
+    And the ask box has focus
+
+  # ── an ALREADY-CONNECTED auto-tune must not steal focus either ────────────────
+
+  # Audit finding: the free-pick branch already guards focus (f6c5be7), but the
+  # already-connected branch yanked focus to the ask box unconditionally. With the desk
+  # focused and a user mid-pick, an already-connected auto-tune must NOT steal focus.
+  Scenario: An already-connected auto-tune keeps the focused desk (no focus-steal)
+    Given a fresh AGENT session with a free band "gpt-oss-20b" on air
+    And the desk scan lands guest "opencode"
+    And a channel is opened on "llama-3.3-70b-instruct"
+    When the desk auto-tunes
+    Then THE DESK has focus
+    And the agent runs on "llama-3.3-70b-instruct"
+
+  # ── a cold auto-tune that can't reach the broker fails cleanly ────────────────
+
+  # Audit finding: broker-unreachable during the COLD auto-tune (the /discover fetch that
+  # feeds the landing) left autoTuning armed and the "finding a free band" beat up until a
+  # later rescan. The failure must disarm, splice the beat, and note the honest unreachable
+  # state ONCE (noteOnce), dropping any parked prompt silently.
+  Scenario: Broker-unreachable during the cold auto-tune clears the beat and notes once
+    Given a fresh AGENT session with nothing tuned in
+    When the broker is unreachable during the cold auto-tune
+    Then the transcript no longer shows "finding a free band"
+    And the transcript shows "couldn't reach the broker to find a band" exactly once
+    And the auto-tune did not arm
+
+  # A parked prompt typed before the unreachable failure is dropped silently (no band to
+  # send it to) and never leaks a chat turn.
+  Scenario: A prompt parked before a broker-unreachable cold auto-tune is dropped silently
+    Given a fresh AGENT session with nothing tuned in
+    When the user submits the prompt "hello"
+    And the broker is unreachable during the cold auto-tune
+    Then the transcript shows "couldn't reach the broker to find a band" exactly once
+    And no chat turn is submitted
+
   # ── the landing DESK collapses once the transcript fills (Phase 3 preserved) ──
 
   Scenario: The focused desk collapses once the transcript has lines

--- a/features/tui/band_badges.feature
+++ b/features/tui/band_badges.feature
@@ -1,0 +1,94 @@
+# AGENT [0] DESK ENTRY REDESIGN — the band-table flag badges (design R4/R5).
+#
+# The band table's flags cell (internal/tui/tui.go: bandBadge / plainBandBadge) gains two
+# capability marks alongside the existing ✓ verified / ◆ confidential / FREE / above-limit:
+#
+#   ⌁   agent-ready  — the model's window fits a coding agent (>=16k, operatorCtxFloor).
+#   ⌁~  agent-ready, INFERRED from the window (R5: today it is ALWAYS inferred; a later
+#       broker tool-call probe can flip the ~ off). No probe ships yet, so ~ is on.
+#   ◪   vision       — the station DECLARED the "vision" capability (never inferred).
+#
+# HONESTY (R4/R5): a band claims a capability ONLY from real signal. Agent-ready is read
+# from the representative window (bandCtx); vision is read from offer.Capabilities, which
+# is DECODE-ONLY on this side. An ABSENT capabilities set claims NOTHING — no "text-only"
+# badge is ever fabricated. A KNOWN-small window (0 < ctx < 16k) is not agent-ready.
+#
+# The marks register in internal/glyphs with ASCII folds (⌁ -> %, so ⌁~ -> %~; ◪ -> [v])
+# so a legacy Windows console / ROGERAI_ASCII stays legible, and a dim legend line under
+# the table explains the two non-self-describing glyphs. NO_COLOR strips the SGR only.
+
+Feature: Band-table capability badges (agent-ready + vision)
+  The band table tells a coding agent, at a glance, which bands fit its window and
+  which see images — from real signal only, never a fabricated claim.
+
+  # ── agent-ready, inferred from the window (R5) ───────────────────────────────
+
+  Scenario: A 16k+ window earns the inferred agent-ready mark
+    Given a band "big" whose representative window is 32768
+    Then the band badge shows the agent-ready mark
+    And the agent-ready mark carries the inferred "~" suffix
+
+  Scenario: Exactly at the 16k floor is agent-ready
+    Given a band "floor" whose representative window is 16384
+    Then the band badge shows the agent-ready mark
+
+  Scenario: A known-small window is NOT agent-ready
+    Given a band "small" whose representative window is 8192
+    Then the band badge does not show the agent-ready mark
+
+  Scenario: An unknown window claims no agent-readiness (no fabrication)
+    Given a band "unknown" whose representative window is 0
+    Then the band badge does not show the agent-ready mark
+    And the band badge does not say "text-only"
+
+  # ── vision, declared only ────────────────────────────────────────────────────
+
+  Scenario: A station that declares "vision" earns the vision mark
+    Given a band "seer" with a station declaring capabilities "vision"
+    Then the band badge shows the vision mark
+
+  Scenario: Absent capabilities claim nothing
+    Given a band "plain" with a station declaring no capabilities
+    Then the band badge does not show the vision mark
+    And the band badge does not say "text-only"
+
+  Scenario: A capability the station did not declare is never shown
+    Given a band "audio-only" with a station declaring capabilities "audio"
+    Then the band badge does not show the vision mark
+
+  # ── the two together, and alongside the existing flags ───────────────────────
+
+  Scenario: Agent-ready and vision render together
+    Given a band "multimodal-big" whose representative window is 65536
+    And that band has a station declaring capabilities "vision"
+    Then the band badge shows the agent-ready mark
+    And the band badge shows the vision mark
+
+  Scenario: The marks sit alongside FREE without displacing it
+    Given a free band "free-big" whose representative window is 32768
+    Then the band badge shows the agent-ready mark
+    And the band badge shows "FREE"
+
+  # ── the legend ───────────────────────────────────────────────────────────────
+
+  Scenario: The legend explains the two non-self-describing glyphs
+    Then the badge legend names the agent-ready mark as "agent-ready"
+    And the badge legend names the inferred suffix as "inferred"
+    And the badge legend names the vision mark as "vision"
+
+  # ── the ASCII fold + NO_COLOR ────────────────────────────────────────────────
+
+  Scenario: ASCII fold — agent-ready folds to %~, vision to [v]
+    Given ROGERAI_ASCII is set
+    And a band "ascii-big" whose representative window is 32768
+    And that band has a station declaring capabilities "vision"
+    Then the band badge contains "%~"
+    And the band badge contains "[v]"
+    And the band badge does not contain "⌁"
+
+  Scenario: NO_COLOR — the plain badge carries the marks without ANSI
+    Given a band "nocolor-big" whose representative window is 32768
+    And that band has a station declaring capabilities "vision"
+    Then the plain band badge shows the agent-ready mark
+    And the plain band badge shows the vision mark
+    And the plain band badge carries no ANSI color

--- a/internal/glyphs/glyphs.go
+++ b/internal/glyphs/glyphs.go
@@ -29,30 +29,39 @@ type Set struct {
 	SigOff  string // a flat "no signal" tower (5 cells)
 	BoxV    string // box-drawing vertical
 	BoxH    string // box-drawing horizontal
+	// AgentReady is the coding-agent-capable mark (a band whose window fits a coding
+	// agent). A trailing "~" is appended by the caller when the readiness is INFERRED
+	// from the window rather than proven by a probe (R5). Vision marks a multimodal band.
+	AgentReady string
+	Vision     string
 }
 
 var unicodeSet = Set{
-	OnAir:   "◉",
-	OffAir:  "○",
-	Verify:  "◆",
-	Lineage: "✓",
-	Beacon:  "(( • ))",
-	Signal:  []rune("▁▂▃▄▅▆▇█"),
-	SigOff:  "▁▁▁▁▁",
-	BoxV:    "│",
-	BoxH:    "─",
+	OnAir:      "◉",
+	OffAir:     "○",
+	Verify:     "◆",
+	Lineage:    "✓",
+	Beacon:     "(( • ))",
+	Signal:     []rune("▁▂▃▄▅▆▇█"),
+	SigOff:     "▁▁▁▁▁",
+	BoxV:       "│",
+	BoxH:       "─",
+	AgentReady: "⌁",
+	Vision:     "◪",
 }
 
 var asciiSet = Set{
-	OnAir:   "(o)",
-	OffAir:  "( )",
-	Verify:  "<>",
-	Lineage: "+",
-	Beacon:  "((*))",
-	Signal:  []rune(".:-=+*#@"),
-	SigOff:  ".....",
-	BoxV:    "|",
-	BoxH:    "-",
+	OnAir:      "(o)",
+	OffAir:     "( )",
+	Verify:     "<>",
+	Lineage:    "+",
+	Beacon:     "((*))",
+	Signal:     []rune(".:-=+*#@"),
+	SigOff:     ".....",
+	BoxV:       "|",
+	BoxH:       "-",
+	AgentReady: "%",
+	Vision:     "[v]",
 }
 
 // Current returns the resolved glyph set for this process (Unicode unless ASCII()).
@@ -134,6 +143,10 @@ var asciiFold = map[rune]rune{
 	'▶': '>', '◀': '<',
 	// The em-dash 'none' mark used in voice tables folds to a plain hyphen.
 	'—': '-',
+	// Band badges: the agent-ready ⌁ folds to '%' (its inferred "~" suffix passes
+	// through). The vision ◪ is a 1->3 expansion ("[v]"), so it is a string-level
+	// pre-pass in Fold (like the ellipsis), not a rune entry here.
+	'⌁': '%',
 }
 
 // Fold replaces non-ASCII art/signal runes with ASCII stand-ins WHEN ASCII() is in
@@ -145,7 +158,11 @@ func Fold(s string) string {
 	if !ASCII() {
 		return s
 	}
-	return foldASCII(strings.ReplaceAll(s, "…", "..."))
+	// 1->N expansions run as a string pre-pass (asciiFold is rune-to-rune): the
+	// ellipsis, and the vision badge ◪ -> "[v]".
+	s = strings.ReplaceAll(s, "…", "...")
+	s = strings.ReplaceAll(s, "◪", "[v]")
+	return foldASCII(s)
 }
 
 // foldASCII applies the asciiFold map to every rune of s. Exposed (unconditionally)

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -179,11 +179,28 @@ func (m model) enterAgent() (tea.Model, tea.Cmd) {
 				stDim.Render("· ")+stDim.Render("AGENT on air - running on ")+stKey.Render(m.agent.model)+stDim.Render(" · dj.md persona · session-only (no memory)"),
 				stDim.Render("· ")+stDim.Render("/model switches model · read/list/fetch run on their own · write/run ask first · files sandboxed to "+m.agent.loop.Root+" · run_shell runs there but is NOT sandboxed"),
 			)
+		} else if m.proxyHolder == nil {
+			// FRESH: nothing has ever been tuned in this session (no endpoint bound). The
+			// old behavior dropped into a dead ask box and spammed "no station on air" on
+			// every turn. Instead: a calm welcome + a SILENT background auto-tune (R1/R6)
+			// that finds a FREE band with no spend. The ask box stays focused (the DJ types
+			// through); when the async desk scan lands GUESTS, THE DESK takes focus as the
+			// selectable operator picker (R3, onOperatorDetected). The auto-tune outcome is
+			// noted once, when it resolves - never a per-turn "no station" pile-up.
+			m.agentLines = append(m.agentLines,
+				stDim.Render("· ")+stDim.Render("AGENT ready · dj.md persona · session-only (no memory)"))
+			m.autoTuneBeatLen = len(m.agentLines) // the beat below is swapped for the outcome
+			m.agentLines = append(m.agentLines,
+				stDim.Render("· ")+stDim.Render("finding a free band…"))
+			m.agentLandingLines = len(m.agentLines)
+			m.autoTuning = true
+			m.agentIn.Focus()
+			m.status = stDim.Render("AGENT ready · esc exits")
+			return m, tea.Batch(textinput.Blink, operatorScanCmd(), autoTuneCmd(m.broker, m.scanned))
 		} else {
-			// Nothing tuned in (and nothing tuned in earlier this session): be honest up
-			// front and point at the two moves. The turn itself is still allowed (it falls
-			// into the same actionable hint), but the user should not have to send one to
-			// learn there is no model.
+			// A proxy holder exists but no model resolves (a disconnected / oddly-seeded
+			// session): keep the honest up-front hint - the turn is still allowed and falls
+			// into the same actionable hint.
 			m.agentLines = append(m.agentLines,
 				stDim.Render("· ")+stDim.Render("AGENT ready · dj.md persona · session-only (no memory)"),
 				stRed.Render("✕ ")+stEmber.Render("no model tuned in"),
@@ -232,9 +249,10 @@ func (m *model) refreshAgentModel() {
 	case want != "":
 		m.agentLines = append(m.agentLines, stDim.Render("· ")+stDim.Render("the agent now runs on ")+stKey.Render(want))
 	default:
-		m.agentLines = append(m.agentLines,
-			stRed.Render("✕ ")+stEmber.Render("no model tuned in"),
-			hintTuneOrShare(m.narrow()))
+		// No model resolves - a STATUS note, not a transcript line, so re-entries / turns
+		// never stack "no model tuned in" (founder spam regression). The actual failure,
+		// if the user sends a turn anyway, still surfaces once via the deduped failureHint.
+		m.status = stRed.Render("✕ ") + stEmber.Render("no model tuned in") + stDim.Render(" · [1] tune in · [2] go on air")
 	}
 }
 
@@ -301,6 +319,55 @@ func (m model) newAgentRuntime() *agentRuntime {
 // distinct from the harness.EventKind values (which start at 0) by being far out of
 // their range, so a real harness event is never mistaken for a cost tick.
 const eventCost = harness.EventKind(1000)
+
+// bandForModel finds the discover band for a model id (false when it is not on the
+// current dial - e.g. a session-recent model whose station has aged out).
+func (m model) bandForModel(mdl string) (band, bool) {
+	for _, b := range m.bands {
+		if b.model == mdl {
+			return b, true
+		}
+	}
+	return band{}, false
+}
+
+// modelBadgeTail is the short flag tail the /model picker appends to a candidate row:
+// the same agent-ready ⌁ (inferred ⌁~) / vision ◪ / FREE marks the band table shows, so
+// picking a model is an informed choice. "" when the model is not on the current dial.
+func (m model) modelBadgeTail(mdl string) string {
+	b, ok := m.bandForModel(mdl)
+	if !ok {
+		return ""
+	}
+	var parts []string
+	if ready, inferred := bandAgentReady(b); ready {
+		t := agentReadyGlyph()
+		if inferred {
+			t += "~"
+		}
+		parts = append(parts, t)
+	}
+	if b.vision {
+		parts = append(parts, visionGlyph())
+	}
+	if b.free {
+		parts = append(parts, "FREE")
+	}
+	return strings.Join(parts, " ")
+}
+
+// deskRowCount is the number of selectable desk rows when THE DESK has focus: the
+// resident DJ (always row 0) plus one row per detected guest.
+func (m model) deskRowCount() int {
+	return 1 + len(deskGuests(m.operatorDetections))
+}
+
+// isPrintableKey reports whether a key press is a printable character (a rune or a
+// space) - the class that falls THROUGH the focused desk into the ask box (R3). Nav /
+// control keys (arrows, esc, enter, tab, ctrl+*, pgup) are not printable.
+func isPrintableKey(k tea.KeyMsg) bool {
+	return k.Type == tea.KeyRunes || k.Type == tea.KeySpace
+}
 
 // onAgentKey handles keys while in AGENT mode. A pending mutating-tool confirm owns
 // every key (y runs, n/esc denies - default DENY). Otherwise it is a text-entry mode:
@@ -370,6 +437,45 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.rcEmitConfirmDone(false, "local")
 			c.resp <- false
 			return m, m.waitAgentEvent()
+		}
+	}
+	// THE DESK has focus (the [0] landing with nothing tuned in, R3): arrows move the
+	// operator cursor, Enter on the DJ focuses the ask box, Enter on a guest opens the
+	// pre-launch plate (auto-tuning first if there is no channel). ANY printable rune
+	// falls through to the ask box and de-focuses the desk (the DJ-still-types-through
+	// path); esc / scroll / control keys fall through to the normal handling below.
+	if m.deskFocused {
+		switch k.String() {
+		case "up":
+			if m.deskCursor > 0 {
+				m.deskCursor--
+			}
+			return m, nil
+		case "down":
+			if m.deskCursor < m.deskRowCount()-1 {
+				m.deskCursor++
+			}
+			return m, nil
+		case "enter":
+			if m.deskCursor <= 0 {
+				// The resident DJ: hand focus to the ask box.
+				m.deskFocused = false
+				m.agentIn.Focus()
+				m.status = stDim.Render("the DJ has the mic · type to ask · esc exits")
+				return m, textinput.Blink
+			}
+			ds := deskGuests(m.operatorDetections)
+			if idx := m.deskCursor - 1; idx >= 0 && idx < len(ds) {
+				m.deskFocused = false
+				return m.startOperatorHandoff(ds[idx], false)
+			}
+			return m, nil
+		}
+		if isPrintableKey(k) {
+			// Type-through: the DJ is implied. De-focus the desk and let the rune land in
+			// the ask box via the text-entry Update below.
+			m.deskFocused = false
+			m.agentIn.Focus()
 		}
 	}
 	// Text-entry mode: enter submits (or QUEUES while a turn runs - see the enter case),
@@ -557,6 +663,22 @@ func (m model) submitAgentPrompt(q queuedPrompt) (model, tea.Cmd) {
 		m.agentLines = append(m.agentLines, stDim.Render("⏳ queued · ")+stDim.Render(clipLine(p))+stDim.Render(" (previous turn still wrapping up)"))
 		return m, nil
 	}
+	// No model tuned in: don't fire a doomed turn (the "no station on air" spam). Echo the
+	// ask, park it, and kick a SILENT auto-tune; runAutoTune sends it the moment a free
+	// band lands, or flushes it with a single deduped failureHint if none is available. A
+	// REMOTE-drained prompt is NEVER parked (it must resolve as a chat turn immediately -
+	// the busy-queue remote-handoff guard); only locally-typed asks park.
+	if m.agent != nil && m.agent.model == "" && !q.remote {
+		m.agentLines = append(m.agentLines, stSelText.Render("▸ ")+p)
+		m.agentPending = append(m.agentPending, q)
+		if !m.autoTuning {
+			m.autoTuning = true
+			m.autoTuneBeatLen = len(m.agentLines)
+			m.agentLines = append(m.agentLines, stDim.Render(glyphOnAir+" ")+stDim.Render("finding a free band…"))
+			return m, autoTuneCmd(m.broker, m.scanned)
+		}
+		return m, nil
+	}
 	m.agentLines = append(m.agentLines, stSelText.Render("▸ ")+p)
 	// Re-resolve to the currently open channel so a model tuned in mid-session is used; if
 	// still nothing is tuned in, the turn fails into the same actionable hint rather than
@@ -568,6 +690,25 @@ func (m model) submitAgentPrompt(q queuedPrompt) (model, tea.Cmd) {
 	now := time.Now()
 	m.agentStart = now
 	m.agentLastEvent = now // reset the stall clock; the first event re-stamps it
+	return m, tea.Batch(m.startAgentTurn(p), m.waitAgentEvent())
+}
+
+// startParkedTurn starts a turn for a prompt that was PARKED while no model was tuned
+// (auto-tune has since bound a band). It is submitAgentPrompt without the echo (the ask
+// was already echoed at park time) and without the model=="" park (a band is now bound).
+func (m model) startParkedTurn(q queuedPrompt) (model, tea.Cmd) {
+	p := q.text
+	if m.agent != nil && m.agent.running.Load() {
+		m.agentQueued = append([]queuedPrompt{q}, m.agentQueued...)
+		return m, nil
+	}
+	m.refreshAgentModel()
+	m.agentBusy = true
+	m.agentCanceling = false
+	m.agentTurnState = poseThinking
+	now := time.Now()
+	m.agentStart = now
+	m.agentLastEvent = now
 	return m, tea.Batch(m.startAgentTurn(p), m.waitAgentEvent())
 }
 
@@ -1172,10 +1313,19 @@ func (m model) agentView(w int) string {
 		b.WriteString("\n" + truncVisible("  "+stSelText.Render("pick a model")+stDim.Render(" - the agent will run on it"), w) + "\n")
 		for i, mdl := range m.agentPickerRows {
 			row := pad(mdl, 28)
+			tail := m.modelBadgeTail(mdl)
 			if i == m.agentPickerCursor {
-				b.WriteString(truncVisible("  "+stSelText.Render(" ▸ "+row), w) + "\n")
+				line := " ▸ " + row
+				if tail != "" {
+					line += "  " + tail // plain: one accent bar governs the reverse-video row
+				}
+				b.WriteString(truncVisible("  "+stSelText.Render(line), w) + "\n")
 			} else {
-				b.WriteString(truncVisible("  "+stDim.Render("   "+row), w) + "\n")
+				line := stDim.Render("   " + row)
+				if tail != "" {
+					line += "  " + stKey.Render(tail)
+				}
+				b.WriteString(truncVisible("  "+line, w) + "\n")
 			}
 		}
 		hint := "↑↓ pick · ⏎ select · esc keep current"

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -516,6 +516,13 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// state (the ask box focused AND the desk focused). enterAgent re-focuses the ask
 		// box and any fresh scan re-arms the desk from a known-clean base.
 		m.deskFocused = false
+		// Tear down any in-flight silent auto-tune and drop the prompts parked while no band
+		// was tuned: otherwise the async /discover result lands AFTER we left - binding a band
+		// and firing a phantom parked turn outside AGENT (audit finding). Mirror the clean
+		// disarm (clearFindingBeat + flush).
+		m.autoTuning = false
+		m.clearFindingBeat()
+		m.flushPendingPrompts()
 		m.mode = modeBrowse
 		m.status = stDim.Render("left AGENT - the session is kept · [0] returns")
 		return m, nil
@@ -647,6 +654,11 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 type queuedPrompt struct {
 	text   string
 	remote bool
+	// echoed marks a prompt whose "▸ …" ask line is ALREADY in the transcript (a prompt
+	// parked before the auto-tune landed, echoed at park time). drainPendingPrompts sets it
+	// on the entries it requeues so submitAgentPrompt does not echo them a SECOND time at
+	// drain (audit finding: the 2nd+ parked prompt was double-echoed).
+	echoed bool
 }
 
 // submitAgentPrompt starts ONE agent turn for prompt q: it echoes the ask, re-resolves
@@ -679,7 +691,11 @@ func (m model) submitAgentPrompt(q queuedPrompt) (model, tea.Cmd) {
 		}
 		return m, nil
 	}
-	m.agentLines = append(m.agentLines, stSelText.Render("▸ ")+p)
+	if !q.echoed {
+		// Skip the echo for a prompt already shown at park time (drainPendingPrompts requeued
+		// it); otherwise echo the ask now.
+		m.agentLines = append(m.agentLines, stSelText.Render("▸ ")+p)
+	}
 	// Re-resolve to the currently open channel so a model tuned in mid-session is used; if
 	// still nothing is tuned in, the turn fails into the same actionable hint rather than
 	// 504-ing on a phantom model.
@@ -829,7 +845,13 @@ func (m model) runAgentCommand(line string) (tea.Model, tea.Cmd) {
 		m.agentTokensOut = 0
 		m.agentTPS = 0
 		m.agentQueued = nil // drop any parked prompts too - a fresh start means fresh
-		m.rcEmitCleared()   // BASE STATION: tell viewers, so a dropped queued turn doesn't dangle
+		// Also disarm any in-flight auto-tune and drop the prompts parked while no band was
+		// tuned. Without this a prompt parked before /clear fired as a phantom turn (its echo
+		// already wiped by the clear) when the auto-tune landed (audit finding, MAJOR).
+		m.agentPending = nil
+		m.autoTuning = false
+		m.autoTuneBeatLen = 0
+		m.rcEmitCleared() // BASE STATION: tell viewers, so a dropped queued turn doesn't dangle
 		note("session cleared - the agent starts fresh (still no long-term memory)")
 		// A cleared session IS the landing again: its one note is the new entry chrome,
 		// so THE DESK roster returns (desk_view: "/clear returns the landing").

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -715,6 +715,10 @@ func (m model) submitAgentPrompt(q queuedPrompt) (model, tea.Cmd) {
 func (m model) startParkedTurn(q queuedPrompt) (model, tea.Cmd) {
 	p := q.text
 	if m.agent != nil && m.agent.running.Load() {
+		// A turn is still running: park this already-echoed prompt onto the busy queue. Mark it
+		// echoed so the drain (submitAgentPrompt) does not re-echo the "▸ …" ask line - it was
+		// echoed once at park time (audit finding: the same double-echo class fixed for rest[]).
+		q.echoed = true
 		m.agentQueued = append([]queuedPrompt{q}, m.agentQueued...)
 		return m, nil
 	}

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -512,6 +512,10 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.agentIn.Blur()
+		// Clear the DESK focus on the way out, so a re-entry never lands in a dual-focus
+		// state (the ask box focused AND the desk focused). enterAgent re-focuses the ask
+		// box and any fresh scan re-arms the desk from a known-clean base.
+		m.deskFocused = false
 		m.mode = modeBrowse
 		m.status = stDim.Render("left AGENT - the session is kept · [0] returns")
 		return m, nil

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -340,12 +340,8 @@ func (m model) modelBadgeTail(mdl string) string {
 		return ""
 	}
 	var parts []string
-	if ready, inferred := bandAgentReady(b); ready {
-		t := agentReadyGlyph()
-		if inferred {
-			t += "~"
-		}
-		parts = append(parts, t)
+	if tag := agentReadyTag(b); tag != "" {
+		parts = append(parts, tag)
 	}
 	if b.vision {
 		parts = append(parts, visionGlyph())

--- a/internal/tui/agent_lifecycle_regression_test.go
+++ b/internal/tui/agent_lifecycle_regression_test.go
@@ -82,6 +82,41 @@ func TestParkedPromptEchoOnceEach(t *testing.T) {
 	}
 }
 
+// TestParkedTurnRequeueEchoesOnce: audit finding (2026-07-07). startParkedTurn requeued
+// the FIRST parked prompt into agentQueued WITHOUT echoed=true when a turn was still running
+// at drain time; the busy-queue drain then re-echoed it (the same double-echo class fixed for
+// the rest[] entries). The requeued prompt must carry echoed=true, and drain exactly once.
+func TestParkedTurnRequeueEchoesOnce(t *testing.T) {
+	m := freshDeskAgent(t, []offer{freeOffer("gpt-oss-20b", 32768)})
+
+	// One ask parks while no band is tuned (echoed "▸ …" once at park time).
+	tm, _ := m.submitAgentPrompt(queuedPrompt{text: "only ask"})
+	m = asModel(tm)
+	if len(m.agentPending) != 1 {
+		t.Fatalf("the ask should park while no band is tuned, got %d pending", len(m.agentPending))
+	}
+
+	// A turn is running at auto-tune time, so drainPendingPrompts -> startParkedTurn requeues
+	// the parked prompt into agentQueued instead of starting it now.
+	m.agent.running.Store(true)
+	_ = m.runAutoTune()
+	if len(m.agentQueued) != 1 {
+		t.Fatalf("the parked ask should requeue while a turn runs, got %d queued", len(m.agentQueued))
+	}
+	if !m.agentQueued[0].echoed {
+		t.Fatalf("the requeued parked prompt must carry echoed=true so the busy-queue drain does not re-echo it")
+	}
+
+	// The running turn finishes and the busy queue drains: the ask must NOT be re-echoed.
+	m.agent.running.Store(false)
+	dm, _ := m.Update(agentDoneMsg{}) // discard cmd: no real relay
+	m = asModel(dm)
+	body := stripANSI(strings.Join(m.agentLines, "\n"))
+	if n := strings.Count(body, "only ask"); n != 1 {
+		t.Fatalf("\"only ask\" echoed %d times, want exactly 1 (the requeue double-echo bug):\n%s", n, body)
+	}
+}
+
 // TestRunAutoTuneBailsOutsideAgentMode: finding #2 (the mode guard). An auto-tune that
 // resolves AFTER the user has left AGENT must be a no-op: never bind a channel, never fire
 // a parked turn, never stomp the browse status.

--- a/internal/tui/agent_lifecycle_regression_test.go
+++ b/internal/tui/agent_lifecycle_regression_test.go
@@ -1,0 +1,174 @@
+package tui
+
+// agent_lifecycle_regression_test.go - permanent regressions for the auto-tune / pending
+// lifecycle leaks the AGENT [0] desk-entry audit caught (2026-07-07):
+//
+//   #2 (minor) runAutoTune had no mode guard: an auto-tune resolving AFTER the user left
+//      AGENT still bound a channel / fired a parked turn outside AGENT.
+//   #3 (minor) the 2nd+ parked prompt was echoed TWICE - once at park time, again when
+//      drainPendingPrompts requeued it and submitAgentPrompt re-echoed at drain.
+//   #5 (minor) deskCursor was never clamped when a re-scan SHRANK deskGuests while the
+//      desk was focused, so the carat/marquee vanished until the user pressed up.
+//   #6 (minor) the handoff auto-tune bound a KNOWN-small free band and only THEN refused
+//      at the §6 gate, leaving the user silently tuned to a band too small for a guest.
+//
+// Candidates for promotion into the approved .feature set at the next founder review
+// (findings #1, #2, #4 are pinned as godog scenarios in features/operator/*.feature).
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rogerai-fyi/roger/internal/operator"
+)
+
+// freshDeskAgent enters [0] AGENT off a market of `offers`, logged in, with NOTHING tuned
+// in (the genuinely-fresh landing: no proxy holder, agent.model == "").
+func freshDeskAgent(t *testing.T, offers []offer) model {
+	t.Helper()
+	var tm tea.Model = New("http://broker.local", "tester")
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	tm, _ = tm.Update(offersMsg(offers))
+	tm, _ = tm.Update(balanceMsg{loggedIn: true, balance: 10})
+	tm, _ = tm.Update(keyMsg("0"))
+	m := asModel(tm)
+	if m.mode != modeAgent {
+		t.Fatalf("[0] should enter AGENT, got mode %d", m.mode)
+	}
+	if m.agent == nil || m.agent.model != "" {
+		t.Fatalf("a fresh landing must have a runtime with no model tuned in, got %+v", m.agent)
+	}
+	return m
+}
+
+func freeOffer(model string, ctx int) offer {
+	return offer{NodeID: "n-" + model, Model: model, Online: true, FreeNow: true, Signal: 50, Ctx: ctx}
+}
+
+// TestParkedPromptEchoOnceEach: finding #3. Two prompts parked before the auto-tune must
+// each be echoed EXACTLY once - the first drains into a turn (echoed at park, not again),
+// the second requeues (echoed at park, and must NOT be re-echoed when the queue drains).
+func TestParkedPromptEchoOnceEach(t *testing.T) {
+	m := freshDeskAgent(t, []offer{freeOffer("gpt-oss-20b", 32768)})
+
+	// Two asks submitted while no band is tuned -> both park, each echoed "▸ …" once.
+	var tm tea.Model
+	tm, _ = m.submitAgentPrompt(queuedPrompt{text: "first ask"})
+	tm, _ = asModel(tm).submitAgentPrompt(queuedPrompt{text: "second ask"})
+	m = asModel(tm)
+	if len(m.agentPending) != 2 {
+		t.Fatalf("both asks should park while no band is tuned, got %d pending", len(m.agentPending))
+	}
+
+	// The auto-tune lands the free band: first drains into a turn (its goroutine cmd is
+	// discarded so running stays false), second requeues into agentQueued.
+	_ = m.runAutoTune()
+	if len(m.agentQueued) != 1 {
+		t.Fatalf("the second parked ask should requeue, got %d queued", len(m.agentQueued))
+	}
+	// The previous turn's goroutine never launched (cmd discarded); the done drains the
+	// queue and submits the second ask.
+	m.agent.running.Store(false)
+	dm, _ := m.Update(agentDoneMsg{}) // discard cmd: no real relay
+	m = asModel(dm)
+
+	body := stripANSI(strings.Join(m.agentLines, "\n"))
+	if n := strings.Count(body, "first ask"); n != 1 {
+		t.Fatalf("\"first ask\" echoed %d times, want exactly 1:\n%s", n, body)
+	}
+	if n := strings.Count(body, "second ask"); n != 1 {
+		t.Fatalf("\"second ask\" echoed %d times, want exactly 1 (the double-echo bug):\n%s", n, body)
+	}
+}
+
+// TestRunAutoTuneBailsOutsideAgentMode: finding #2 (the mode guard). An auto-tune that
+// resolves AFTER the user has left AGENT must be a no-op: never bind a channel, never fire
+// a parked turn, never stomp the browse status.
+func TestRunAutoTuneBailsOutsideAgentMode(t *testing.T) {
+	m := freshDeskAgent(t, []offer{freeOffer("gpt-oss-20b", 32768)})
+	// A prompt parks and arms the auto-tune.
+	tm, _ := m.submitAgentPrompt(queuedPrompt{text: "leftover"})
+	m = asModel(tm)
+	if !m.autoTuning {
+		t.Fatalf("submitting with no band should arm the auto-tune")
+	}
+	// The user left AGENT (esc to BROWSE) while the cold fetch was in flight.
+	m.mode = modeBrowse
+	cmd := m.runAutoTune()
+	if cmd != nil {
+		t.Fatalf("runAutoTune outside AGENT must be a no-op, got a cmd")
+	}
+	if m.connected != nil {
+		t.Fatalf("runAutoTune outside AGENT must not bind a channel")
+	}
+	if m.autoTuning {
+		t.Fatalf("runAutoTune outside AGENT must disarm the auto-tune")
+	}
+	if len(m.agentPending) != 0 {
+		t.Fatalf("runAutoTune outside AGENT must drop the parked prompts, got %d", len(m.agentPending))
+	}
+}
+
+// TestDeskCursorClampsOnGuestShrink: finding #5. A re-scan that SHRINKS the guest list
+// while THE DESK is focused must clamp deskCursor into range - not strand it past the last
+// row until the user presses up.
+func TestDeskCursorClampsOnGuestShrink(t *testing.T) {
+	oc, err := registryGuest("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hz, err := registryGuest("hermes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := freshDeskAgent(t, []offer{freeOffer("gpt-oss-20b", 32768)})
+	m.operatorDetections = []operator.Detection{
+		{Guest: oc, Path: "/fake/opencode", Version: oc.KnownGood},
+		{Guest: hz, Path: "/fake/hermes", Version: hz.KnownGood},
+	}
+	m.deskFocused = true
+	m.deskCursor = 2 // parked on the 2nd guest (DJ=0, opencode=1, hermes=2)
+
+	// A re-scan drops back to a SINGLE guest: rows are now DJ=0, opencode=1 (max index 1).
+	nm, _ := m.onOperatorDetected(operatorDetectedMsg{ds: []operator.Detection{
+		{Guest: oc, Path: "/fake/opencode", Version: oc.KnownGood},
+	}})
+	got := asModel(nm)
+	if max := got.deskRowCount() - 1; got.deskCursor > max || got.deskCursor < 0 {
+		t.Fatalf("deskCursor %d out of range after a shrink (rows=%d, want 0..%d)", got.deskCursor, got.deskRowCount(), max)
+	}
+	if got.deskCursor != 1 {
+		t.Fatalf("deskCursor should clamp to the last row (1), got %d", got.deskCursor)
+	}
+}
+
+// TestHandoffRefusesKnownSmallFreeBandWithoutBinding: finding #6. When the ONLY free band
+// is a KNOWN-small window, the handoff auto-tune must land on the honest refusal WITHOUT
+// binding - never leave the user silently tuned to a band too small for a guest.
+func TestHandoffRefusesKnownSmallFreeBandWithoutBinding(t *testing.T) {
+	oc, err := registryGuest("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The only free band on air has an 8k window - known-small (under the 16k floor).
+	m := freshDeskAgent(t, []offer{freeOffer("tiny-free", 8192)})
+	m.operatorDetections = []operator.Detection{{Guest: oc, Path: "/fake/opencode", Version: oc.KnownGood}}
+	d := operator.Detection{Guest: oc, Path: "/fake/opencode", Version: oc.KnownGood}
+
+	nm, _ := m.startOperatorHandoff(d, false)
+	got := asModel(nm)
+	if got.connected != nil {
+		t.Fatalf("the handoff must NOT bind a known-small free band, but connected to %q", got.connected.Model)
+	}
+	if got.proxyHolder != nil && got.proxyHolder.Connected() {
+		t.Fatalf("the handoff must NOT open a channel on a known-small free band")
+	}
+	if got.operatorPlate != nil {
+		t.Fatalf("no pre-launch plate should open over a refused band")
+	}
+	body := stripANSI(strings.Join(got.agentLines, "\n"))
+	if !strings.Contains(body, "16k") && !strings.Contains(strings.ToLower(body), "too small") {
+		t.Fatalf("the transcript must carry an honest 'no agent-ready band' refusal:\n%s", body)
+	}
+}

--- a/internal/tui/band_badges_bdd_test.go
+++ b/internal/tui/band_badges_bdd_test.go
@@ -1,0 +1,194 @@
+package tui
+
+// band_badges_bdd_test.go - the godog harness for features/tui/band_badges.feature
+// (the AGENT [0] desk-entry redesign, R4/R5: agent-ready ⌁ / vision ◪ badges). The steps
+// drive the REAL badge builders (bandBadge / plainBandBadge / bandBadgeLegend) over a
+// REAL band grouped from real offers by groupBands - no mocks, no seams.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/glyphs"
+)
+
+type badgeBDD struct {
+	t       *testing.T
+	free    bool
+	ctx     int
+	caps    []string
+	name    string
+	haveCtx bool
+}
+
+func (b *badgeBDD) reset() { *b = badgeBDD{t: b.t} }
+
+// build groups the declared offer(s) into the one band under test.
+func (b *badgeBDD) band() band {
+	o := offer{NodeID: "n1", Model: b.name, Online: true, PriceOut: 0.3, PriceIn: 0.2}
+	if b.haveCtx {
+		o.Ctx = b.ctx
+	}
+	if b.free {
+		o.FreeNow, o.PriceIn, o.PriceOut = true, 0, 0
+	}
+	o.Capabilities = b.caps
+	bands := groupBands([]offer{o}, &LimitStore{})
+	if len(bands) != 1 {
+		b.t.Fatalf("expected one band, got %d", len(bands))
+	}
+	return bands[0]
+}
+
+func (b *badgeBDD) badge() string      { return stripANSI(bandBadge(b.band(), &LimitStore{}, false)) }
+func (b *badgeBDD) plainBadge() string { return plainBandBadge(b.band(), &LimitStore{}, false) }
+
+// --- Given -------------------------------------------------------------------------------
+
+func (b *badgeBDD) bandWithWindow(name string, ctx int) error {
+	b.name, b.ctx, b.haveCtx = name, ctx, true
+	return nil
+}
+func (b *badgeBDD) freeBandWithWindow(name string, ctx int) error {
+	b.name, b.ctx, b.haveCtx, b.free = name, ctx, true, true
+	return nil
+}
+func (b *badgeBDD) bandDeclaringCaps(name, caps string) error {
+	b.name = name
+	if strings.TrimSpace(caps) != "" {
+		b.caps = strings.Split(caps, ",")
+	}
+	return nil
+}
+func (b *badgeBDD) bandDeclaringNoCaps(name string) error { b.name = name; return nil }
+func (b *badgeBDD) thatBandDeclaresCaps(caps string) error {
+	b.caps = strings.Split(caps, ",")
+	return nil
+}
+func (b *badgeBDD) asciiSet() error {
+	b.t.Setenv("ROGERAI_ASCII", "1")
+	return nil
+}
+
+// --- Then --------------------------------------------------------------------------------
+
+func (b *badgeBDD) showsAgentReady() error {
+	if !strings.Contains(b.badge(), glyphs.Current().AgentReady) {
+		return fmt.Errorf("badge %q lacks the agent-ready mark", b.badge())
+	}
+	return nil
+}
+func (b *badgeBDD) noAgentReady() error {
+	if strings.Contains(b.badge(), glyphs.Current().AgentReady) {
+		return fmt.Errorf("badge %q unexpectedly shows the agent-ready mark", b.badge())
+	}
+	return nil
+}
+func (b *badgeBDD) agentReadyInferred() error {
+	want := glyphs.Current().AgentReady + "~"
+	if !strings.Contains(b.badge(), want) {
+		return fmt.Errorf("badge %q lacks the inferred %q", b.badge(), want)
+	}
+	return nil
+}
+func (b *badgeBDD) showsVision() error {
+	if !strings.Contains(b.badge(), glyphs.Current().Vision) {
+		return fmt.Errorf("badge %q lacks the vision mark", b.badge())
+	}
+	return nil
+}
+func (b *badgeBDD) noVision() error {
+	if strings.Contains(b.badge(), glyphs.Current().Vision) {
+		return fmt.Errorf("badge %q unexpectedly shows the vision mark", b.badge())
+	}
+	return nil
+}
+func (b *badgeBDD) badgeSays(text string) error {
+	if !strings.Contains(b.badge(), text) {
+		return fmt.Errorf("badge %q lacks %q", b.badge(), text)
+	}
+	return nil
+}
+func (b *badgeBDD) badgeNotSays(text string) error {
+	if strings.Contains(b.badge(), text) {
+		return fmt.Errorf("badge %q unexpectedly contains %q", b.badge(), text)
+	}
+	return nil
+}
+func (b *badgeBDD) badgeContains(text string) error {
+	if !strings.Contains(b.badge(), text) {
+		return fmt.Errorf("badge %q lacks %q", b.badge(), text)
+	}
+	return nil
+}
+func (b *badgeBDD) badgeNotContains(text string) error {
+	if strings.Contains(b.badge(), text) {
+		return fmt.Errorf("badge %q unexpectedly contains %q", b.badge(), text)
+	}
+	return nil
+}
+func (b *badgeBDD) plainShowsAgentReady() error {
+	if !strings.Contains(b.plainBadge(), glyphs.Current().AgentReady) {
+		return fmt.Errorf("plain badge %q lacks the agent-ready mark", b.plainBadge())
+	}
+	return nil
+}
+func (b *badgeBDD) plainShowsVision() error {
+	if !strings.Contains(b.plainBadge(), glyphs.Current().Vision) {
+		return fmt.Errorf("plain badge %q lacks the vision mark", b.plainBadge())
+	}
+	return nil
+}
+func (b *badgeBDD) plainNoANSI() error {
+	if strings.Contains(b.plainBadge(), "\x1b[") {
+		return fmt.Errorf("plain badge carries ANSI: %q", b.plainBadge())
+	}
+	return nil
+}
+func (b *badgeBDD) legendNames(text string) error {
+	leg := stripANSI(bandBadgeLegend())
+	if !strings.Contains(leg, text) {
+		return fmt.Errorf("legend %q lacks %q", leg, text)
+	}
+	return nil
+}
+
+func TestBandBadgesBDD(t *testing.T) {
+	st := &badgeBDD{t: t}
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				st.reset()
+				return ctx, nil
+			})
+			sc.Step(`^a band "([^"]*)" whose representative window is (\d+)$`, st.bandWithWindow)
+			sc.Step(`^a free band "([^"]*)" whose representative window is (\d+)$`, st.freeBandWithWindow)
+			sc.Step(`^a band "([^"]*)" with a station declaring capabilities "([^"]*)"$`, st.bandDeclaringCaps)
+			sc.Step(`^a band "([^"]*)" with a station declaring no capabilities$`, st.bandDeclaringNoCaps)
+			sc.Step(`^that band has a station declaring capabilities "([^"]*)"$`, st.thatBandDeclaresCaps)
+			sc.Step(`^ROGERAI_ASCII is set$`, st.asciiSet)
+			sc.Step(`^the band badge shows the agent-ready mark$`, st.showsAgentReady)
+			sc.Step(`^the band badge does not show the agent-ready mark$`, st.noAgentReady)
+			sc.Step(`^the agent-ready mark carries the inferred "~" suffix$`, st.agentReadyInferred)
+			sc.Step(`^the band badge shows the vision mark$`, st.showsVision)
+			sc.Step(`^the band badge does not show the vision mark$`, st.noVision)
+			sc.Step(`^the band badge shows "([^"]*)"$`, st.badgeSays)
+			sc.Step(`^the band badge does not say "([^"]*)"$`, st.badgeNotSays)
+			sc.Step(`^the band badge contains "([^"]*)"$`, st.badgeContains)
+			sc.Step(`^the band badge does not contain "([^"]*)"$`, st.badgeNotContains)
+			sc.Step(`^the plain band badge shows the agent-ready mark$`, st.plainShowsAgentReady)
+			sc.Step(`^the plain band badge shows the vision mark$`, st.plainShowsVision)
+			sc.Step(`^the plain band badge carries no ANSI color$`, st.plainNoANSI)
+			sc.Step(`^the badge legend names the agent-ready mark as "([^"]*)"$`, st.legendNames)
+			sc.Step(`^the badge legend names the inferred suffix as "([^"]*)"$`, st.legendNames)
+			sc.Step(`^the badge legend names the vision mark as "([^"]*)"$`, st.legendNames)
+		},
+		Options: &godog.Options{Format: "pretty", Paths: []string{"../../features/tui"}, TestingT: t, Strict: true},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("band-badge scenarios failed (see godog output above)")
+	}
+}

--- a/internal/tui/desk_entry_capture_test.go
+++ b/internal/tui/desk_entry_capture_test.go
@@ -1,0 +1,126 @@
+package tui
+
+// desk_entry_capture_test.go - a golden-RENDER capture harness for the AGENT [0] desk
+// redesign. Run with ROGER_CAPTURE=<dir> to WRITE the screens (plain + ANSI) to .txt for
+// the founder to eyeball in the PR; without it, it still renders every scene and asserts
+// the load-bearing markers, so it is a real regression test (not just a screenshot tool).
+//
+//   go test ./internal/tui/ -run TestDeskEntryCaptures -count=1               (assert)
+//   ROGER_CAPTURE=/tmp/caps go test ./internal/tui/ -run TestDeskEntryCaptures (write)
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/rogerai-fyi/roger/internal/operator"
+)
+
+func capOffer(model string, ctx int, free bool, caps []string, priceOut float64, signal int) offer {
+	o := offer{NodeID: "n-" + model, Region: "us-w", Model: model, Online: true,
+		Ctx: ctx, Signal: signal, TPS: 55, Capabilities: caps, PriceIn: priceOut / 2, PriceOut: priceOut}
+	if free {
+		o.FreeNow, o.PriceIn, o.PriceOut = true, 0, 0
+	}
+	return o
+}
+
+func capWrite(t *testing.T, dir, name, ansi string) {
+	if dir == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".ansi.txt"), []byte(ansi), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".txt"), []byte(stripANSI(ansi)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeskEntryCaptures(t *testing.T) {
+	dir := os.Getenv("ROGER_CAPTURE")
+	// Force TrueColor so the marquee hues + red beats render as ANSI (off a TTY the profile
+	// is Ascii); the .txt (stripANSI) fallback stays legible for the PR body.
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+
+	mustContain := func(scene, got string, wants ...string) {
+		for _, w := range wants {
+			if !strings.Contains(stripANSI(got), w) {
+				t.Errorf("scene %q missing %q:\n%s", scene, w, stripANSI(got))
+			}
+		}
+	}
+
+	// ── Scene 1: [0] entry, nothing tuned in - the "finding a band" beat ──────────
+	fresh := func(offers []offer, loggedIn bool) model {
+		var tm tea.Model = New("http://broker.local", "tester")
+		tm, _ = tm.Update(tea.WindowSizeMsg{Width: 96, Height: 30})
+		tm, _ = tm.Update(offersMsg(offers))
+		tm, _ = tm.Update(balanceMsg{loggedIn: loggedIn, balance: 12.50})
+		tm, _ = tm.Update(keyMsg("0"))
+		return asModel(tm)
+	}
+	freeBand := capOffer("gpt-oss-20b", 32768, true, nil, 0, 72)
+	beat := fresh([]offer{freeBand}, true)
+	capWrite(t, dir, "01_entry_finding_band", beat.View())
+	mustContain("entry-beat", beat.View(), "finding a free band")
+
+	// ── Scene 2: [0] entry after the silent auto-tune lands a free band ───────────
+	landedTm, _ := beat.Update(autoTuneMsg{})
+	landed := asModel(landedTm)
+	capWrite(t, dir, "02_entry_auto_tuned", landed.View())
+	mustContain("entry-landed", landed.View(), "auto-tuned to", "gpt-oss-20b")
+
+	// ── Scene 3: the honest EMPTY state (nothing on air) ─────────────────────────
+	emptyTm, _ := fresh(nil, true).Update(autoTuneMsg{})
+	empty := asModel(emptyTm)
+	capWrite(t, dir, "03_honest_empty", empty.View())
+	mustContain("empty", empty.View(), "no station on air right now")
+
+	// ── Scene 4: badged TUNE IN rows + the legend ────────────────────────────────
+	var browseTm tea.Model = New("http://broker.local", "tester")
+	browseTm, _ = browseTm.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	browseTm, _ = browseTm.Update(offersMsg([]offer{
+		capOffer("qwen3-coder-30b", 131072, true, nil, 0, 88),        // agent-ready + FREE
+		capOffer("llava-vision-13b", 8192, false, []string{"vision"}, 0.25, 60), // vision, small
+		capOffer("big-multimodal-70b", 65536, false, []string{"vision"}, 0.9, 74), // agent-ready + vision
+		capOffer("tiny-1b", 4096, true, nil, 0, 40),                 // known-small free
+	}))
+	browseTm, _ = browseTm.Update(balanceMsg{loggedIn: true, balance: 12.50})
+	browseTm, _ = browseTm.Update(tickMsg{})
+	browse := asModel(browseTm)
+	capWrite(t, dir, "04_tunein_badges", browse.View())
+	mustContain("badges", browse.browseView(100), "agent-ready", "vision")
+
+	// ── Scene 5: the colored marquee picker, one capture per selected operator ────
+	pick := func(cursor int) model {
+		var tm tea.Model = New("http://broker.local", "tester")
+		tm, _ = tm.Update(tea.WindowSizeMsg{Width: 96, Height: 34})
+		tm, _ = tm.Update(offersMsg([]offer{freeBand}))
+		tm, _ = tm.Update(balanceMsg{loggedIn: true, balance: 12.50})
+		tm, _ = tm.Update(keyMsg("0"))
+		m := asModel(tm)
+		m.bindChannel(freeBand) // an open channel so the picker header is honest
+		for _, name := range []string{"opencode", "hermes", "aider"} {
+			g, _ := registryGuest(name)
+			m.operatorDetections = append(m.operatorDetections, operator.Detection{Guest: g, Path: "/usr/bin/" + g.Bin, Version: g.KnownGood})
+		}
+		m.operatorPicker = true
+		m.operatorRows = m.buildOperatorRows()
+		m.operatorCursor = cursor
+		return m
+	}
+	for i, name := range []string{"dj", "opencode", "hermes", "aider"} {
+		m := pick(i)
+		capWrite(t, dir, "05_picker_"+name, m.agentView(m.width))
+	}
+	mustContain("picker-dj", pick(0).agentView(96), "hand the mic", "ROGER")
+}

--- a/internal/tui/desk_entry_capture_test.go
+++ b/internal/tui/desk_entry_capture_test.go
@@ -89,10 +89,10 @@ func TestDeskEntryCaptures(t *testing.T) {
 	var browseTm tea.Model = New("http://broker.local", "tester")
 	browseTm, _ = browseTm.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
 	browseTm, _ = browseTm.Update(offersMsg([]offer{
-		capOffer("qwen3-coder-30b", 131072, true, nil, 0, 88),        // agent-ready + FREE
-		capOffer("llava-vision-13b", 8192, false, []string{"vision"}, 0.25, 60), // vision, small
+		capOffer("qwen3-coder-30b", 131072, true, nil, 0, 88),                     // agent-ready + FREE
+		capOffer("llava-vision-13b", 8192, false, []string{"vision"}, 0.25, 60),   // vision, small
 		capOffer("big-multimodal-70b", 65536, false, []string{"vision"}, 0.9, 74), // agent-ready + vision
-		capOffer("tiny-1b", 4096, true, nil, 0, 40),                 // known-small free
+		capOffer("tiny-1b", 4096, true, nil, 0, 40),                               // known-small free
 	}))
 	browseTm, _ = browseTm.Update(balanceMsg{loggedIn: true, balance: 12.50})
 	browseTm, _ = browseTm.Update(tickMsg{})

--- a/internal/tui/desk_entry_unit_test.go
+++ b/internal/tui/desk_entry_unit_test.go
@@ -1,0 +1,62 @@
+package tui
+
+// desk_entry_unit_test.go - focused unit tests for the AGENT [0] desk-entry primitives
+// that the BDD exercises only indirectly: the noteOnce tail-compare dedup (the spam
+// guard) and the clearFindingBeat single-line splice (the echo-preservation fix).
+
+import "testing"
+
+// TestNoteOnceDedup pins noteOnce's contract: an identical block already AT THE TAIL is
+// skipped; a block whose tail differs is appended. Multi-line blocks dedup as a unit.
+func TestNoteOnceDedup(t *testing.T) {
+	m := &model{}
+	a, b := "✕ no station on air right now", "  [1] tune in · [2] go on air"
+
+	m.noteOnce(a, b)
+	m.noteOnce(a, b) // identical block at the tail -> skipped
+	if got := len(m.agentLines); got != 2 {
+		t.Fatalf("noteOnce stacked an identical tail block: %d lines %q", got, m.agentLines)
+	}
+
+	m.agentLines = append(m.agentLines, "▸ a user turn") // an intervening line
+	m.noteOnce(a, b)                                     // tail differs now -> appended
+	if got := len(m.agentLines); got != 5 {
+		t.Fatalf("noteOnce should re-append after a different tail: %d lines %q", got, m.agentLines)
+	}
+
+	// A single-line note dedups against a single-line tail too.
+	m.agentLines = []string{"x"}
+	m.noteOnce("x")
+	if got := len(m.agentLines); got != 1 {
+		t.Fatalf("single-line noteOnce stacked: %d", got)
+	}
+}
+
+// TestClearFindingBeatKeepsParkedEcho pins the echo-preservation fix: clearing the beat
+// removes ONLY the beat line, never a prompt echo parked after it.
+func TestClearFindingBeatKeepsParkedEcho(t *testing.T) {
+	m := &model{
+		agentLines:      []string{"· AGENT ready", "· finding a free band…", "▸ my parked prompt"},
+		autoTuneBeatLen: 1, // the beat sits at index 1
+	}
+	m.clearFindingBeat()
+	if len(m.agentLines) != 2 || m.agentLines[1] != "▸ my parked prompt" {
+		t.Fatalf("clearFindingBeat did not preserve the parked echo: %q", m.agentLines)
+	}
+	if m.autoTuneBeatLen != 0 {
+		t.Fatalf("clearFindingBeat should reset autoTuneBeatLen, got %d", m.autoTuneBeatLen)
+	}
+}
+
+// TestClearFindingBeatGuardsNonBeat pins the content guard: if the indexed line is not
+// the beat (the transcript shifted underneath), nothing is removed.
+func TestClearFindingBeatGuardsNonBeat(t *testing.T) {
+	m := &model{
+		agentLines:      []string{"· AGENT ready", "▸ some other line"},
+		autoTuneBeatLen: 1,
+	}
+	m.clearFindingBeat()
+	if len(m.agentLines) != 2 {
+		t.Fatalf("clearFindingBeat removed a non-beat line: %q", m.agentLines)
+	}
+}

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -584,7 +584,14 @@ func (m model) startOperatorHandoff(d operator.Detection, fromPicker bool) (tea.
 			return m, nil
 		}
 		o := *pick.cheapest
-		m.bindChannel(o)
+		if _, err := m.bindChannel(o); err != nil {
+			// The local endpoint failed to bind: refuse rather than open a plate over an
+			// unbound channel that would hand the guest a wall of 502s.
+			m.agentLines = append(m.agentLines,
+				stRed.Render("✕ ")+stEmber.Render("could not open a channel: "+err.Error()),
+				stDim.Render("· ")+stDim.Render("tune in manually with ")+stKey.Render("[1]")+stDim.Render(", then hand off again with ")+stKey.Render("/operator"))
+			return m, nil
+		}
 		m.noteOnce(stDim.Render("· ") + stDim.Render("auto-tuned to ") + stKey.Render(o.Model) + stDim.Render(" (free) for the handoff"))
 	}
 	// The DJ's in-flight turn owns the completer and the terminal; a queued prompt

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -156,7 +156,35 @@ func (m model) onOperatorDetected(msg operatorDetectedMsg) (tea.Model, tea.Cmd) 
 		}
 		m.operatorCursor = operatorNearestSelectable(m.operatorRows, m.operatorCursor)
 	}
+	// AGENT [0] DESK entry (R3): on the FRESH landing (nothing tuned in, nothing typed,
+	// no modal, empty transcript beyond the entry chrome), a scan that lands GUESTS turns
+	// THE DESK into the focused, selectable operator picker - the ask box hands focus over
+	// until the user types through. Zero guests keeps the ask focused (nothing to pick).
+	if m.deskEntryEligible() && len(deskGuests(m.operatorDetections)) > 0 {
+		m.deskFocused = true
+		m.deskCursor = 0
+		m.agentIn.Blur()
+	}
 	return m, nil
+}
+
+// deskEntryEligible reports whether the AGENT is on the FRESH landing where THE DESK may
+// take focus: AGENT mode, no channel/model, the ask box empty (nothing typed), the
+// landing transcript untouched, no turn running, and no modal / plate / handoff up.
+func (m model) deskEntryEligible() bool {
+	if m.mode != modeAgent || m.deskFocused {
+		return false
+	}
+	if m.proxyHolder != nil || m.connected != nil || m.resolveAgentModel() != "" {
+		return false // a channel is (or was) up - not a fresh landing
+	}
+	if strings.TrimSpace(m.agentIn.Value()) != "" || m.agentBusy || (m.agent != nil && m.agent.running.Load()) {
+		return false
+	}
+	if len(m.agentLines) != m.agentLandingLines {
+		return false
+	}
+	return !m.operatorPicker && !m.agentPicker && m.agentPendingConfirm == nil && m.operatorPlate == nil && m.operatorHandoff == nil
 }
 
 // --- the /operator command -----------------------------------------------------------
@@ -312,6 +340,16 @@ func (m model) operatorPickerView(w int) string {
 		tail = " - the guest runs on " + mdl + ", through your open channel"
 	}
 	b.WriteString("\n" + truncVisible("  "+stSelText.Render("hand the mic")+stDim.Render(tail), w) + "\n")
+	// R2 (amends GUEST-OPERATOR-PLATES.md §6 "no brand art in the picker"): the SELECTED
+	// operator's marquee plate, in its one canonical hue - the same renderer THE DESK uses.
+	// The list rows below stay mono+red. The cursor never lands on a suggestion row.
+	if m.operatorCursor >= 0 && m.operatorCursor < len(m.operatorRows) {
+		if row := m.operatorRows[m.operatorCursor]; row.isDJ {
+			b.WriteString(operatorBrandArtBlock(djBrandArt(), w))
+		} else if !row.suggestion {
+			b.WriteString(deskMarqueeForGuest(row.det.Guest, w))
+		}
+	}
 	for i, row := range m.operatorRows {
 		switch {
 		case row.suggestion:
@@ -533,13 +571,21 @@ func (m model) startOperatorHandoff(d operator.Detection, fromPicker bool) (tea.
 		m.rcNote(note)
 		return m, nil
 	}
-	// No band tuned: a disconnected proxy REFUSES to spend (Phase 1 ruling 5), so a
-	// launch now would only hand the guest a wall of 502s - block it at the desk.
+	// No band tuned: a disconnected proxy REFUSES to spend (Phase 1 ruling 5), so a launch
+	// now would only hand the guest a wall of 502s. Rather than dead-end, try a SILENT
+	// auto-tune to a FREE band first (R1 - never a paid auto-spend); land the plate on
+	// success, a SINGLE honest refusal on failure.
 	if m.proxyHolder == nil || !m.proxyHolder.Connected() {
-		m.agentLines = append(m.agentLines,
-			stRed.Render("✕ ")+stEmber.Render("no channel to patch into - a guest runs on your open channel"),
-			stDim.Render("· ")+stDim.Render("tune in first: press ")+stKey.Render("[1]")+stDim.Render(", ⏎ on a band opens the channel · then come back with ")+stKey.Render("[0]"))
-		return m, nil
+		pick := pickAutoBand(m.bands, m.loggedInState())
+		if pick == nil || !pick.free || pick.cheapest == nil {
+			m.agentLines = append(m.agentLines,
+				stRed.Render("✕ ")+stEmber.Render("no channel to patch into - a guest runs on your open channel"),
+				stDim.Render("· ")+stDim.Render("tune in first: press ")+stKey.Render("[1]")+stDim.Render(", ⏎ on a band opens the channel · then come back with ")+stKey.Render("[0]"))
+			return m, nil
+		}
+		o := *pick.cheapest
+		m.bindChannel(o)
+		m.noteOnce(stDim.Render("· ") + stDim.Render("auto-tuned to ") + stKey.Render(o.Model) + stDim.Render(" (free) for the handoff"))
 	}
 	// The DJ's in-flight turn owns the completer and the terminal; a queued prompt
 	// would drain into a new turn against a suspended TUI - both block the handoff.
@@ -1032,16 +1078,16 @@ func (m model) deskCompactCount() string {
 	return stDim.Render(" · ") + stDim.Render(fmt.Sprintf("%d at the desk", n))
 }
 
-// deskRosterBlock is THE DESK roster (§3a): a STATIC PREVIEW of who can take the mic,
-// rendered on the LANDING state only (>=1 guest, empty transcript, no turn running, no
-// modal up, full view) - it collapses once the conversation starts, exactly like the
-// empty-band CTA. No carat, no reverse-video row: carats mean "interactive" in this
-// house, and picking happens in the /operator modal, never here. Returns the exact
-// inserted substring (clamped lines), or "".
+// deskRosterBlock is the LANDING wrapper for THE DESK (§3a): it gates on the landing
+// state (empty transcript, no turn running, no modal up, full view) and then renders the
+// roster via deskRosterView. When the AGENT lands with nothing tuned in the desk is
+// FOCUSED and selectable (the [0] redesign, R3: deskFocused); when a band is already
+// tuned it stays the STATIC PREVIEW it always was (no carat, no marquee) - the desk_view
+// bytes are unchanged. Returns the inserted substring (clamped lines), or "".
 func (m model) deskRosterBlock(w int) string {
 	ds := deskGuests(m.operatorDetections)
 	if len(ds) == 0 || m.compact {
-		return ""
+		return "" // the zero-guest byte-identical invariant: no guests, no desk chrome
 	}
 	if len(m.agentLines) != m.agentLandingLines || m.agentBusy || (m.agent != nil && m.agent.running.Load()) {
 		return "" // any line beyond the entry chrome = the conversation started
@@ -1049,6 +1095,15 @@ func (m model) deskRosterBlock(w int) string {
 	if m.operatorPicker || m.agentPicker || m.agentPendingConfirm != nil || m.operatorPlate != nil || m.operatorHandoff != nil {
 		return ""
 	}
+	return m.deskRosterView(w, m.deskCursor, m.deskFocused)
+}
+
+// deskRosterView renders THE DESK roster: the header, the SELECTED operator's marquee
+// plate (focused only, R2 - the one hue), and the operator rows. When focused the cursor
+// row carries a red carat; the row bodies stay mono+red (R2). The SAME renderer (via the
+// marquee) feeds the /operator picker, so the modal gets the marquee too.
+func (m model) deskRosterView(w, cursor int, focused bool) string {
+	ds := deskGuests(m.operatorDetections)
 	mdl := ""
 	if m.proxyHolder != nil && m.proxyHolder.Connected() {
 		mdl = m.proxyHolder.Get().Model
@@ -1059,11 +1114,15 @@ func (m model) deskRosterBlock(w int) string {
 	}
 	var b strings.Builder
 	b.WriteString("\n" + truncVisible("  "+stSelBar.Render("▌")+" "+stBrand.Render("THE DESK")+"    "+stDim.Render(sub), w) + "\n")
+	// R2: the selected operator's plate as a marquee, in its ONE canonical hue. Focused
+	// only - the static preview stays byte-identical (no marquee, no carat).
+	if focused {
+		b.WriteString(m.deskMarquee(w, cursor))
+	}
 	b.WriteString(truncVisible("    "+stDim.Render(pad("operator", 13)+pad("wire", 11)+"status"), w) + "\n")
-	// The resident DJ row is always first, with the red on-air mark (the connected band
-	// row treatment): whenever this TUI is painting, the DJ has the mic.
-	b.WriteString(truncVisible("  "+stRed.Render(glyphOnAir)+" "+stKey.Render(pad("DJ", 12))+" "+stDim.Render(pad("in the TUI", 10)+" resident · dj.md persona · read/list auto, write/run confirm"), w) + "\n")
-	for _, d := range ds {
+	// The resident DJ row is always first (index 0), with the red on-air mark.
+	b.WriteString(truncVisible(deskGutter(focused && cursor == 0)+stRed.Render(glyphOnAir)+" "+stKey.Render(pad("DJ", 12))+" "+stDim.Render(pad("in the TUI", 10)+" resident · dj.md persona · read/list auto, write/run confirm"), w) + "\n")
+	for i, d := range ds {
 		status := "guest · on PATH · patches into your open channel"
 		if d.Guest.NeedsSetup {
 			status = "guest · needs a key first - /operator " + d.Guest.Name + " shows how"
@@ -1074,10 +1133,11 @@ func (m model) deskRosterBlock(w int) string {
 			}
 			status += " · version " + v + " unproven"
 		}
-		b.WriteString(truncVisible("    "+stKey.Render(pad(d.Guest.Name, 12))+" "+stDim.Render(pad("hands off", 10)+" "+status), w) + "\n")
+		b.WriteString(truncVisible(deskGutter(focused && cursor == i+1)+"  "+stKey.Render(pad(d.Guest.Name, 12))+" "+stDim.Render(pad("hands off", 10)+" "+status), w) + "\n")
 	}
 	// At most ONE dim not-installed suggestion, at the bottom, only while the desk is
-	// sparse - a healthy desk advertises nothing (the buildOperatorRows rule).
+	// sparse - a healthy desk advertises nothing (the buildOperatorRows rule). Never
+	// selectable (the cursor never lands on it).
 	if len(ds) < 2 {
 		seen := map[string]bool{}
 		for _, d := range ds {
@@ -1091,4 +1151,59 @@ func (m model) deskRosterBlock(w int) string {
 		}
 	}
 	return b.String()
+}
+
+// deskGutter is the 2-cell row gutter: a red carat on the selected (focused) row, two
+// spaces otherwise - so the un-focused static preview keeps its exact leading spacing.
+func deskGutter(selected bool) string {
+	if selected {
+		return stSelText.Render("▸ ")
+	}
+	return "  "
+}
+
+// deskMarquee renders the SELECTED operator's brand plate (R2): the DJ house plate at
+// cursor 0, else the detected guest's shipped plate (or a plain name lockup when a guest
+// ships none). One hue per the plate; the list rows below stay mono+red.
+func (m model) deskMarquee(w, cursor int) string {
+	ds := deskGuests(m.operatorDetections)
+	if cursor <= 0 {
+		return operatorBrandArtBlock(djBrandArt(), w)
+	}
+	if idx := cursor - 1; idx >= 0 && idx < len(ds) {
+		return deskMarqueeForGuest(ds[idx].Guest, w)
+	}
+	return ""
+}
+
+// deskMarqueeForGuest renders one guest's marquee plate: its shipped BrandArt when it
+// has one, else a plain (mono) name lockup so the marquee is never blank.
+func deskMarqueeForGuest(g operator.Guest, w int) string {
+	if g.Brand != nil {
+		return operatorBrandArtBlock(*g.Brand, w)
+	}
+	return truncVisible("  "+stBrand.Render(g.Name), w) + "\n"
+}
+
+// djBrandArt is the resident DJ's house plate: a TUI-side mono+red ROGER·AI · DJ lockup
+// built from the corner-Ping operator pose (the ((•)) beacon + the R body). It lives
+// here, NOT in internal/operator/brand.go, which stays guests-only (data-free of the
+// house). One red beat on the beacon dot + the DJ tag; the wordmark in house brand ink.
+func djBrandArt() operator.BrandArt {
+	red := operator.BrandInk{Token: operator.InkRedBold}
+	brand := operator.BrandInk{Token: operator.InkBrand}
+	dim := operator.BrandInk{Token: operator.InkDim}
+	return operator.BrandArt{
+		Rows: []operator.BrandRow{
+			{Text: "((•))", Spans: []operator.BrandSpan{{From: 2, To: 3, Ink: red}}},
+			{Text: " \\(R)/   ROGER·AI · DJ", Spans: []operator.BrandSpan{
+				{From: 3, To: 4, Ink: red},    // the R body
+				{From: 9, To: 17, Ink: brand}, // ROGER·AI
+				{From: 20, To: 22, Ink: red},  // DJ
+			}},
+			{Text: " ╰───╯   resident · the house agent · dj.md", Ink: dim},
+		},
+		Width:  43,
+		Lockup: operator.BrandRow{Text: "ROGER·AI · DJ", Spans: []operator.BrandSpan{{From: 0, To: 8, Ink: brand}, {From: 11, To: 13, Ink: red}}},
+	}
 }

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -588,7 +588,16 @@ func (m model) startOperatorHandoff(d operator.Detection, fromPicker bool) (tea.
 	// success, a SINGLE honest refusal on failure.
 	if m.proxyHolder == nil || !m.proxyHolder.Connected() {
 		pick := pickAutoBand(m.bands, m.loggedInState())
-		if pick == nil || !pick.free || pick.cheapest == nil {
+		// R1 money-safety: a SILENT handoff auto-tune may only bind a genuinely-FREE station
+		// (FreeNow / zero-priced), never pick.cheapest - the min-PRICE station across ALL of
+		// the band's stations, which can be PAID even in a band flagged free. No free station
+		// (nil pick, or a free-flagged band with only paid/promo-priced stations) -> refuse
+		// rather than spend.
+		var freeSt *offer
+		if pick != nil {
+			freeSt = bestFreeStation(*pick)
+		}
+		if freeSt == nil {
 			m.agentLines = append(m.agentLines,
 				stRed.Render("✕ ")+stEmber.Render("no channel to patch into - a guest runs on your open channel"),
 				stDim.Render("· ")+stDim.Render("tune in first: press ")+stKey.Render("[1]")+stDim.Render(", ⏎ on a band opens the channel · then come back with ")+stKey.Render("[0]"))
@@ -605,7 +614,7 @@ func (m model) startOperatorHandoff(d operator.Detection, fromPicker bool) (tea.
 				stDim.Render("· ")+stDim.Render("tune in to a larger band with ")+stKey.Render("[1]")+stDim.Render(", then hand off again with ")+stKey.Render("/operator"))
 			return m, nil
 		}
-		o := *pick.cheapest
+		o := *freeSt
 		if _, err := m.bindChannel(o); err != nil {
 			// The local endpoint failed to bind: refuse rather than open a plate over an
 			// unbound channel that would hand the guest a wall of 502s.

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -149,6 +149,17 @@ func operatorScanCmd() tea.Cmd {
 // its rows in place (the r re-scan) with the cursor clamped to a selectable row.
 func (m model) onOperatorDetected(msg operatorDetectedMsg) (tea.Model, tea.Cmd) {
 	m.operatorDetections = msg.ds
+	// A re-scan can SHRINK the guest list while THE DESK is focused; clamp the cursor into
+	// the new row range so the carat/marquee never vanish off the end until the user presses
+	// up (audit finding). deskRowCount reads the freshly-set detections.
+	if m.deskFocused {
+		if max := m.deskRowCount() - 1; m.deskCursor > max {
+			m.deskCursor = max
+		}
+		if m.deskCursor < 0 {
+			m.deskCursor = 0
+		}
+	}
 	if m.operatorPicker {
 		m.operatorRows = m.buildOperatorRows()
 		if m.operatorCursor >= len(m.operatorRows) {
@@ -581,6 +592,17 @@ func (m model) startOperatorHandoff(d operator.Detection, fromPicker bool) (tea.
 			m.agentLines = append(m.agentLines,
 				stRed.Render("✕ ")+stEmber.Render("no channel to patch into - a guest runs on your open channel"),
 				stDim.Render("· ")+stDim.Render("tune in first: press ")+stKey.Render("[1]")+stDim.Render(", ⏎ on a band opens the channel · then come back with ")+stKey.Render("[0]"))
+			return m, nil
+		}
+		// Require an agent-ready pick BEFORE binding (audit finding): pickAutoBand returns
+		// the strongest CONNECTABLE free band even when it is KNOWN-small, so binding here
+		// and only THEN hitting the §6 gate below would leave the user silently tuned to a
+		// band too small for a guest. If the only free band is known-small, land on the
+		// honest 'no agent-ready band' refusal WITHOUT binding.
+		if bandKnownSmall(*pick) {
+			m.agentLines = append(m.agentLines,
+				stRed.Render("✕ ")+stEmber.Render("no agent-ready band to patch into - the only free band's window is too small for a guest (needs 16k+)"),
+				stDim.Render("· ")+stDim.Render("tune in to a larger band with ")+stKey.Render("[1]")+stDim.Render(", then hand off again with ")+stKey.Render("/operator"))
 			return m, nil
 		}
 		o := *pick.cheapest

--- a/internal/tui/operator_steps_desk_entry_test.go
+++ b/internal/tui/operator_steps_desk_entry_test.go
@@ -113,6 +113,46 @@ func (s *opBDD) channelOpenedBeforeScan(mdl string) error {
 	return nil
 }
 
+// channelOpened opens a real channel on `model`. Same as channelOpenedBeforeScan but with
+// no ordering implied in the phrasing - used to open a channel AFTER a guest scan has
+// focused the desk (the already-connected focus-steal regression).
+func (s *opBDD) channelOpened(mdl string) error { return s.channelOpenedBeforeScan(mdl) }
+
+// userReEntersAgent presses [0] again after an esc-exit. The async desk scan cmd it emits
+// is deliberately NOT drained here, so no fresh scan re-arms the desk: the focus state on
+// re-entry is exactly what the exit left behind (the dual-focus regression).
+func (s *opBDD) userReEntersAgent() error {
+	s.update(keyMsg("0"))
+	return nil
+}
+
+// userPressesRealEsc delivers a REAL Escape key (tea.KeyEsc), not the multi-rune keyMsg
+// helper "esc" - which isPrintableKey would treat as a type-through and de-focus the desk
+// as a side effect. Only a real Esc exercises the esc-EXIT path (the dual-focus fix).
+func (s *opBDD) userPressesRealEsc() error {
+	cmd := s.update(tea.KeyMsg{Type: tea.KeyEsc})
+	for _, msg := range collectCmdMsgs(cmd) {
+		if msg != nil {
+			s.update(msg)
+		}
+	}
+	return nil
+}
+
+// brokerUnreachableColdAutoTune delivers the errMsg that fetchOffers emits when the cold
+// AGENT [0] auto-tune cannot reach the broker - the real message, straight into Update.
+func (s *opBDD) brokerUnreachableColdAutoTune() error {
+	s.update(errMsg("broker unreachable: http://broker.local"))
+	return nil
+}
+
+func (s *opBDD) transcriptNoLongerShows(text string) error {
+	if strings.Contains(s.view(), text) {
+		return fmt.Errorf("transcript still shows %q:\n%s", text, s.view())
+	}
+	return nil
+}
+
 // --- focus assertions --------------------------------------------------------------------
 
 func (s *opBDD) deskHasFocus() error {
@@ -269,6 +309,11 @@ func initializeDeskEntryScenarios(st *opBDD, sc *godog.ScenarioContext) {
 	sc.Step(`^the desk scan lands no guests$`, st.deskScanLandsNoGuests)
 	sc.Step(`^the desk auto-tunes$`, st.theDeskAutoTunes)
 	sc.Step(`^a channel is opened on "([^"]*)" before the scan lands$`, st.channelOpenedBeforeScan)
+	sc.Step(`^a channel is opened on "([^"]*)"$`, st.channelOpened)
+	sc.Step(`^the user re-enters AGENT$`, st.userReEntersAgent)
+	sc.Step(`^the user presses the escape key$`, st.userPressesRealEsc)
+	sc.Step(`^the broker is unreachable during the cold auto-tune$`, st.brokerUnreachableColdAutoTune)
+	sc.Step(`^the transcript no longer shows "([^"]*)"$`, st.transcriptNoLongerShows)
 	sc.Step(`^THE DESK has focus$`, st.deskHasFocus)
 	sc.Step(`^THE DESK does not have focus$`, st.deskNoFocus)
 	sc.Step(`^the ask box has focus$`, st.askBoxHasFocus)

--- a/internal/tui/operator_steps_desk_entry_test.go
+++ b/internal/tui/operator_steps_desk_entry_test.go
@@ -1,0 +1,295 @@
+package tui
+
+// operator_steps_desk_entry_test.go - step definitions for the AGENT [0] desk-entry
+// redesign specs (features/operator/desk_entry.feature + auto_tune.feature). They drive
+// the REAL bubbletea model: a FRESH session is New(...) with NO proxy holder (nothing
+// tuned in), the desk scan is delivered as the real operatorDetectedMsg, and the silent
+// auto-tune is delivered as the real autoTuneMsg - no mocks. pickAutoBand is exercised
+// directly (it is pure). Registered from initializeOperatorScenarios (operator_bdd_test).
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/operator"
+)
+
+// --- fresh-session seeding (no proxy holder = nothing tuned in) --------------------------
+
+// freshAgent builds a fresh AGENT session: New(broker), sized, fed the given market +
+// login state, then [0] enters AGENT with NO holder (the genuinely-fresh landing).
+func (s *opBDD) freshAgent(offers []offer, loggedIn bool) {
+	var tm tea.Model = New("http://broker.local", "tester")
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	tm, _ = tm.Update(offersMsg(offers))
+	tm, _ = tm.Update(balanceMsg{loggedIn: loggedIn, balance: 10})
+	tm, _ = tm.Update(keyMsg("0"))
+	s.tm = asModel(tm)
+}
+
+func (s *opBDD) freshNothingTuned() error { s.freshAgent(nil, true); return nil }
+
+func offerFree(model string) offer {
+	return offer{NodeID: "n-" + model, Model: model, Online: true, FreeNow: true, Signal: 50, Ctx: 32768}
+}
+func offerPaid(model string, out float64) offer {
+	return offer{NodeID: "n-" + model, Model: model, Online: true, PriceIn: out / 2, PriceOut: out, Signal: 50, Ctx: 32768}
+}
+
+func (s *opBDD) freshFreeBand(mdl string) error {
+	s.freshAgent([]offer{offerFree(mdl)}, true)
+	return nil
+}
+func (s *opBDD) freshPaidOnly() error {
+	s.freshAgent([]offer{offerPaid("paid-model", 0.30)}, true)
+	return nil
+}
+func (s *opBDD) freshPaidOnlyLoggedIn() error {
+	s.freshAgent([]offer{offerPaid("paid-model", 0.30)}, true)
+	return nil
+}
+func (s *opBDD) freshPaidOnlyLoggedOut() error {
+	s.freshAgent([]offer{offerPaid("paid-model", 0.30)}, false)
+	return nil
+}
+func (s *opBDD) freshEmptyMarket() error { s.freshAgent(nil, true); return nil }
+
+// lastBandStillOnAir seeds a session that last tuned band `model`, still on air: a live
+// holder + lastConnected on that model + the market carrying it. resolveAgentModel then
+// reuses it, so entering AGENT never arms an auto-tune (the sticky-when-online path).
+func (s *opBDD) lastBandStillOnAir(mdl string) error {
+	var tm tea.Model = New("http://broker.local", "tester")
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	tm, _ = tm.Update(offersMsg([]offer{offerFree(mdl)}))
+	tm, _ = tm.Update(balanceMsg{loggedIn: true, balance: 10})
+	m := asModel(tm)
+	o := offerFree(mdl)
+	m.proxyHolder = nil
+	m.connected = &o
+	m.lastConnected = &o
+	var mm tea.Model = m
+	mm, _ = mm.Update(keyMsg("0"))
+	s.tm = asModel(mm)
+	return nil
+}
+
+// --- desk scan delivery ------------------------------------------------------------------
+
+func (s *opBDD) deskScanLandsGuest(name string) error {
+	g, err := registryGuest(name)
+	if err != nil {
+		return err
+	}
+	s.tuiPaths[g.Bin] = "/fake/" + g.Bin
+	s.update(operatorDetectedMsg{ds: []operator.Detection{{Guest: g, Path: "/fake/" + g.Bin, Version: g.KnownGood}}})
+	return nil
+}
+func (s *opBDD) deskScanLandsNoGuests() error {
+	s.update(operatorDetectedMsg{ds: nil})
+	return nil
+}
+
+// theDeskAutoTunes delivers the real autoTuneMsg (what autoTuneCmd produces once a scan is
+// in hand) and folds any drained turn cmd back in.
+func (s *opBDD) theDeskAutoTunes() error {
+	cmd := s.update(autoTuneMsg{})
+	for _, msg := range collectCmdMsgs(cmd) {
+		if msg != nil {
+			s.update(msg)
+		}
+	}
+	return nil
+}
+
+// channelOpenedBeforeScan opens a real channel on `model` (deliberate tune) before the
+// auto-tune resolves, to pin that auto-tune never overrides it.
+func (s *opBDD) channelOpenedBeforeScan(mdl string) error {
+	s.mutate(func(m *model) {
+		o := offerFree(mdl)
+		m.bindChannel(o)
+	})
+	return nil
+}
+
+// --- focus assertions --------------------------------------------------------------------
+
+func (s *opBDD) deskHasFocus() error {
+	m := s.model()
+	if !m.deskFocused {
+		return fmt.Errorf("THE DESK does not have focus")
+	}
+	if m.agentIn.Focused() {
+		return fmt.Errorf("the ask box unexpectedly has focus while the desk is focused")
+	}
+	return nil
+}
+func (s *opBDD) deskNoFocus() error {
+	if s.model().deskFocused {
+		return fmt.Errorf("THE DESK unexpectedly has focus")
+	}
+	return nil
+}
+func (s *opBDD) askBoxHasFocus() error {
+	if !s.model().agentIn.Focused() {
+		return fmt.Errorf("the ask box does not have focus")
+	}
+	return nil
+}
+func (s *opBDD) askBoxNotFocused() error {
+	if s.model().agentIn.Focused() {
+		return fmt.Errorf("the ask box unexpectedly has focus")
+	}
+	return nil
+}
+func (s *opBDD) deskCursorOnDJ() error {
+	if c := s.model().deskCursor; c != 0 {
+		return fmt.Errorf("desk cursor is %d, want 0 (DJ)", c)
+	}
+	return nil
+}
+func (s *opBDD) deskCursorOn(name string) error {
+	m := s.model()
+	ds := deskGuests(m.operatorDetections)
+	idx := m.deskCursor - 1
+	if idx < 0 || idx >= len(ds) || ds[idx].Guest.Name != name {
+		return fmt.Errorf("desk cursor %d is not on %q (guests=%d)", m.deskCursor, name, len(ds))
+	}
+	return nil
+}
+func (s *opBDD) userTypes(text string) error {
+	s.tm = typeRunes(s.tm, text)
+	return nil
+}
+func (s *opBDD) askBoxEchoes(text string) error { return s.askPromptEchoes(text) }
+
+// --- auto-tune outcome assertions --------------------------------------------------------
+
+func (s *opBDD) agentRunsOn(mdl string) error {
+	if got := s.model().agent.model; got != mdl {
+		return fmt.Errorf("agent runs on %q, want %q", got, mdl)
+	}
+	return nil
+}
+func (s *opBDD) channelIsOpen() error {
+	if s.model().connected == nil {
+		return fmt.Errorf("no channel is open")
+	}
+	return nil
+}
+func (s *opBDD) noChannelOpen() error {
+	if s.model().connected != nil {
+		return fmt.Errorf("a channel is unexpectedly open on %q", s.model().connected.Model)
+	}
+	return nil
+}
+func (s *opBDD) noCostConfirmShown() error {
+	if s.model().agentPendingConfirm != nil {
+		return fmt.Errorf("a confirm is unexpectedly pending")
+	}
+	if strings.Contains(s.view(), "cost confirm") || strings.Contains(s.view(), "[y/N]") {
+		return fmt.Errorf("a cost confirm is on screen:\n%s", s.view())
+	}
+	return nil
+}
+func (s *opBDD) pointsAtLoggingIn() error { return s.transcriptShows("/login") }
+func (s *opBDD) noHonestNoBandNote() error {
+	v := s.view()
+	if strings.Contains(v, "no free band on air") || strings.Contains(v, "no station on air") {
+		return fmt.Errorf("an honest no-band note leaked:\n%s", v)
+	}
+	return nil
+}
+func (s *opBDD) autoTuneDidNotArm() error {
+	if s.model().autoTuning {
+		return fmt.Errorf("the auto-tune armed unexpectedly")
+	}
+	return nil
+}
+func (s *opBDD) transcriptShowsExactlyOnce(text string) error {
+	if n := strings.Count(s.view(), text); n != 1 {
+		return fmt.Errorf("transcript shows %q %d times, want exactly 1:\n%s", text, n, s.view())
+	}
+	return nil
+}
+func (s *opBDD) transcriptShowsAtMostOnce(text string) error {
+	if n := strings.Count(s.view(), text); n > 1 {
+		return fmt.Errorf("transcript shows %q %d times, want at most 1:\n%s", text, n, s.view())
+	}
+	return nil
+}
+
+// --- pickAutoBand (pure) -----------------------------------------------------------------
+
+func (s *opBDD) mktFree(mdl string, signal int) error {
+	s.deskMkt = append(s.deskMkt, offer{NodeID: "n-" + mdl, Model: mdl, Online: true, FreeNow: true, Signal: signal, Ctx: 32768})
+	return nil
+}
+func (s *opBDD) mktFreeWindow(mdl string, signal, ctx int) error {
+	s.deskMkt = append(s.deskMkt, offer{NodeID: "n-" + mdl, Model: mdl, Online: true, FreeNow: true, Signal: signal, Ctx: ctx})
+	return nil
+}
+func (s *opBDD) mktPaid(mdl string, out float64) error {
+	s.deskMkt = append(s.deskMkt, offer{NodeID: "n-" + mdl, Model: mdl, Online: true, PriceIn: out / 2, PriceOut: out, Signal: 50, Ctx: 32768})
+	return nil
+}
+func (s *opBDD) mktEmpty() error { s.deskMkt = nil; return nil }
+
+func (s *opBDD) pickAutoBandPicks(login, model string) error {
+	bands := groupBands(s.deskMkt, &LimitStore{})
+	got := pickAutoBand(bands, login == "in")
+	if got == nil || got.model != model {
+		name := "<nil>"
+		if got != nil {
+			name = got.model
+		}
+		return fmt.Errorf("pickAutoBand logged %s = %q, want %q", login, name, model)
+	}
+	return nil
+}
+func (s *opBDD) pickAutoBandPicksNothing(login string) error {
+	bands := groupBands(s.deskMkt, &LimitStore{})
+	if got := pickAutoBand(bands, login == "in"); got != nil {
+		return fmt.Errorf("pickAutoBand logged %s = %q, want nothing", login, got.model)
+	}
+	return nil
+}
+
+// initializeDeskEntryScenarios registers the desk_entry + auto_tune step definitions.
+func initializeDeskEntryScenarios(st *opBDD, sc *godog.ScenarioContext) {
+	sc.Step(`^a fresh AGENT session with nothing tuned in$`, st.freshNothingTuned)
+	sc.Step(`^a fresh AGENT session with a free band "([^"]*)" on air$`, st.freshFreeBand)
+	sc.Step(`^a fresh AGENT session with only a paid band on air$`, st.freshPaidOnly)
+	sc.Step(`^a fresh AGENT session logged in with only a paid band on air$`, st.freshPaidOnlyLoggedIn)
+	sc.Step(`^a fresh AGENT session logged out with only a paid band on air$`, st.freshPaidOnlyLoggedOut)
+	sc.Step(`^a fresh AGENT session with an empty market$`, st.freshEmptyMarket)
+	sc.Step(`^an AGENT session whose last band "([^"]*)" is still on air$`, st.lastBandStillOnAir)
+	sc.Step(`^the desk scan lands guest "([^"]*)"$`, st.deskScanLandsGuest)
+	sc.Step(`^the desk scan lands no guests$`, st.deskScanLandsNoGuests)
+	sc.Step(`^the desk auto-tunes$`, st.theDeskAutoTunes)
+	sc.Step(`^a channel is opened on "([^"]*)" before the scan lands$`, st.channelOpenedBeforeScan)
+	sc.Step(`^THE DESK has focus$`, st.deskHasFocus)
+	sc.Step(`^THE DESK does not have focus$`, st.deskNoFocus)
+	sc.Step(`^the ask box has focus$`, st.askBoxHasFocus)
+	sc.Step(`^the ask box is not focused$`, st.askBoxNotFocused)
+	sc.Step(`^the desk cursor is on the DJ row$`, st.deskCursorOnDJ)
+	sc.Step(`^the desk cursor is on "([^"]*)"$`, st.deskCursorOn)
+	sc.Step(`^the user types "([^"]*)"$`, st.userTypes)
+	sc.Step(`^the ask box echoes "([^"]*)"$`, st.askBoxEchoes)
+	sc.Step(`^the agent runs on "([^"]*)"$`, st.agentRunsOn)
+	sc.Step(`^a channel is open$`, st.channelIsOpen)
+	sc.Step(`^no channel is open$`, st.noChannelOpen)
+	sc.Step(`^no cost confirm is shown$`, st.noCostConfirmShown)
+	sc.Step(`^the transcript points at logging in$`, st.pointsAtLoggingIn)
+	sc.Step(`^no honest "no band" note appears$`, st.noHonestNoBandNote)
+	sc.Step(`^the auto-tune did not arm$`, st.autoTuneDidNotArm)
+	sc.Step(`^the transcript shows "([^"]*)" exactly once$`, st.transcriptShowsExactlyOnce)
+	sc.Step(`^the transcript shows "([^"]*)" at most once$`, st.transcriptShowsAtMostOnce)
+	sc.Step(`^the market has a free band "([^"]*)" at signal (\d+)$`, st.mktFree)
+	sc.Step(`^the market has a free band "([^"]*)" at signal (\d+) window (\d+)$`, st.mktFreeWindow)
+	sc.Step(`^the market has a paid band "([^"]*)" out ([0-9.]+)$`, st.mktPaid)
+	sc.Step(`^the market is empty$`, st.mktEmpty)
+	sc.Step(`^pickAutoBand logged (in|out) picks "([^"]*)"$`, st.pickAutoBandPicks)
+	sc.Step(`^pickAutoBand logged (in|out) picks nothing$`, st.pickAutoBandPicksNothing)
+}

--- a/internal/tui/operator_steps_desk_entry_test.go
+++ b/internal/tui/operator_steps_desk_entry_test.go
@@ -56,6 +56,31 @@ func (s *opBDD) freshPaidOnlyLoggedOut() error {
 }
 func (s *opBDD) freshEmptyMarket() error { s.freshAgent(nil, true); return nil }
 
+// freshMixedFreeAndCheaperPaid seeds ONE band ("mixed") of two online stations: a FreeNow
+// promo station carrying a NONZERO nominal price, and a genuinely PAID station whose price
+// is CHEAPER. groupBands flags the band free (the FreeNow station) but sets cheapest to the
+// paid station (lower PriceOut) - the R1 money-safety trap: binding cheapest silently spends.
+func (s *opBDD) freshMixedFreeAndCheaperPaid() error {
+	free := offer{NodeID: "n-free", Model: "mixed", Online: true, FreeNow: true, PriceIn: 0.25, PriceOut: 0.50, Signal: 60, Ctx: 32768}
+	paid := offer{NodeID: "n-paid", Model: "mixed", Online: true, PriceIn: 0.05, PriceOut: 0.10, Signal: 90, Ctx: 32768}
+	s.freshAgent([]offer{free, paid}, true)
+	return nil
+}
+
+// staleFreeFlaggedAllPaid seeds a hand-built band whose `free` flag is set but whose only
+// station is PAID (a stale/mixed signal groupBands cannot produce, injected directly to pin
+// the defensive fallback). Auto-tune must bind nothing and land on the honest paid state.
+func (s *opBDD) staleFreeFlaggedAllPaid() error {
+	s.freshAgent(nil, true)
+	s.mutate(func(m *model) {
+		paid := offer{NodeID: "n-stale-paid", Model: "stale", Online: true, PriceIn: 0.05, PriceOut: 0.10, Signal: 50, Ctx: 32768}
+		b := band{model: "stale", online: true, free: true, stations: 1, minIn: 0.05, minOut: 0.10, maxOut: 0.10, all: []offer{paid}}
+		b.cheapest = &b.all[0]
+		m.bands = []band{b}
+	})
+	return nil
+}
+
 // lastBandStillOnAir seeds a session that last tuned band `model`, still on air: a live
 // holder + lastConnected on that model + the market carrying it. resolveAgentModel then
 // reuses it, so entering AGENT never arms an auto-tune (the sticky-when-online path).
@@ -260,6 +285,16 @@ func (s *opBDD) noCostConfirmShown() error {
 	}
 	return nil
 }
+func (s *opBDD) boundStationIsGenuinelyFree() error {
+	c := s.model().connected
+	if c == nil {
+		return fmt.Errorf("no channel is open - nothing was bound")
+	}
+	if !(c.FreeNow || (c.PriceIn == 0 && c.PriceOut == 0)) {
+		return fmt.Errorf("bound station %q is NOT genuinely free (FreeNow=%v in=%v out=%v) - auto-tune silently bound a PAID station (R1 violation)", c.NodeID, c.FreeNow, c.PriceIn, c.PriceOut)
+	}
+	return nil
+}
 func (s *opBDD) pointsAtLoggingIn() error { return s.transcriptShows("/login") }
 func (s *opBDD) noHonestNoBandNote() error {
 	v := s.view()
@@ -331,6 +366,9 @@ func initializeDeskEntryScenarios(st *opBDD, sc *godog.ScenarioContext) {
 	sc.Step(`^a fresh AGENT session logged in with only a paid band on air$`, st.freshPaidOnlyLoggedIn)
 	sc.Step(`^a fresh AGENT session logged out with only a paid band on air$`, st.freshPaidOnlyLoggedOut)
 	sc.Step(`^a fresh AGENT session with an empty market$`, st.freshEmptyMarket)
+	sc.Step(`^a fresh AGENT session with a band mixing a free station and a cheaper paid station$`, st.freshMixedFreeAndCheaperPaid)
+	sc.Step(`^a fresh AGENT session with a free-flagged band whose stations are all paid$`, st.staleFreeFlaggedAllPaid)
+	sc.Step(`^the bound station is genuinely free$`, st.boundStationIsGenuinelyFree)
 	sc.Step(`^an AGENT session whose last band "([^"]*)" is still on air$`, st.lastBandStillOnAir)
 	sc.Step(`^the desk scan lands guest "([^"]*)"$`, st.deskScanLandsGuest)
 	sc.Step(`^the desk scan lands no guests$`, st.deskScanLandsNoGuests)

--- a/internal/tui/operator_steps_desk_entry_test.go
+++ b/internal/tui/operator_steps_desk_entry_test.go
@@ -153,6 +153,33 @@ func (s *opBDD) transcriptNoLongerShows(text string) error {
 	return nil
 }
 
+// sessionClearedWith runs an in-AGENT slash command (e.g. /clear) through the REAL
+// runAgentCommand path and folds any emitted cmd back in.
+func (s *opBDD) sessionClearedWith(cmd string) error {
+	tm, c := s.model().runAgentCommand(cmd)
+	s.tm = tm
+	for _, msg := range collectCmdMsgs(c) {
+		if msg != nil {
+			s.update(msg)
+		}
+	}
+	return nil
+}
+
+// nonUnreachableErr delivers a NON-broker-unreachable errMsg (fetchBalance's errMsg("") in
+// the cold-fetch window is the reported case) - it must NOT disarm an armed auto-tune.
+func (s *opBDD) nonUnreachableErr() error {
+	s.update(errMsg(""))
+	return nil
+}
+
+func (s *opBDD) autoTuneIsArmed() error {
+	if !s.model().autoTuning {
+		return fmt.Errorf("the auto-tune is not armed (a non-unreachable error disarmed it)")
+	}
+	return nil
+}
+
 // --- focus assertions --------------------------------------------------------------------
 
 func (s *opBDD) deskHasFocus() error {
@@ -313,6 +340,9 @@ func initializeDeskEntryScenarios(st *opBDD, sc *godog.ScenarioContext) {
 	sc.Step(`^the user re-enters AGENT$`, st.userReEntersAgent)
 	sc.Step(`^the user presses the escape key$`, st.userPressesRealEsc)
 	sc.Step(`^the broker is unreachable during the cold auto-tune$`, st.brokerUnreachableColdAutoTune)
+	sc.Step(`^a non-unreachable error arrives during the cold auto-tune$`, st.nonUnreachableErr)
+	sc.Step(`^the session is cleared with "([^"]*)"$`, st.sessionClearedWith)
+	sc.Step(`^the auto-tune is still armed$`, st.autoTuneIsArmed)
 	sc.Step(`^the transcript no longer shows "([^"]*)"$`, st.transcriptNoLongerShows)
 	sc.Step(`^THE DESK has focus$`, st.deskHasFocus)
 	sc.Step(`^THE DESK does not have focus$`, st.deskNoFocus)

--- a/internal/tui/operator_steps_tui_test.go
+++ b/internal/tui/operator_steps_tui_test.go
@@ -262,18 +262,20 @@ func (s *opBDD) proxyCallsCosts(costs []string) error {
 func (s *opBDD) seedTUI(bandModel string) {
 	m := browseSeed(120)
 	m.mouseOff = false // the handoff specs default to "the user has the mouse on"
-	var tm tea.Model = m
-	tm, _ = tm.Update(keyMsg("0"))
-	mm := asModel(tm)
+	// Wire the live proxy holder BEFORE entering AGENT - the real order is "tune in, then
+	// [0]", so enterAgent sees a live channel and lands on the ask prompt (not the fresh
+	// DESK auto-tune landing, which is only for a genuinely fresh session with no holder).
 	if bandModel != "" {
 		s.startMoneyServers(bandModel)
-		mm.proxyHolder = s.holder
-		mm.endpoint = s.proxySrv.URL + "/v1"
-		mm.broker = s.brokerSrv.URL
+		m.proxyHolder = s.holder
+		m.endpoint = s.proxySrv.URL + "/v1"
+		m.broker = s.brokerSrv.URL
 		s.keyAtSeed = s.holder.Get().SessionKey
 		s.budgetAtSeed = s.holder.Get().Budget
 	}
-	s.tm = mm
+	var tm tea.Model = m
+	tm, _ = tm.Update(keyMsg("0"))
+	s.tm = asModel(tm)
 }
 
 func (s *opBDD) agentSessionAtPrompt() error {

--- a/internal/tui/operator_steps_tui_test.go
+++ b/internal/tui/operator_steps_tui_test.go
@@ -74,6 +74,7 @@ type opBDD struct {
 	budgetAtSeed  float64           // holder budget at seed (the "unchanged" baseline)
 	launchWorkdir string            // what the operatorWorkdir seam resolves for this scenario
 	tuiPaths      map[string]string // guest bin -> fake path for the TUI-side detect seam
+	deskMkt       []offer           // accumulated market offers for the pickAutoBand pure steps
 
 	// money servers (real HTTP through the real proxy handler)
 	brokerSrv *httptest.Server
@@ -1960,4 +1961,7 @@ func initializeOperatorScenarios(t *testing.T, st *opBDD, sc *godog.ScenarioCont
 
 	// ── Phase 3: THE DESK view · band gate · pre-launch plate ─────────────────
 	initializePhase3Steps(st, sc)
+
+	// ── AGENT [0] desk-entry redesign: focus, auto-tune, badges ───────────────
+	initializeDeskEntryScenarios(st, sc)
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1409,7 +1409,10 @@ func (m model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case autoTuneMsg:
 		// The AGENT [0] DESK landing armed a silent auto-tune and a scan is already in
 		// hand: decide now (R1/R6). Cold launches route through offersMsg instead.
-		return m, m.runAutoTune()
+		// runAutoTune has a pointer receiver + mutates m, so sequence the call BEFORE the
+		// return value is copied (don't lean on Go's return arg-eval order).
+		cmd := m.runAutoTune()
+		return m, cmd
 	case sharesDetectedMsg:
 		return m.onSharesDetected(msg.found, msg.needKey)
 	case balanceMsg:
@@ -1473,6 +1476,20 @@ func (m model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.relaying = false
 		if strings.HasPrefix(string(msg), "broker unreachable") {
 			m.scanErr = true // the band scan dropped -> Ping goes "...static"
+		}
+		// A COLD AGENT [0] auto-tune fetches /discover first; if the broker is unreachable
+		// the fetch fails HERE. Without this the auto-tune stays armed and the "finding a
+		// free band…" beat sits up until a later rescan. Disarm, splice out the beat, and
+		// note the honest unreachable state ONCE (noteOnce dedups), dropping any parked
+		// prompt silently - there is no band to send it to.
+		if m.autoTuning {
+			m.autoTuning = false
+			m.clearFindingBeat()
+			m.noteOnce(
+				stRed.Render("✕ ")+stEmber.Render("couldn't reach the broker to find a band"),
+				hintTuneOrShare(m.narrow()))
+			m.agentLandingLines = len(m.agentLines)
+			m.flushPendingPrompts()
 		}
 		m.status = stEmber.Render("! " + string(msg))
 		return m, nil
@@ -6404,8 +6421,12 @@ func (m *model) runAutoTune() tea.Cmd {
 	// A channel opened / a band deliberately tuned since we armed: never override it.
 	if m.connected != nil || m.resolveAgentModel() != "" {
 		m.clearFindingBeat()
-		m.deskFocused = false
-		m.agentIn.Focus()
+		// Mirror the free-pick branch's guard (the f6c5be7 ruling): if the user is mid-pick
+		// on the FOCUSED desk, an already-connected auto-tune must NOT yank them to the ask
+		// box. Only grab focus when the desk isn't holding it.
+		if !m.deskFocused {
+			m.agentIn.Focus()
+		}
 		m.refreshAgentModel()
 		return m.drainPendingPrompts()
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6435,7 +6435,7 @@ func (m *model) runAutoTune() tea.Cmd {
 			m.noteOnce(
 				stRed.Render("✕ ")+stEmber.Render("no station on air right now"),
 				hintTuneOrShare(m.narrow()))
-			m.status = stDim.Render("no station on air · [1] tune in · [2] go on air · esc exits")
+			m.status = stDim.Render("nothing on air · [1] tune in · [2] go on air · esc exits")
 		}
 		m.agentLandingLines = len(m.agentLines)
 		m.flushPendingPrompts()
@@ -6460,14 +6460,11 @@ func (m *model) drainPendingPrompts() tea.Cmd {
 }
 
 // flushPendingPrompts drops prompts parked while no model was tuned, when the auto-tune
-// found no free band to land on: a SINGLE deduped failureHint, never one per prompt.
+// found no free band to land on. It drops them SILENTLY: runAutoTune has already noted
+// the ONE honest state (empty / paid) right after the echoed ask, so a second "no station
+// on air" failureHint would be exactly the per-turn spam this redesign kills.
 func (m *model) flushPendingPrompts() {
-	if len(m.agentPending) == 0 {
-		return
-	}
 	m.agentPending = nil
-	m.noteOnce(failureHint("no station on air - no model is tuned in", "", m.narrow())...)
-	m.agentLandingLines = len(m.agentLines)
 }
 
 // clearFindingBeat drops the "finding a band…" beat line the fresh AGENT landing shows

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -441,13 +441,13 @@ type offer struct {
 	// did not declare, so an ABSENT set claims nothing (no "text-only" badge).
 	Capabilities []string `json:"capabilities,omitempty"`
 	Online       bool     `json:"online"`
-	Confidential bool    `json:"confidential"`
-	FreeNow      bool    `json:"free_now"`
-	TPS          float64 `json:"tps"`
-	TTFTMs       float64 `json:"ttft_ms"`      // probe-measured time-to-first-token (ms; 0 = unmeasured)
-	SuccessRate  float64 `json:"success"`      // 0..1 time-decayed success evidence
-	SuccessSeen  bool    `json:"success_seen"` // SuccessRate is REAL (not the no-evidence fallback)
-	Verified     bool    `json:"verified"`     // recent PASSED serving canary (distinct from confidential ◆)
+	Confidential bool     `json:"confidential"`
+	FreeNow      bool     `json:"free_now"`
+	TPS          float64  `json:"tps"`
+	TTFTMs       float64  `json:"ttft_ms"`      // probe-measured time-to-first-token (ms; 0 = unmeasured)
+	SuccessRate  float64  `json:"success"`      // 0..1 time-decayed success evidence
+	SuccessSeen  bool     `json:"success_seen"` // SuccessRate is REAL (not the no-evidence fallback)
+	Verified     bool     `json:"verified"`     // recent PASSED serving canary (distinct from confidential ◆)
 	// Signal is the broker's 0..100 channel-health score (online + quality + tps +
 	// reliability). It carries even when TPS==0, so a freshly-on-air band meters at
 	// its baseline strength instead of a blank tps-driven bar.
@@ -844,15 +844,15 @@ type model struct {
 	// and clears deskFocused (the DJ-still-types-through path). autoTuning marks a silent
 	// auto-tune in flight (R1/R6); autoTuneBeatLen is the transcript length BEFORE the
 	// "finding a band…" beat, so the beat is swapped for the outcome without stacking.
-	deskFocused    bool
-	deskCursor     int
-	autoTuning     bool
+	deskFocused     bool
+	deskCursor      int
+	autoTuning      bool
 	autoTuneBeatLen int
 	// agentPending holds prompts submitted while NO model is tuned in: rather than fire a
 	// doomed turn (the "no station on air" spam), the turn is parked, a silent auto-tune
 	// is kicked, and the prompt is sent the moment a band lands (drained by runAutoTune).
-	agentPending []queuedPrompt
-	agentLandingLines  int                  // transcript length that still counts as the AGENT landing (entry chrome only)
+	agentPending      []queuedPrompt
+	agentLandingLines int // transcript length that still counts as the AGENT landing (entry chrome only)
 	// `ask ›` slash-command autocomplete (agent.go: agentCommands / agentSlashStrip /
 	// the tab case in onAgentKey). agentTabPrefix is the typed prefix a live Tab
 	// completion cycle is stepping ("" = no cycle); agentTabIdx is the current pick

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -308,6 +308,12 @@ var (
 	glyphVerify = glyphConf
 )
 
+// bandCapGlyph resolves a band-badge capability mark LIVE from the current glyph set
+// (unlike the package-init glyph vars above), so a test that flips ROGERAI_ASCII after
+// init sees the ASCII fold. agentReadyGlyph carries its inferred "~" at the call site.
+func agentReadyGlyph() string { return glyphs.Current().AgentReady }
+func visionGlyph() string     { return glyphs.Current().Vision }
+
 // beaconPulse is the breathing "(( • ))" Ping beacon string, folded to ASCII
 // ("((*))") on a legacy Windows console. Centralized so the one motif has one source.
 func beaconPulse() string { return glyphs.Current().Beacon }
@@ -430,7 +436,11 @@ type offer struct {
 	PriceTier    int     `json:"price_tier"` // broker's neutral 0..4 $-tier (0 = FREE/unknown)
 	Ctx          int     `json:"ctx"`
 	CtxEstimated bool    `json:"ctx_estimated"` // Ctx is the estimated default, not a detected window
-	Online       bool    `json:"online"`
+	// Capabilities is the broker's declared per-station capability set (e.g. "vision").
+	// Decode-only on this side: the browser NEVER fabricates a capability the station
+	// did not declare, so an ABSENT set claims nothing (no "text-only" badge).
+	Capabilities []string `json:"capabilities,omitempty"`
+	Online       bool     `json:"online"`
 	Confidential bool    `json:"confidential"`
 	FreeNow      bool    `json:"free_now"`
 	TPS          float64 `json:"tps"`
@@ -593,6 +603,7 @@ type band struct {
 	free     bool    // any station FREE now
 	lineage  int     // count of confidential/lineage stations
 	verified bool    // any ONLINE station passed the broker's serving probe (✓, distinct from ◆)
+	vision   bool    // any station DECLARED the "vision" capability (◪; never inferred)
 	inFlight int     // active (in-flight) requests summed across online stations - the REAL
 	// activity that animates the signal meter (idle band steady, busy band scans). Honest:
 	// it is the broker's live load, never a fabricated pulse.
@@ -826,6 +837,21 @@ type model struct {
 	operatorCursor     int                  // selected picker row (never the suggestion)
 	operatorHandoff    *operatorHandoff     // non-nil from staging until the exec returns
 	operatorPlate      *operatorPlate       // the Phase 3 pre-launch confirm plate; nil = no plate up
+	// AGENT [0] desk entry (the redesign): when the AGENT lands with nothing tuned in,
+	// THE DESK becomes the FOCUSED, selectable operator picker (R3) - the ask box is NOT
+	// focused, arrows move deskCursor, Enter on the DJ focuses the ask box and Enter on a
+	// guest opens the pre-launch plate; any printable rune falls through to the ask box
+	// and clears deskFocused (the DJ-still-types-through path). autoTuning marks a silent
+	// auto-tune in flight (R1/R6); autoTuneBeatLen is the transcript length BEFORE the
+	// "finding a band…" beat, so the beat is swapped for the outcome without stacking.
+	deskFocused    bool
+	deskCursor     int
+	autoTuning     bool
+	autoTuneBeatLen int
+	// agentPending holds prompts submitted while NO model is tuned in: rather than fire a
+	// doomed turn (the "no station on air" spam), the turn is parked, a silent auto-tune
+	// is kicked, and the prompt is sent the moment a band lands (drained by runAutoTune).
+	agentPending []queuedPrompt
 	agentLandingLines  int                  // transcript length that still counts as the AGENT landing (entry chrome only)
 	// `ask ›` slash-command autocomplete (agent.go: agentCommands / agentSlashStrip /
 	// the tab case in onAgentKey). agentTabPrefix is the typed prefix a live Tab
@@ -1347,6 +1373,12 @@ func (m model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loadedOnce = true // the first scan has come back: never re-enter the initial loading pose
 		m.offers = []offer(msg)
 		m.bands = m.mergeStickyBand(groupBands(m.offers, m.limits))
+		// AGENT [0] cold auto-tune: this scan was fetched to find a band for the DESK
+		// landing. Decide now that the band list is in hand (single-shot; no retry loop).
+		var autoTuneDrain tea.Cmd
+		if m.autoTuning {
+			autoTuneDrain = m.runAutoTune()
+		}
 		m.world.data = buildWorldData(m.bands) // refresh the screensaver's LIVE signal towers
 		// Clamp the cursor + window into the FILTERED view (the list the user actually
 		// navigates), so a re-scan that shrinks the matches never strands the cursor.
@@ -1371,7 +1403,11 @@ func (m model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !notified && !m.relaying && (m.mode == modeBrowse || m.mode == modeCommand) {
 			m.status = m.ambientStatus()
 		}
-		return m, nil
+		return m, autoTuneDrain
+	case autoTuneMsg:
+		// The AGENT [0] DESK landing armed a silent auto-tune and a scan is already in
+		// hand: decide now (R1/R6). Cold launches route through offersMsg instead.
+		return m, m.runAutoTune()
 	case sharesDetectedMsg:
 		return m.onSharesDetected(msg.found, msg.needKey)
 	case balanceMsg:
@@ -3672,18 +3708,21 @@ func (m model) liveProxyOpts(o offer, alert *alertBox) client.ProxyOptions {
 	}
 }
 
-func (m model) openChannel() (tea.Model, tea.Cmd) {
-	q := m.q
-	o := *q.b.cheapest
+// bindChannel is the endpoint-binding half of tuning in, factored out of openChannel so
+// the SILENT auto-tune (autoTuneCmd) can open a channel WITHOUT the staged animation or
+// any mode switch: bind (or re-point) the local proxy to station o, mark it connected,
+// and record it as the sticky/recent band. It returns warm=true when the model was
+// already tuned in this session (a reconnect skips the cold-tune animation) and any
+// endpoint-bind error (openChannel bounces back to BROWSE; the auto-tune notes it once).
+// It mutates the receiver in place - callers pass a &m.
+func (m *model) bindChannel(o offer) (warm bool, err error) {
 	if !m.proxyUp {
 		// Auto-pick a free port instead of dead-ending if 4141 is taken (mirrors the CLI's
 		// freePort): scan upward from the configured port so a busy port never bounces the
 		// user back to browse with a bind error and no recovery.
-		ln, err := listenFreePort(m.proxyAddr)
-		if err != nil {
-			m.mode = modeBrowse
-			m.status = stEmber.Render("! endpoint bind failed: " + err.Error())
-			return m, nil
+		ln, lerr := listenFreePort(m.proxyAddr)
+		if lerr != nil {
+			return false, lerr
 		}
 		m.proxyAddr = ln.Addr().String() // remember the port we actually bound
 		m.endpoint = "http://" + ln.Addr().String() + "/v1"
@@ -3704,7 +3743,8 @@ func (m model) openChannel() (tea.Model, tea.Cmd) {
 	if m.proxyHolder != nil {
 		m.proxyHolder.SetBand(m.liveProxyOpts(o, m.alert))
 	}
-	m.connected = &o
+	oc := o
+	m.connected = &oc
 	m.apikey = m.proxyKey
 	if m.apikey == "" {
 		m.apikey = "roger-local"
@@ -3714,15 +3754,27 @@ func (m model) openChannel() (tea.Model, tea.Cmd) {
 	// founder's vanishing-band bug). mergeStickyBand re-includes it on every re-scan.
 	sticky := o
 	m.lastConnected = &sticky
-	// WARM RECONNECT: a band we have tuned in to before this session skips the staged
-	// scan/lock/handshake animation and drops straight into the open channel - only a
-	// FIRST (cold) tune-in plays the full sequence. The endpoint is already bound, so a
-	// reconnect is genuinely instant.
-	warm := m.recentBands[o.Model]
+	warm = m.recentBands[o.Model]
 	if m.recentBands == nil {
 		m.recentBands = map[string]bool{}
 	}
 	m.recentBands[o.Model] = true
+	return warm, nil
+}
+
+func (m model) openChannel() (tea.Model, tea.Cmd) {
+	q := m.q
+	o := *q.b.cheapest
+	// WARM RECONNECT: a band we have tuned in to before this session skips the staged
+	// scan/lock/handshake animation and drops straight into the open channel - only a
+	// FIRST (cold) tune-in plays the full sequence. The endpoint is already bound, so a
+	// reconnect is genuinely instant.
+	warm, err := m.bindChannel(o)
+	if err != nil {
+		m.mode = modeBrowse
+		m.status = stEmber.Render("! endpoint bind failed: " + err.Error())
+		return m, nil
+	}
 	if warm {
 		m.mode = modeConnecting
 		m.connectStage = connectStageDone
@@ -5919,6 +5971,22 @@ func (m model) browseView(w int) string {
 	if matched > rows {
 		b.WriteString("  " + stDim.Render(fmt.Sprintf("%d-%d of %d", top+1, end, matched)) + "\n")
 	}
+	// BADGE LEGEND: one dim key line, shown only when a visible band actually carries a
+	// non-self-describing glyph (agent-ready / vision) - a plain-text-flags list needs no
+	// legend. Full view only (compact folds flags away). Sits directly under the table.
+	if !m.compact {
+		legend := false
+		for i := top; i < end; i++ {
+			bd := vis[i]
+			if ready, _ := bandAgentReady(bd); ready || bd.vision {
+				legend = true
+				break
+			}
+		}
+		if legend {
+			b.WriteString(truncVisible(bandBadgeLegend(), w) + "\n")
+		}
+	}
 	// VOICE FOOTNOTE (LLM primacy): one DIM line at the FOOT of the LLM band list —
 	// "also on air: N voices ▸ [v]" — shown ONLY when a voice band is actually on air. It is the
 	// quietest live line on the screen (no ◉, no accent), drilling into THE DJ BOOTH (a child
@@ -5990,6 +6058,39 @@ func (m model) filterLine(matched, total int) string {
 	return "  " + strings.Join(parts, "  ")
 }
 
+// offerHasCapability reports whether the station DECLARED cap (case-insensitive). It
+// is the ONLY source of a capability badge: an absent set claims nothing.
+func offerHasCapability(o offer, cap string) bool {
+	for _, c := range o.Capabilities {
+		if strings.EqualFold(strings.TrimSpace(c), cap) {
+			return true
+		}
+	}
+	return false
+}
+
+// bandAgentReady reports whether a band is coding-agent capable, and whether that
+// readiness is INFERRED (from the window) rather than proven (R5). Today it is ALWAYS
+// inferred from the representative window meeting the agent-ready floor (operatorCtxFloor,
+// the same 16k gate the handoff uses); a later broker tool-call probe can flip inferred
+// off. An UNKNOWN window (ctx 0) is NOT claimed agent-ready here - the badge never
+// asserts a window it cannot see (that is the auto-tune partition's job, not the badge's).
+func bandAgentReady(bd band) (ready, inferred bool) {
+	ctx, _ := bandCtx(bd)
+	if ctx >= operatorCtxFloor {
+		return true, true
+	}
+	return false, false
+}
+
+// bandKnownSmall reports a band whose window is KNOWN and under the agent-ready floor -
+// the one partition auto-tune de-prioritises for a coding handoff (R6). Unknown (ctx 0)
+// is NOT known-small: it may well be a large model the broker sent without ctx metadata.
+func bandKnownSmall(bd band) bool {
+	ctx, _ := bandCtx(bd)
+	return ctx > 0 && ctx < operatorCtxFloor
+}
+
 // plainBandBadge is bandBadge without color, for the reverse-video selected row
 // (one accent style governs the whole row; an embedded fg color reads as noise).
 // connected leads the cell with the "◉ connected" marker so the open channel's
@@ -6004,6 +6105,16 @@ func plainBandBadge(bd band, limits *LimitStore, connected bool) string {
 	}
 	if bd.lineage > 0 {
 		parts = append(parts, fmt.Sprintf("◆ %d", bd.lineage))
+	}
+	if ready, inferred := bandAgentReady(bd); ready {
+		tag := agentReadyGlyph()
+		if inferred {
+			tag += "~"
+		}
+		parts = append(parts, tag)
+	}
+	if bd.vision {
+		parts = append(parts, visionGlyph())
 	}
 	if bd.free {
 		parts = append(parts, "FREE")
@@ -6034,6 +6145,18 @@ func bandBadge(bd band, limits *LimitStore, connected bool) string {
 	if bd.lineage > 0 {
 		parts = append(parts, stGold.Render(fmt.Sprintf("◆ %d", bd.lineage)))
 	}
+	// Agent-ready ⌁ (inferred ⌁~) - the coding-agent-capable mark, keyed like the ctx
+	// value it is derived from. Vision ◪ - a declared multimodal band.
+	if ready, inferred := bandAgentReady(bd); ready {
+		tag := agentReadyGlyph()
+		if inferred {
+			tag += "~"
+		}
+		parts = append(parts, stKey.Render(tag))
+	}
+	if bd.vision {
+		parts = append(parts, stKey.Render(visionGlyph()))
+	}
 	if bd.free {
 		parts = append(parts, stLive.Render("FREE"))
 	}
@@ -6044,6 +6167,15 @@ func bandBadge(bd band, limits *LimitStore, connected bool) string {
 		return stDim.Render("·")
 	}
 	return strings.Join(parts, " ")
+}
+
+// bandBadgeLegend is the one dim key line under the band table explaining the flag
+// glyphs that are NOT self-describing text: the agent-ready ⌁ (inferred ⌁~) and the
+// vision ◪. FREE / ◆ / ✓ carry their own words in the cell, so the legend stays short.
+// Rendered plain (dim) and folded for ASCII so a legacy console shows "%~ / [v]".
+func bandBadgeLegend() string {
+	ar := agentReadyGlyph()
+	return stDim.Render("  " + ar + " agent-ready (" + ar + "~ inferred) · " + visionGlyph() + " vision")
 }
 
 // groupBands groups offers by model into bands, computing each band's live
@@ -6065,6 +6197,11 @@ func groupBands(offers []offer, limits *LimitStore) []band {
 		b.all = append(b.all, oc)
 		if o.Confidential {
 			b.lineage++
+		}
+		// A DECLARED capability is intrinsic to the model, so it counts from any station
+		// (online or not) - a vision model does not stop being multimodal while off air.
+		if offerHasCapability(o, "vision") {
+			b.vision = true
 		}
 		if !o.Online {
 			continue
@@ -6155,6 +6292,194 @@ func (m *model) mergeStickyBand(bands []band) []band {
 		sticky.lineage = 1
 	}
 	return append(bands, sticky)
+}
+
+// pickAutoBand chooses the band the AGENT [0] DESK auto-tunes onto when it lands with
+// nothing tuned in. PURE + deterministic. Rulings:
+//
+//   - R1 (never auto-spend): a FREE band is the only kind ever SILENTLY connectable, and
+//     the CALLER (runAutoTune) - never this function - decides that a PAID pick lands on
+//     the honest paid state instead of spending. A PAID band is offered here ONLY when
+//     loggedIn (a logged-out user cannot pay), so a logged-out user with no free band
+//     gets nil -> the honest empty state, never a named paid band it cannot reach.
+//   - R6 (agent-ready first): a coding handoff must not dead-end, so agent-ready bands
+//     (window unknown or >=16k) sort before KNOWN-small ones. Within a partition FREE
+//     precedes paid; free bands sort by signal desc (the iOS order), paid by cheapest
+//     out-price. Model name is the final deterministic tie-break.
+//
+// Only ONLINE, non-voice (a brain is a chat band) candidates are considered.
+func pickAutoBand(bands []band, loggedIn bool) *band {
+	var cands []band
+	for _, b := range bands {
+		if !b.online || b.isVoice() {
+			continue
+		}
+		if !b.free && !loggedIn {
+			continue // a paid band needs a wallet
+		}
+		cands = append(cands, b)
+	}
+	if len(cands) == 0 {
+		return nil
+	}
+	sort.SliceStable(cands, func(i, j int) bool {
+		bi, bj := cands[i], cands[j]
+		if si, sj := bandKnownSmall(bi), bandKnownSmall(bj); si != sj {
+			return !si // agent-ready (not known-small) first
+		}
+		if bi.free != bj.free {
+			return bi.free // free before paid
+		}
+		if bi.free {
+			if gi, gj := bandSignal(bi), bandSignal(bj); gi != gj {
+				return gi > gj // free: strongest signal first
+			}
+		} else if bi.minOut != bj.minOut {
+			return bi.minOut < bj.minOut // paid: cheapest first
+		}
+		return bi.model < bj.model
+	})
+	top := cands[0]
+	return &top
+}
+
+// autoTuneMsg asks the model to run the auto-tune decision now (bands are already
+// scanned). The cold path fetches /discover first (fetchOffers -> offersMsg), whose
+// handler runs the decision when m.autoTuning is set.
+type autoTuneMsg struct{}
+
+// autoTuneCmd kicks the silent auto-tune off the AGENT [0] landing: decide immediately
+// when a scan is already in hand, else fetch /discover first so a cold launch (AGENT
+// before any BROWSE scan) still finds a band. There is NO retry loop - a single empty
+// scan lands on the honest empty state (the founder's "spams no station" regression).
+func autoTuneCmd(broker string, scanned bool) tea.Cmd {
+	if scanned {
+		return func() tea.Msg { return autoTuneMsg{} }
+	}
+	return fetchOffers(broker)
+}
+
+// noteOnce appends a transcript block UNLESS it already IS the tail - the guard that
+// stops the "no station on air / no free band / no model tuned in" honest states from
+// stacking on every turn / re-entry (founder live-test pain). Dedup is per-BLOCK so a
+// two-line honest state (the ✕ + its hint) collapses as a unit.
+func (m *model) noteOnce(lines ...string) {
+	if n := len(m.agentLines); n >= len(lines) && len(lines) > 0 {
+		same := true
+		for i, ln := range lines {
+			if m.agentLines[n-len(lines)+i] != ln {
+				same = false
+				break
+			}
+		}
+		if same {
+			return
+		}
+	}
+	m.agentLines = append(m.agentLines, lines...)
+}
+
+// runAutoTune folds a silent auto-tune outcome into the model (R1/R6): a FREE pick is
+// connected on the spot at $0 and the agent binds to it; a PAID pick (logged-in
+// cheapest-paid) lands on the honest paid state, NEVER a spend; nothing available lands
+// on the honest empty state. It respects a channel opened since entry and a
+// deliberately-tuned band (no override). It is a no-op unless an auto-tune is armed.
+func (m *model) runAutoTune() tea.Cmd {
+	if !m.autoTuning || m.agent == nil {
+		return nil
+	}
+	m.autoTuning = false
+	// A channel opened / a band deliberately tuned since we armed: never override it.
+	if m.connected != nil || m.resolveAgentModel() != "" {
+		m.clearFindingBeat()
+		m.deskFocused = false
+		m.agentIn.Focus()
+		m.refreshAgentModel()
+		return m.drainPendingPrompts()
+	}
+	pick := pickAutoBand(m.bands, m.loggedInState())
+	switch {
+	case pick != nil && pick.free && pick.cheapest != nil:
+		o := *pick.cheapest
+		m.clearFindingBeat()
+		m.bindChannel(o)
+		m.agent.model = o.Model
+		m.agentPicked = false
+		m.deskFocused = false
+		m.agentIn.Focus()
+		m.noteOnce(stDim.Render("· ") + stDim.Render("auto-tuned to ") + stKey.Render(o.Model) + stDim.Render(" (free) · the agent runs on it"))
+		m.agentLandingLines = len(m.agentLines)
+		m.status = stRed.Render(glyphOnAir+" ") + stDim.Render("auto-tuned to ") + stKey.Render(o.Model) + stDim.Render(" · type to ask")
+		return m.drainPendingPrompts()
+	case pick != nil: // paid, logged in - the honest paid state (R1: never auto-spend)
+		m.clearFindingBeat()
+		m.noteOnce(stDim.Render("· ") + stDim.Render("no free band on air - ") + stKey.Render("[1]") + stDim.Render(" picks a paid band (the usual cost confirm applies)"))
+		m.agentLandingLines = len(m.agentLines)
+		m.status = stDim.Render("no free band on air · [1] to pick a paid band · esc exits")
+		m.flushPendingPrompts()
+	default: // nothing to land on - the honest empty state
+		m.clearFindingBeat()
+		anyOnline := false
+		for _, b := range m.bands {
+			if b.online && !b.isVoice() {
+				anyOnline = true
+				break
+			}
+		}
+		if anyOnline && !m.loggedInState() {
+			// Paid-only market, logged out: name the honest move (log in) without naming a
+			// band it cannot reach.
+			m.noteOnce(stDim.Render("· ") + stDim.Render("no free band on air - ") + stKey.Render("/login") + stDim.Render(", then ") + stKey.Render("[1]") + stDim.Render(" picks a paid band"))
+			m.status = stDim.Render("no free band on air · /login for paid bands · esc exits")
+		} else {
+			m.noteOnce(
+				stRed.Render("✕ ")+stEmber.Render("no station on air right now"),
+				hintTuneOrShare(m.narrow()))
+			m.status = stDim.Render("no station on air · [1] tune in · [2] go on air · esc exits")
+		}
+		m.agentLandingLines = len(m.agentLines)
+		m.flushPendingPrompts()
+	}
+	return nil
+}
+
+// drainPendingPrompts starts the first prompt parked while no model was tuned (now that
+// a free band is bound) and moves any others to the normal busy queue.
+func (m *model) drainPendingPrompts() tea.Cmd {
+	if len(m.agentPending) == 0 {
+		return nil
+	}
+	q := m.agentPending[0]
+	rest := m.agentPending[1:]
+	m.agentPending = nil
+	m.agentQueued = append(m.agentQueued, rest...)
+	// The prompt was already echoed at park time, so start the turn WITHOUT re-echoing.
+	nm, cmd := m.startParkedTurn(q)
+	*m = nm
+	return cmd
+}
+
+// flushPendingPrompts drops prompts parked while no model was tuned, when the auto-tune
+// found no free band to land on: a SINGLE deduped failureHint, never one per prompt.
+func (m *model) flushPendingPrompts() {
+	if len(m.agentPending) == 0 {
+		return
+	}
+	m.agentPending = nil
+	m.noteOnce(failureHint("no station on air - no model is tuned in", "", m.narrow())...)
+	m.agentLandingLines = len(m.agentLines)
+}
+
+// clearFindingBeat drops the "finding a band…" beat line the fresh AGENT landing shows
+// while an auto-tune is in flight, so the outcome replaces it in place (no stale beat).
+func (m *model) clearFindingBeat() {
+	if m.autoTuneBeatLen > 0 && m.autoTuneBeatLen <= len(m.agentLines) {
+		m.agentLines = m.agentLines[:m.autoTuneBeatLen]
+		if m.agentLandingLines > len(m.agentLines) {
+			m.agentLandingLines = len(m.agentLines)
+		}
+	}
+	m.autoTuneBeatLen = 0
 }
 
 // bandOverLimit reports whether a band's cheapest online station is over the

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6376,6 +6376,32 @@ func pickAutoBand(bands []band, loggedIn bool) *band {
 	return &top
 }
 
+// bestFreeStation returns the highest-signal ONLINE genuinely-free station in b (FreeNow, or
+// zero-priced: PriceIn==0 && PriceOut==0), or nil when the band carries none. It is the ONLY
+// station kind runAutoTune / the operator handoff may SILENTLY bind (R1: a $0 spend, no
+// confirm). It is DISTINCT from b.cheapest, which is the min-PRICE station across ALL of the
+// band's stations and can be a PAID station even in a band flagged free - a FreeNow promo
+// station carrying a nonzero nominal price sitting beside a cheaper paid one makes b.free true
+// while b.cheapest points at the paid station. Binding cheapest there would silently spend on
+// a paid station labelled "(free)" (the R1 money-safety trap); binding bestFreeStation cannot.
+// Deterministic: strongest signal wins, NodeID breaks a tie.
+func bestFreeStation(b band) *offer {
+	var best *offer
+	for i := range b.all {
+		o := &b.all[i]
+		if !o.Online {
+			continue
+		}
+		if !(o.FreeNow || (o.PriceIn == 0 && o.PriceOut == 0)) {
+			continue
+		}
+		if best == nil || o.Signal > best.Signal || (o.Signal == best.Signal && o.NodeID < best.NodeID) {
+			best = o
+		}
+	}
+	return best
+}
+
 // autoTuneMsg asks the model to run the auto-tune decision now (bands are already
 // scanned). The cold path fetches /discover first (fetchOffers -> offersMsg), whose
 // handler runs the decision when m.autoTuning is set.
@@ -6445,9 +6471,18 @@ func (m *model) runAutoTune() tea.Cmd {
 		return m.drainPendingPrompts()
 	}
 	pick := pickAutoBand(m.bands, m.loggedInState())
+	// R1 money-safety: bind the band's genuinely-FREE station (FreeNow / zero-priced), NEVER
+	// pick.cheapest - the min-PRICE station across ALL stations, which can be a PAID station
+	// even when the band is flagged free (a FreeNow promo beside a cheaper paid one). If no
+	// free station exists (a stale/mixed free flag, or only paid), fall to the honest paid
+	// state below - a silent bind is only ever a $0 station.
+	var freeSt *offer
+	if pick != nil {
+		freeSt = bestFreeStation(*pick)
+	}
 	switch {
-	case pick != nil && pick.free && pick.cheapest != nil:
-		o := *pick.cheapest
+	case freeSt != nil:
+		o := *freeSt
 		m.clearFindingBeat()
 		if _, err := m.bindChannel(o); err != nil {
 			// The local endpoint failed to bind: never claim a channel that is not there.
@@ -6472,7 +6507,8 @@ func (m *model) runAutoTune() tea.Cmd {
 		m.agentLandingLines = len(m.agentLines)
 		m.status = stRed.Render(glyphOnAir+" ") + stDim.Render("auto-tuned to ") + stKey.Render(o.Model) + stDim.Render(" · type to ask")
 		return m.drainPendingPrompts()
-	case pick != nil: // paid, logged in - the honest paid state (R1: never auto-spend)
+	case pick != nil: // a paid pick, OR a free-flagged band with no genuinely-free station -
+		// either way the honest paid state, never a silent spend (R1: never auto-spend)
 		m.clearFindingBeat()
 		m.noteOnce(stDim.Render("· ") + stDim.Render("no free band on air - ") + stKey.Render("[1]") + stDim.Render(" picks a paid band (the usual cost confirm applies)"))
 		m.agentLandingLines = len(m.agentLines)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6405,8 +6405,12 @@ func (m *model) runAutoTune() tea.Cmd {
 		m.bindChannel(o)
 		m.agent.model = o.Model
 		m.agentPicked = false
-		m.deskFocused = false
-		m.agentIn.Focus()
+		// Keep focus where it is: if the user is on the FOCUSED desk (a guest scan landed
+		// first), a silent auto-tune must not yank them to the ask box mid-pick. Otherwise
+		// the ask box takes focus so a turn can be typed straight away.
+		if !m.deskFocused {
+			m.agentIn.Focus()
+		}
 		m.noteOnce(stDim.Render("· ") + stDim.Render("auto-tuned to ") + stKey.Render(o.Model) + stDim.Render(" (free) · the agent runs on it"))
 		m.agentLandingLines = len(m.agentLines)
 		m.status = stRed.Render(glyphOnAir+" ") + stDim.Render("auto-tuned to ") + stKey.Render(o.Model) + stDim.Render(" · type to ask")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1482,7 +1482,11 @@ func (m model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// free band…" beat sits up until a later rescan. Disarm, splice out the beat, and
 		// note the honest unreachable state ONCE (noteOnce dedups), dropping any parked
 		// prompt silently - there is no band to send it to.
-		if m.autoTuning {
+		//
+		// Scope the disarm to broker-UNREACHABLE errors only (audit finding): a non-unreachable
+		// errMsg in the cold-fetch window (e.g. fetchBalance's errMsg("")) must NOT kill a tune
+		// whose /discover then succeeds - and must not wrongly note "couldn't reach the broker".
+		if m.autoTuning && strings.HasPrefix(string(msg), "broker unreachable") {
 			m.autoTuning = false
 			m.clearFindingBeat()
 			m.noteOnce(
@@ -6417,6 +6421,16 @@ func (m *model) runAutoTune() tea.Cmd {
 	if !m.autoTuning || m.agent == nil {
 		return nil
 	}
+	// The auto-tune is an AGENT-landing affordance. If the user has since LEFT AGENT (esc to
+	// BROWSE during the cold /discover fetch), its effects - binding a channel, stomping the
+	// status, firing a parked turn - must NOT land outside AGENT. Disarm and bail, dropping
+	// any parked prompt (there is no landing to send it to). Audit finding.
+	if m.mode != modeAgent {
+		m.autoTuning = false
+		m.clearFindingBeat()
+		m.flushPendingPrompts()
+		return nil
+	}
 	m.autoTuning = false
 	// A channel opened / a band deliberately tuned since we armed: never override it.
 	if m.connected != nil || m.resolveAgentModel() != "" {
@@ -6499,6 +6513,11 @@ func (m *model) drainPendingPrompts() tea.Cmd {
 	q := m.agentPending[0]
 	rest := m.agentPending[1:]
 	m.agentPending = nil
+	// The requeued prompts were ALREADY echoed at park time; mark them so submitAgentPrompt
+	// does not re-echo the "▸ …" ask line when the busy queue drains (audit finding).
+	for i := range rest {
+		rest[i].echoed = true
+	}
 	m.agentQueued = append(m.agentQueued, rest...)
 	// The prompt was already echoed at park time, so start the turn WITHOUT re-echoing.
 	nm, cmd := m.startParkedTurn(q)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6083,6 +6083,20 @@ func bandAgentReady(bd band) (ready, inferred bool) {
 	return false, false
 }
 
+// agentReadyTag is the agent-ready badge glyph for a band, or "" when it is not
+// agent-ready: "⌁" proven, "⌁~" inferred (R5, always inferred today). The ONE place the
+// ⌁ / inferred-~ shape is composed, shared by the band table + the /model picker tail.
+func agentReadyTag(bd band) string {
+	ready, inferred := bandAgentReady(bd)
+	if !ready {
+		return ""
+	}
+	if inferred {
+		return agentReadyGlyph() + "~"
+	}
+	return agentReadyGlyph()
+}
+
 // bandKnownSmall reports a band whose window is KNOWN and under the agent-ready floor -
 // the one partition auto-tune de-prioritises for a coding handoff (R6). Unknown (ctx 0)
 // is NOT known-small: it may well be a large model the broker sent without ctx metadata.
@@ -6106,11 +6120,7 @@ func plainBandBadge(bd band, limits *LimitStore, connected bool) string {
 	if bd.lineage > 0 {
 		parts = append(parts, fmt.Sprintf("◆ %d", bd.lineage))
 	}
-	if ready, inferred := bandAgentReady(bd); ready {
-		tag := agentReadyGlyph()
-		if inferred {
-			tag += "~"
-		}
+	if tag := agentReadyTag(bd); tag != "" {
 		parts = append(parts, tag)
 	}
 	if bd.vision {
@@ -6147,11 +6157,7 @@ func bandBadge(bd band, limits *LimitStore, connected bool) string {
 	}
 	// Agent-ready ⌁ (inferred ⌁~) - the coding-agent-capable mark, keyed like the ctx
 	// value it is derived from. Vision ◪ - a declared multimodal band.
-	if ready, inferred := bandAgentReady(bd); ready {
-		tag := agentReadyGlyph()
-		if inferred {
-			tag += "~"
-		}
+	if tag := agentReadyTag(bd); tag != "" {
 		parts = append(parts, stKey.Render(tag))
 	}
 	if bd.vision {
@@ -6324,11 +6330,15 @@ func pickAutoBand(bands []band, loggedIn bool) *band {
 	}
 	sort.SliceStable(cands, func(i, j int) bool {
 		bi, bj := cands[i], cands[j]
+		// FREE is the top-level key: only a free band is ever SILENTLY connected (R1), so a
+		// never-connectable paid band must NEVER outrank a connectable free one - even a
+		// known-small free one (else auto-tune would report "no free band" while a $0 band
+		// is on air). The agent-ready partition (R6) orders only WITHIN free (and within paid).
+		if bi.free != bj.free {
+			return bi.free
+		}
 		if si, sj := bandKnownSmall(bi), bandKnownSmall(bj); si != sj {
 			return !si // agent-ready (not known-small) first
-		}
-		if bi.free != bj.free {
-			return bi.free // free before paid
 		}
 		if bi.free {
 			if gi, gj := bandSignal(bi), bandSignal(bj); gi != gj {
@@ -6402,7 +6412,17 @@ func (m *model) runAutoTune() tea.Cmd {
 	case pick != nil && pick.free && pick.cheapest != nil:
 		o := *pick.cheapest
 		m.clearFindingBeat()
-		m.bindChannel(o)
+		if _, err := m.bindChannel(o); err != nil {
+			// The local endpoint failed to bind: never claim a channel that is not there.
+			// Fall to the honest empty state (deduped) and drop any parked prompt silently.
+			m.noteOnce(
+				stRed.Render("✕ ")+stEmber.Render("no station on air right now"),
+				hintTuneOrShare(m.narrow()))
+			m.agentLandingLines = len(m.agentLines)
+			m.status = stEmber.Render("! endpoint bind failed: " + err.Error())
+			m.flushPendingPrompts()
+			return nil
+		}
 		m.agent.model = o.Model
 		m.agentPicked = false
 		// Keep focus where it is: if the user is on the FOCUSED desk (a guest scan landed
@@ -6471,16 +6491,25 @@ func (m *model) flushPendingPrompts() {
 	m.agentPending = nil
 }
 
-// clearFindingBeat drops the "finding a band…" beat line the fresh AGENT landing shows
-// while an auto-tune is in flight, so the outcome replaces it in place (no stale beat).
+// clearFindingBeat splices out the single "finding a free band…" beat line the fresh
+// AGENT landing shows while an auto-tune is in flight, so the outcome replaces it in
+// place. It removes ONLY that one line (index autoTuneBeatLen), never the tail: a prompt
+// the user typed + parked while the auto-tune was in flight sits AFTER the beat, and must
+// survive to be drained (the review's echo-eating bug). A content guard keeps it from
+// deleting an unrelated line if the transcript shifted underneath it.
 func (m *model) clearFindingBeat() {
-	if m.autoTuneBeatLen > 0 && m.autoTuneBeatLen <= len(m.agentLines) {
-		m.agentLines = m.agentLines[:m.autoTuneBeatLen]
-		if m.agentLandingLines > len(m.agentLines) {
-			m.agentLandingLines = len(m.agentLines)
-		}
-	}
+	i := m.autoTuneBeatLen
 	m.autoTuneBeatLen = 0
+	if i <= 0 || i >= len(m.agentLines) {
+		return
+	}
+	if !strings.Contains(m.agentLines[i], "finding a free band") {
+		return
+	}
+	m.agentLines = append(m.agentLines[:i], m.agentLines[i+1:]...)
+	if m.agentLandingLines > len(m.agentLines) {
+		m.agentLandingLines = len(m.agentLines)
+	}
 }
 
 // bandOverLimit reports whether a band's cheapest online station is over the


### PR DESCRIPTION
Fixes the founder's live-test pain: [0] AGENT dropped into a dead ask box and spammed "no station on air". Now [0] auto-tunes a band and makes the operator picker the front door. Six asks, all delivered, spec-first.

## What ships (6 rulings, delegated defaults, overrulable)
- R1 auto-tune FREE bands only, silent $0; binds only a genuinely-free station (bestFreeStation); paid-only lands on the honest "no free band - [1] picks a paid band" - NEVER auto-spends
- R2 colored marquee brand plate for the SELECTED operator in the picker (hermes gold/aider green/opencode mono); list rows mono+red
- R3 [0] with nothing connected focuses THE DESK as a selectable picker (not the dead ask box); printable runes fall through to ask; Enter-on-DJ focuses ask; Enter-on-guest opens the plate
- R4/R5 capability badges: agent-ready (⌁, ~ = inferred from ctx>=16k until the tool-call probe lands), vision (◪ from declared capabilities), ASCII/NO_COLOR folds + legend
- R6 auto-tune prefers agent-ready bands, then iOS order (free by signal, cheapest paid)
- spam-kill: noteOnce dedupe; enterAgent/refreshAgentModel/submitAgentPrompt no longer append repeated no-station/no-channel/no-model lines

## Screens
Colored Artifact of all 8: https://claude.ai/code/artifact/0e635a1a-7103-4e89-a5f3-6f1d04b3f79e

## Verification
- 293 godog scenarios (strict) green; cover-gate PASS (total 92.3%, every pkg >=90%); go vet, -race clean; merged with current main (enrichment #28)
- Iterated through the pre-push audit: caught and fixed a MAJOR R1 money-safety bug (auto-tune could silently bind a paid station on a mixed free/paid band) + a lifecycle round (/clear resurrection, focus-steal, double-echo) - all spec-first with regression tests
- Final gate: PASS

## Known minor follow-ups (non-blocking, from the passing audit)
- operator.go:611 pre-bind gate checks band-level ctx not the bound station's own window (bind-then-refuse edge on a mixed-ctx band)
- operator.go:152 deskFocused not cleared when a re-scan drops guests to zero
- 3 cosmetic copy/status nits (status precedence, "only free band" plural, beat-prefix inconsistency)