### PR TITLE
Fix 5 residuals from the AGENT redesign audit (2 bugs + 3 cosmetic)

### DIFF
--- a/features/operator/auto_tune.feature
+++ b/features/operator/auto_tune.feature
@@ -138,6 +138,26 @@ Feature: The AGENT [0] silent auto-tune (pickAutoBand + runAutoTune)
     And the transcript no longer shows "leftover ask"
     And the auto-tune did not arm
 
+  # ── the handoff auto-tune binds the BOUND station's window, never the band's best ──
+  #
+  # Finding (2026-07-08): startOperatorHandoff's pre-bind gate read the BAND ctx (the MAX
+  # window across the band's stations) but then bound bestFreeStation - a SPECIFIC station.
+  # A free 8k station beside a paid 32k sibling: the band ctx (32k) cleared the pre-bind
+  # gate, the free 8k station was bound, and the §6 floor then refused it POST-bind - the
+  # bind-then-refuse state finding #6 was meant to kill. The gate must read the station it
+  # is about to bind: a free station is bound only when ITS OWN window clears the 16k floor,
+  # else an honest refusal with NO bind.
+  Scenario: A free small station beside a paid large sibling is refused WITHOUT binding
+    Given an AGENT session with a tuned band "qwen3-32b-fp8" and a live proxy holder
+    And a detected guest "opencode"
+    And the proxy holder is disconnected
+    And the only free band pairs a free 8k station with a paid 32k sibling
+    When the user runs "/operator opencode"
+    Then no channel is open
+    And the transcript does not show "auto-tuned to"
+    And the transcript notes "no agent-ready free band on air"
+    And no child process is launched
+
   # ── sticky + no-op ───────────────────────────────────────────────────────────
 
   Scenario: Sticky — a last-tuned band still on air is reused, not re-picked

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -218,11 +218,12 @@ func (m model) enterAgent() (tea.Model, tea.Cmd) {
 		m.refreshAgentModel()
 	}
 	m.agentIn.Focus()
-	// Set the generic "AGENT ready" only when a model IS tuned in: otherwise preserve the
-	// more-specific "no model tuned in" status (refreshAgentModel sets it on re-entry; set
-	// it here too for the fresh no-model landing) instead of clobbering it (finding
-	// 2026-07-08).
-	if m.agent.model != "" {
+	// Set the generic "AGENT ready" only when a model IS tuned in (or a silent auto-tune is
+	// in flight finding one): otherwise preserve the more-specific "no model tuned in" status
+	// (refreshAgentModel sets it on re-entry; set it here too for the fresh no-model landing)
+	// instead of clobbering it (finding 2026-07-08). The autoTuning guard keeps the status
+	// from contradicting the still-up "finding a free band…" beat on a re-entry mid-tune.
+	if m.agent.model != "" || m.autoTuning {
 		m.status = stDim.Render("AGENT ready · esc exits")
 	} else {
 		m.status = agentNoModelStatus()

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -191,7 +191,7 @@ func (m model) enterAgent() (tea.Model, tea.Cmd) {
 				stDim.Render("· ")+stDim.Render("AGENT ready · dj.md persona · session-only (no memory)"))
 			m.autoTuneBeatLen = len(m.agentLines) // the beat below is swapped for the outcome
 			m.agentLines = append(m.agentLines,
-				stDim.Render("· ")+stDim.Render("finding a free band…"))
+				agentFindingBandBeat())
 			m.agentLandingLines = len(m.agentLines)
 			m.autoTuning = true
 			m.agentIn.Focus()
@@ -218,7 +218,15 @@ func (m model) enterAgent() (tea.Model, tea.Cmd) {
 		m.refreshAgentModel()
 	}
 	m.agentIn.Focus()
-	m.status = stDim.Render("AGENT ready · esc exits")
+	// Set the generic "AGENT ready" only when a model IS tuned in: otherwise preserve the
+	// more-specific "no model tuned in" status (refreshAgentModel sets it on re-entry; set
+	// it here too for the fresh no-model landing) instead of clobbering it (finding
+	// 2026-07-08).
+	if m.agent.model != "" {
+		m.status = stDim.Render("AGENT ready · esc exits")
+	} else {
+		m.status = agentNoModelStatus()
+	}
 	// Async desk scan (Guest Operators): LookPath + bounded version probes off the event
 	// loop, landing as operatorDetectedMsg - the same pattern as onSharesDetected.
 	return m, tea.Batch(textinput.Blink, operatorScanCmd())
@@ -252,8 +260,22 @@ func (m *model) refreshAgentModel() {
 		// No model resolves - a STATUS note, not a transcript line, so re-entries / turns
 		// never stack "no model tuned in" (founder spam regression). The actual failure,
 		// if the user sends a turn anyway, still surfaces once via the deduped failureHint.
-		m.status = stRed.Render("✕ ") + stEmber.Render("no model tuned in") + stDim.Render(" · [1] tune in · [2] go on air")
+		m.status = agentNoModelStatus()
 	}
+}
+
+// agentNoModelStatus is the status line shown when the AGENT has no model tuned in - the
+// ONE place that copy lives, so refreshAgentModel and enterAgent never drift (enterAgent
+// used to clobber a fresh no-model status with the generic "AGENT ready" on re-entry).
+func agentNoModelStatus() string {
+	return stRed.Render("✕ ") + stEmber.Render("no model tuned in") + stDim.Render(" · [1] tune in · [2] go on air")
+}
+
+// agentFindingBandBeat is the single "finding a free band…" transcript beat, shared by
+// enterAgent's fresh landing and submitAgentPrompt's park path so the prefix never drifts
+// (finding 2026-07-08: enterAgent used "· ", submitAgentPrompt used the on-air glyph).
+func agentFindingBandBeat() string {
+	return stDim.Render("· ") + stDim.Render("finding a free band…")
 }
 
 // pickAgentModel re-points the agent at the chosen model and notes the switch. It sets
