### PR TITLE
cli: render RC status frames in the `roger remote` viewer

### DIFF
--- a/cmd/rogerai/remote.go
+++ b/cmd/rogerai/remote.go
@@ -154,6 +154,14 @@ func remoteAttach(cfg config, code string) error {
 				v = "approved"
 			}
 			fmt.Printf("  ✓ %s from %s\n", v, f.Origin)
+		case protocol.RCKindStatus:
+			// A guest-operator handoff (or the DJ-back return): render it so the CLI viewer
+			// never sees the stream go dead mid-handoff, matching the TUI + web console. The
+			// ONE shared formatter keeps the copy from drifting; "◉" is the CLI's on-air glyph
+			// (as on tool_call). Content-blind: only operator/model/spend + the fixed text.
+			if line := client.OperatorStatusLine(f, "◉"); strings.TrimSpace(line) != "" {
+				fmt.Printf("%s\n", line)
+			}
 		case protocol.RCKindBackfill:
 			if strings.TrimSpace(f.Text) != "" {
 				fmt.Printf("%s\n─── (live from here) ───\n", f.Text)

--- a/cmd/rogerai/remote_test.go
+++ b/cmd/rogerai/remote_test.go
@@ -316,6 +316,11 @@ func TestRemoteAttachNarratesEveryFrameKind(t *testing.T) {
 		sseFrame(w, protocol.RCFrame{Kind: protocol.RCKindConfirmReq, Tool: "Edit", ConfirmID: "cf1"})
 		sseFrame(w, protocol.RCFrame{Kind: protocol.RCKindConfirmDone, Approve: &approve, Origin: "web"})
 		sseFrame(w, protocol.RCFrame{Kind: protocol.RCKindConfirmDone, Approve: &deny, Origin: "cli"})
+		// A guest-operator handoff (enriched) then the DJ-back return: the CLI viewer must
+		// narrate both (it used to DROP every status frame, so a handoff looked dead).
+		sseFrame(w, protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "opencode", Model: "gpt-oss-120b", Spend: 0.19, Text: "guest has the mic: opencode - the DJ answers when the handoff ends"})
+		sseFrame(w, protocol.RCFrame{Kind: protocol.RCKindStatus, Text: "the DJ is back at the desk"})
+		sseFrame(w, protocol.RCFrame{Kind: protocol.RCKindStatus}) // neither operator nor text: skipped
 		sseFrame(w, protocol.RCFrame{Kind: protocol.RCKindBackfill, Text: "earlier transcript"})
 		sseFrame(w, protocol.RCFrame{Kind: protocol.RCKindBackfill, Text: ""}) // blank: skipped
 		sseFrame(w, protocol.RCFrame{Kind: protocol.RCKindError, Text: "boom"})
@@ -339,6 +344,8 @@ func TestRemoteAttachNarratesEveryFrameKind(t *testing.T) {
 		"? Edit — type 'y' to approve",
 		"✓ approved from web",
 		"✓ denied from cli",
+		"◉ opencode has the mic on gpt-oss-120b · $0.19",
+		"the DJ is back at the desk",
 		"earlier transcript",
 		"(live from here)",
 		"✕ boom",

--- a/internal/client/rc.go
+++ b/internal/client/rc.go
@@ -394,6 +394,33 @@ func OperatorStatusFrame(operator, model string, spend float64) protocol.RCFrame
 	}
 }
 