@@ -686,7 +708,7 @@ func (m model) submitAgentPrompt(q queuedPrompt) (model, tea.Cmd) {
 		if !m.autoTuning {
 			m.autoTuning = true
 			m.autoTuneBeatLen = len(m.agentLines)
-			m.agentLines = append(m.agentLines, stDim.Render(glyphOnAir+" ")+stDim.Render("finding a free band…"))
+			m.agentLines = append(m.agentLines, agentFindingBandBeat())
 			return m, autoTuneCmd(m.broker, m.scanned)
 		}
 		return m, nil

--- a/internal/tui/agent_lifecycle_regression_test.go
+++ b/internal/tui/agent_lifecycle_regression_test.go
@@ -268,6 +268,25 @@ func TestReentryPreservesNoModelStatus(t *testing.T) {
 	}
 }
 
+// TestReentryDuringAutoTuneKeepsReadyStatus: a silent auto-tune in flight (no model bound
+// YET) must NOT flip the re-entry status to "no model tuned in" - that would contradict the
+// still-up "finding a free band…" beat. While autoTuning, the status stays "AGENT ready".
+func TestReentryDuringAutoTuneKeepsReadyStatus(t *testing.T) {
+	m := freshDeskAgent(t, nil)
+	m.connected = nil
+	m.lastConnected = nil
+	m.autoTuning = true // a cold auto-tune is finding a band
+
+	nm, _ := m.enterAgent()
+	status := stripANSI(asModel(nm).status)
+	if !strings.Contains(status, "AGENT ready") {
+		t.Fatalf("re-entry mid-auto-tune should keep the AGENT ready status, got %q", status)
+	}
+	if strings.Contains(status, "no model tuned in") {
+		t.Fatalf("re-entry mid-auto-tune must not show the no-model status (contradicts the finding-a-band beat): %q", status)
+	}
+}
+
 // TestFindingBandBeatPrefixConsistent: finding (2026-07-08, cosmetic). The "finding a free
 // band…" beat used a "· " prefix in enterAgent but glyphOnAir in submitAgentPrompt. Pin ONE
 // prefix at both sites so the transcript reads consistently.

--- a/internal/tui/agent_lifecycle_regression_test.go
+++ b/internal/tui/agent_lifecycle_regression_test.go
@@ -12,6 +12,17 @@ package tui
 //   #6 (minor) the handoff auto-tune bound a KNOWN-small free band and only THEN refused
 //      at the §6 gate, leaving the user silently tuned to a band too small for a guest.
 //
+// AGENT redesign residuals (2026-07-08):
+//   - the handoff pre-bind gate read the BAND ctx (max across stations) but bound a SPECIFIC
+//     free station: a free 8k station beside a paid 32k sibling was bound then refused
+//     post-bind (the mixed-band twin of #6). Pinned as a godog scenario in auto_tune.feature.
+//   - a re-scan to ZERO guests while THE DESK was focused left an invisible focused desk that
+//     swallowed arrows/enter (TestDeskFocusClearsWhenGuestsVanish).
+//   - re-entry clobbered refreshAgentModel's "no model tuned in" status with "AGENT ready"
+//     (TestReentryPreservesNoModelStatus).
+//   - the "finding a free band…" beat prefix differed between the two sites that emit it
+//     (TestFindingBandBeatPrefixConsistent).
+//
 // Candidates for promotion into the approved .feature set at the next founder review
 // (findings #1, #2, #4 are pinned as godog scenarios in features/operator/*.feature).
 