+// OperatorStatusLine renders one RCKindStatus frame as the SINGLE piecewise-degrading
+// viewer line shared by every Go surface - the TUI transcript (onRemoteFrame) and the
+// `roger remote` CLI viewer (StreamRC) - so the "<op> has the mic on <model> · $<spend>"
+// copy can never drift between them (the web console mirrors it in web/src/js/private.js).
+// It is content-blind: only the operator name plus the additive Model/Spend metadata ever
+// ride the line, never guest content, and the enrichment stays out of the frame Text (which
+// carries the fixed handoff sentence). glyph is the surface's own on-air marker, prefixed to
+// a guest handoff; the DJ-back (and any operator-less) frame renders its plain Text with no
+// glyph. An empty return means "render nothing" (a status carrying neither operator nor text)
+// - callers guard with strings.TrimSpace(line) != "" exactly as the web frameLine does.
+func OperatorStatusLine(f protocol.RCFrame, glyph string) string {
+	if f.Operator == "" {
+		return f.Text
+	}
+	line := glyph + " guest has the mic: " + f.Operator
+	if f.Model != "" || f.Spend > 0 {
+		line = glyph + " " + f.Operator + " has the mic"
+		if f.Model != "" {
+			line += " on " + f.Model
+		}
+		if f.Spend > 0 {
+			line += " · " + fmt.Sprintf("$%.2f", f.Spend)
+		}
+	}
+	return line
+}
+
 // SessionID reports the bridge's session id (for the roster / disable).
 func (rb *RCBridge) SessionID() string { return rb.sessionID }
 