@@ -205,5 +216,87 @@ func TestHandoffRefusesKnownSmallFreeBandWithoutBinding(t *testing.T) {
 	body := stripANSI(strings.Join(got.agentLines, "\n"))
 	if !strings.Contains(body, "16k") && !strings.Contains(strings.ToLower(body), "too small") {
 		t.Fatalf("the transcript must carry an honest 'no agent-ready band' refusal:\n%s", body)
+	}
+}
+
+// TestDeskFocusClearsWhenGuestsVanish: finding (2026-07-08). A re-scan that shrinks
+// deskGuests to ZERO while THE DESK is focused left deskFocused=true over an EMPTY roster
+// (deskRosterBlock renders nothing at zero guests) - an INVISIBLE focused desk that
+// swallowed arrows/enter. onOperatorDetected must clear deskFocused (and reset the cursor)
+// when the new guest set is empty, so keys reach the ask box again.
+func TestDeskFocusClearsWhenGuestsVanish(t *testing.T) {
+	oc, err := registryGuest("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := freshDeskAgent(t, []offer{freeOffer("gpt-oss-20b", 32768)})
+	m.operatorDetections = []operator.Detection{{Guest: oc, Path: "/fake/opencode", Version: oc.KnownGood}}
+	m.deskFocused = true
+	m.deskCursor = 1 // parked on the guest row
+
+	// A re-scan lands ZERO guests (the guest quit / dropped off PATH).
+	nm, _ := m.onOperatorDetected(operatorDetectedMsg{ds: nil})
+	got := asModel(nm)
+	if got.deskFocused {
+		t.Fatalf("deskFocused must clear when the guest set empties - an invisible focused desk swallows arrows/enter")
+	}
+	if got.deskCursor != 0 {
+		t.Fatalf("deskCursor should reset to 0 when the desk defocuses, got %d", got.deskCursor)
+	}
+}
+
+// TestReentryPreservesNoModelStatus: finding (2026-07-08, cosmetic). On RE-ENTRY with no
+// model resolving, refreshAgentModel sets the specific "no model tuned in" status; enterAgent
+// then unconditionally overwrote it with the generic "AGENT ready", making the status wrong.
+// The specific no-model status must survive re-entry.
+func TestReentryPreservesNoModelStatus(t *testing.T) {
+	m := freshDeskAgent(t, nil)
+	// A session that HAD a model but no longer resolves one (the band dropped, nothing
+	// sticky): agent.model set, but connected/lastConnected nil so resolveAgentModel()=="".
+	m.agent.model = "gpt-oss-20b"
+	m.connected = nil
+	m.lastConnected = nil
+	m.autoTuning = false
+
+	nm, _ := m.enterAgent()
+	status := stripANSI(asModel(nm).status)
+	if !strings.Contains(status, "no model tuned in") {
+		t.Fatalf("re-entry must preserve the specific no-model status refreshAgentModel set, got %q", status)
+	}
+	if strings.Contains(status, "AGENT ready") {
+		t.Fatalf("re-entry clobbered the no-model status with the generic AGENT ready: %q", status)
+	}
+}
+
+// TestFindingBandBeatPrefixConsistent: finding (2026-07-08, cosmetic). The "finding a free
+// band…" beat used a "· " prefix in enterAgent but glyphOnAir in submitAgentPrompt. Pin ONE
+// prefix at both sites so the transcript reads consistently.
+func TestFindingBandBeatPrefixConsistent(t *testing.T) {
+	beatLine := func(lines []string) string {
+		for _, ln := range lines {
+			if strings.Contains(stripANSI(ln), "finding a free band") {
+				return ln
+			}
+		}
+		return ""
+	}
+	// enterAgent's fresh-landing beat.
+	m1 := freshDeskAgent(t, []offer{freeOffer("gpt-oss-20b", 32768)})
+	enterBeat := beatLine(m1.agentLines)
+	// submitAgentPrompt's park-path beat (no model tuned -> park + auto-tune beat). Clear the
+	// transcript + re-arm so the ONLY beat present is the one submitAgentPrompt emits (else
+	// beatLine would find the enter beat freshDeskAgent already appended).
+	m2 := freshDeskAgent(t, []offer{freeOffer("gpt-oss-20b", 32768)})
+	m2.agentLines = nil
+	m2.autoTuning = false
+	tm, _ := m2.submitAgentPrompt(queuedPrompt{text: "hello"})
+	submitBeat := beatLine(asModel(tm).agentLines)
+
+	if enterBeat == "" || submitBeat == "" {
+		t.Fatalf("both sites must emit the finding-a-band beat: enter=%q submit=%q", enterBeat, submitBeat)
+	}
+	if enterBeat != submitBeat {
+		t.Fatalf("the finding-a-band beat prefix differs between enterAgent and submitAgentPrompt:\n enter=%q\nsubmit=%q",
+			stripANSI(enterBeat), stripANSI(submitBeat))
 	}
 }

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -153,11 +153,20 @@ func (m model) onOperatorDetected(msg operatorDetectedMsg) (tea.Model, tea.Cmd) 
 	// the new row range so the carat/marquee never vanish off the end until the user presses
 	// up (audit finding). deskRowCount reads the freshly-set detections.
 	if m.deskFocused {
-		if max := m.deskRowCount() - 1; m.deskCursor > max {
-			m.deskCursor = max
-		}
-		if m.deskCursor < 0 {
+		if len(deskGuests(m.operatorDetections)) == 0 {
+			// The guest set emptied while THE DESK had focus: the roster renders NOTHING at
+			// zero guests (deskRosterBlock), so a still-focused desk would be invisible and
+			// swallow arrows/enter (finding 2026-07-08). Hand focus back to the ask box.
+			m.deskFocused = false
 			m.deskCursor = 0
+			m.agentIn.Focus()
+		} else {
+			if max := m.deskRowCount() - 1; m.deskCursor > max {
+				m.deskCursor = max
+			}
+			if m.deskCursor < 0 {
+				m.deskCursor = 0
+			}
 		}
 	}
 	if m.operatorPicker {
@@ -603,14 +612,17 @@ func (m model) startOperatorHandoff(d operator.Detection, fromPicker bool) (tea.
 				stDim.Render("· ")+stDim.Render("tune in first: press ")+stKey.Render("[1]")+stDim.Render(", ⏎ on a band opens the channel · then come back with ")+stKey.Render("[0]"))
 			return m, nil
 		}
-		// Require an agent-ready pick BEFORE binding (audit finding): pickAutoBand returns
-		// the strongest CONNECTABLE free band even when it is KNOWN-small, so binding here
-		// and only THEN hitting the §6 gate below would leave the user silently tuned to a
-		// band too small for a guest. If the only free band is known-small, land on the
-		// honest 'no agent-ready band' refusal WITHOUT binding.
-		if bandKnownSmall(*pick) {
+		// Gate on the STATION we are about to bind, not the band (finding 2026-07-08):
+		// bandCtx is the MAX window across a band's stations, so a free 8k station beside a
+		// paid 32k sibling cleared a band-level gate, got bound, then hit the §6 floor
+		// POST-bind - the bind-then-refuse state finding #6 was meant to kill. Bind a free
+		// station only when ITS OWN window clears the 16k floor; an unknown window (ctx 0)
+		// stays connectable (G2: it warns on the plate, never blocks). Else land the honest
+		// refusal WITHOUT binding. (The copy stays correct with multiple known-small free
+		// bands on air - it names no "only" band.)
+		if freeSt.Ctx > 0 && freeSt.Ctx < operatorCtxFloor {
 			m.agentLines = append(m.agentLines,
-				stRed.Render("✕ ")+stEmber.Render("no agent-ready band to patch into - the only free band's window is too small for a guest (needs 16k+)"),
+				stRed.Render("✕ ")+stEmber.Render("no agent-ready free band on air - the free channel's window is too small for a guest (needs 16k+)"),
 				stDim.Render("· ")+stDim.Render("tune in to a larger band with ")+stKey.Render("[1]")+stDim.Render(", then hand off again with ")+stKey.Render("/operator"))
 			return m, nil
 		}

--- a/internal/tui/operator_steps_desk_entry_test.go
+++ b/internal/tui/operator_steps_desk_entry_test.go
@@ -285,6 +285,23 @@ func (s *opBDD) noCostConfirmShown() error {
 	}
 	return nil
 }
+// onlyFreeBandSmallBesidePaidLarge seeds the model's market with a SINGLE band whose free
+// station has an 8k window and whose paid sibling has a 32k window - the mixed band the
+// handoff auto-tune must NOT bind the 8k free station onto (finding 2026-07-08). The band
+// ctx is 32k (the max), so a band-level known-small gate is fooled; the fix reads the
+// station it is about to bind.
+func (s *opBDD) onlyFreeBandSmallBesidePaidLarge() error {
+	s.mutate(func(m *model) {
+		m.offers = []offer{
+			{NodeID: "FREE-8K", Model: "handoff-mix", Online: true, FreeNow: true, Signal: 80, Ctx: 8192},
+			{NodeID: "PAID-32K", Model: "handoff-mix", Online: true, PriceIn: 0.15, PriceOut: 0.30, PriceTier: 1, Signal: 70, Ctx: 32768},
+		}
+		m.lastConnected = nil
+		m.bands = groupBands(m.offers, m.limits)
+	})
+	return nil
+}
+
 func (s *opBDD) boundStationIsGenuinelyFree() error {
 	c := s.model().connected
 	if c == nil {
@@ -369,6 +386,7 @@ func initializeDeskEntryScenarios(st *opBDD, sc *godog.ScenarioContext) {
 	sc.Step(`^a fresh AGENT session with a band mixing a free station and a cheaper paid station$`, st.freshMixedFreeAndCheaperPaid)
 	sc.Step(`^a fresh AGENT session with a free-flagged band whose stations are all paid$`, st.staleFreeFlaggedAllPaid)
 	sc.Step(`^the bound station is genuinely free$`, st.boundStationIsGenuinelyFree)
+	sc.Step(`^the only free band pairs a free 8k station with a paid 32k sibling$`, st.onlyFreeBandSmallBesidePaidLarge)
 	sc.Step(`^an AGENT session whose last band "([^"]*)" is still on air$`, st.lastBandStillOnAir)
 	sc.Step(`^the desk scan lands guest "([^"]*)"$`, st.deskScanLandsGuest)
 	sc.Step(`^the desk scan lands no guests$`, st.deskScanLandsNoGuests)


### PR DESCRIPTION
Fixes the 5 residual findings from the AGENT [0] entry redesign's passing audit (#30) - two real minor bugs (spec-first, RED then GREEN) and three cosmetic drifts. Build-and-hold; no behavior outside these findings changed.

## The 5 findings

**1. [BUG] handoff pre-bind gate read the BAND window, not the bound station's**
`startOperatorHandoff`'s pre-bind gate checked `bandKnownSmall` (which reads `bandCtx` - the MAX window across a band's stations) but then bound `bestFreeStation` - a *specific* station. A free 8k station beside a paid 32k sibling cleared the band-level gate, got bound, then hit the §6 floor **post-bind** - the bind-then-refuse state finding #6 was meant to eliminate. Now gates on the station about to be bound: `freeSt.Ctx > 0 && freeSt.Ctx < operatorCtxFloor`, so a free station is bound only when its **own** window clears 16k, else an honest refusal with no bind.
Pinned as a godog scenario in `features/operator/auto_tune.feature`.

**2. [BUG] a re-scan to zero guests left an invisible focused desk**
When a re-scan shrank `deskGuests` to zero while THE DESK was focused, `deskFocused` stayed true over an empty roster (`deskRosterBlock` renders nothing at zero guests) - an invisible desk that swallowed arrows/enter (enter self-healed). `onOperatorDetected` now clears `deskFocused`, resets the cursor, and refocuses the ask box when the guest set empties.
Pinned by `TestDeskFocusClearsWhenGuestsVanish`.

**3. [cosmetic] re-entry clobbered the "no model tuned in" status**
Re-entry unconditionally set "AGENT ready", overwriting `refreshAgentModel`'s more-specific "no model tuned in" status. Now "AGENT ready" is set only when a model is tuned (or an auto-tune is in flight); the copy lives in one shared helper so the two sites cannot drift.
Pinned by `TestReentryPreservesNoModelStatus` + `TestReentryDuringAutoTuneKeepsReadyStatus`.

**4. [cosmetic] refusal copy said "the only free band"**
Wrong when multiple known-small free bands are on air. Reworded to "no agent-ready free band on air" (no "only"). Asserted by the finding #1 scenario.

**5. [cosmetic] the "finding a free band…" beat prefix differed**
`enterAgent` used "· ", `submitAgentPrompt` used the on-air glyph. Unified via one shared helper.
Pinned by `TestFindingBandBeatPrefixConsistent`.

## Verification
- RED then GREEN captured for the two bugs (finding #1 godog scenario, finding #2 test).
- `go build ./...` and `go vet ./...` clean.
- `go test ./internal/tui ./internal/operator` green (godog strict), `-race ./internal/tui` green.
- `make cover-gate` PASS - every package >=90%, module total 92.3% (internal/tui 92.4%, internal/operator 93.8%).
- Pre-push claude-audit gate: PASS (high confidence) on both pushes. One follow-up commit addresses a new cosmetic status contradiction the first audit surfaced. The only remaining flag is a pre-existing `freqResolvedMsg` mode-yank, out of scope here.

No R1-R6 or existing scenario weakened.