--- a/internal/client/rc_statusline_test.go
+++ b/internal/client/rc_statusline_test.go
@@ -1,0 +1,77 @@
+package client
+
+// rc_statusline_test.go pins OperatorStatusLine, the ONE Go formatter that renders an
+// RCKindStatus frame as the piecewise-degrading viewer line shared by every Go surface
+// (the TUI transcript and the `roger remote` CLI viewer), so the "<op> has the mic on
+// <model> · $<spend>" copy can never drift between them (the web console mirrors it in
+// private.js). It is content-blind: only the operator name plus the additive Model/Spend
+// metadata ever ride the line - never guest content.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// TestOperatorStatusLine pins the exact piecewise-degrade copy for every permutation:
+// enriched (model+spend), model-only (drops the money), spend-only (drops the on-clause),
+// bare operator (the short handoff line, never the frame's full sentence), the DJ-back /
+// operator-less plain-text return, and the empty "render nothing" frame.
+func TestOperatorStatusLine(t *testing.T) {
+	const glyph = "◉"
+	cases := []struct {
+		name string
+		f    protocol.RCFrame
+		want string
+	}{
+		{
+			"enriched with model and spend",
+			protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "opencode", Model: "gpt-oss-120b", Spend: 0.19, Text: "guest has the mic: opencode - the DJ answers when the handoff ends"},
+			glyph + " opencode has the mic on gpt-oss-120b · $0.19",
+		},
+		{
+			"model only drops the money",
+			protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "opencode", Model: "gpt-oss-120b"},
+			glyph + " opencode has the mic on gpt-oss-120b",
+		},
+		{
+			"spend only drops the on-clause",
+			protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "aider", Spend: 1.05},
+			glyph + " aider has the mic · $1.05",
+		},
+		{
+			"bare operator is the short handoff line",
+			protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "opencode", Text: "guest has the mic: opencode - the DJ answers when the handoff ends"},
+			glyph + " guest has the mic: opencode",
+		},
+		{
+			"DJ back is the plain text, no glyph",
+			protocol.RCFrame{Kind: protocol.RCKindStatus, Text: "the DJ is back at the desk"},
+			"the DJ is back at the desk",
+		},
+		{
+			"neither operator nor text renders nothing",
+			protocol.RCFrame{Kind: protocol.RCKindStatus},
+			"",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := OperatorStatusLine(tc.f, glyph); got != tc.want {
+				t.Errorf("OperatorStatusLine = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOperatorStatusLineContentBlind pins that the guest's spoken content never leaks into
+// the line: an operator frame renders only the operator/model/spend, never the frame Text's
+// full sentence tail ("answers when the handoff ends").
+func TestOperatorStatusLineContentBlind(t *testing.T) {
+	f := protocol.RCFrame{Kind: protocol.RCKindStatus, Operator: "opencode", Model: "gpt-oss-120b", Spend: 0.19, Text: "guest has the mic: opencode - secret plan the guest typed"}
+	got := OperatorStatusLine(f, "◉")
+	if strings.Contains(got, "secret plan") || strings.Contains(got, "handoff") || strings.Contains(got, "answers") {
+		t.Errorf("the line must be content-blind, got %q", got)
+	}
+}

--- a/internal/tui/rc.go
+++ b/internal/tui/rc.go
@@ -635,24 +635,12 @@ func (m model) onRemoteFrame(msg remoteFrameMsg) (tea.Model, tea.Cmd) {
 	case protocol.RCKindStatus:
 		// A guest-operator handoff (or the DJ-back return) - render it so the viewer never
 		// sees the stream go dead mid-handoff. Operator-aware + content-blind: only the guest
-		// name plus the model/spend metadata ride the frame, matching the web console.
-		// Enriched copy (founder ruling 3): "<op> has the mic on <model> · $<spend>",
-		// degrading piecewise - no model drops "on <model>", zero spend drops "· $",
-		// neither degrades to the pre-enrichment line (an old host's frames).
-		line := f.Text
-		if f.Operator != "" {
-			line = glyphOnAir + " guest has the mic: " + f.Operator
-			if f.Model != "" || f.Spend > 0 {
-				line = glyphOnAir + " " + f.Operator + " has the mic"
-				if f.Model != "" {
-					line += " on " + f.Model
-				}
-				if f.Spend > 0 {
-					line += " · " + fmt.Sprintf("$%.2f", f.Spend)
-				}
-			}
-		}
-		if strings.TrimSpace(line) != "" {
+		// name plus the model/spend metadata ride the frame, matching the web console. The ONE
+		// shared client.OperatorStatusLine formatter keeps this copy from drifting between the
+		// TUI, the `roger remote` CLI, and (mirrored) the web console - the enriched piecewise
+		// line "<op> has the mic on <model> · $<spend>" degrading to the bare handoff line, then
+		// the plain DJ-back text. glyphOnAir is this surface's on-air marker.
+		if line := client.OperatorStatusLine(f, glyphOnAir); strings.TrimSpace(line) != "" {
 			m.rsLines = append(m.rsLines, stDim.Render(line))
 		}
 	case protocol.RCKindBackfill:


### PR DESCRIPTION
## What

The `roger remote` CLI viewer silently dropped every remote-control **status** frame, so during a guest-operator handoff it showed nothing while the TUI and web console both narrate `<op> has the mic` / `the DJ is back at the desk`. Its `StreamRC` switch had cases for user/assistant/final/tool_call/tool_result/confirm_req/confirm_done/backfill/error/ended but **no `RCKindStatus` case** (and no default), so handoff and DJ-back frames were eaten.

## Fix

- Extract the piecewise-degrade copy into **one shared formatter**, `client.OperatorStatusLine(frame, glyph)`, and reuse it from **both** Go viewers - the TUI transcript (`internal/tui/rc.go`) and the CLI (`cmd/rogerai/remote.go`) - so the wording can never drift between surfaces (the web console mirrors it in `web/src/js/private.js`).
- The CLI now renders the enriched `◉ <op> has the mic on <model> · $<spend>` line, degrading piecewise (no model drops `on <model>`, zero spend drops `· $<spend>`) to the bare `◉ guest has the mic: <op>` handoff line, then the plain `the DJ is back at the desk` text. A status carrying neither operator nor text renders nothing.
- **Content-blind:** only operator/model/spend plus the fixed handoff text ever reach the line - never guest content.

## Tests

- `TestOperatorStatusLine` (+ `TestOperatorStatusLineContentBlind`) pin every permutation of the shared formatter (enriched, model-only, spend-only, bare operator, DJ-back plain text, empty -> render nothing, content-blindness).
- The CLI narration test (`TestRemoteAttachNarratesEveryFrameKind`) now asserts the enriched handoff line and the DJ-back line render, and an empty status frame is skipped.
- The TUI refactor is a behavior-identical extraction; its existing `base_station_test.go` status table still passes.

## Verify

- `go build ./...`, `go vet` clean.
- `go test ./cmd/rogerai ./internal/client ./internal/tui` pass.
- `make cover-gate` **PASS** - every package >=90% (cmd/rogerai 91.9%, internal/client 95.7%, internal/tui 92.4%), module total 92.3%.
- Pre-push claude-audit: **PASS** (high confidence, 0 blocking findings).
