### PR TITLE
Tool-call capability probe: verified agent-ready (BUILD-AND-HOLD)

### DIFF
--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -105,6 +105,10 @@ type broker struct {
 	// the next sync so a peer never surfaces a retracted verdict. Guarded by metricsMu. Single-
 	// instance leaves it unused (emission reads b.toolsOK directly). Keyed by toolKey(node,model).
 	toolsMerged map[string]bool
+	// lastToolMark throttles the served-traffic refresh of a verified model's shared field
+	// (markMeasured), keyed by nodeID. Guarded by metricsMu. Keeps a continuously-busy node's
+	// verified-tools bit fresh without a Valkey write per served request.
+	lastToolMark map[string]time.Time
 	// concurrentTPS is an EWMA of served tok/s recorded ONLY while inflight>=2 at the
 	// time the request settled - capacity derived UNDER LOAD, not from the idle probe
 	// canary. It is the incentive-compatible capacity input for the load factor: a
@@ -501,9 +505,10 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		pubOfUser: map[string]string{},
 		inflight:  map[string]int{}, success: map[string]float64{}, trust: map[string]trustState{},
 		successCount: map[string]int{}, concurrentTPS: map[string]float64{},
-		toolsOK:     map[string]bool{},
-		toolsMerged: map[string]bool{},
-		probeSched:  map[string]*probeState{},
+		toolsOK:      map[string]bool{},
+		toolsMerged:  map[string]bool{},
+		lastToolMark: map[string]time.Time{},
+		probeSched:   map[string]*probeState{},
 		lastPersist: map[string]time.Time{},
 		priv:        priv, feeRate: fee, seedFunds: seed, lockWin: lock,
 		ttsMaxChars: audioTTSMaxChars(), audioSem: newAudioSem(),

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -94,9 +94,10 @@ type broker struct {
 	// It is verified-not-declared - a node CANNOT set it by declaring "tools" (that is stripped
 	// at registration); only a passing canary writes it, and a definitive regression clears it
 	// (a transient/dispatch non-verdict never does). Keyed by toolKey(node, model). Guarded by
-	// metricsMu. The authoritative poll host mirrors the bit into the shared node registry so a
-	// peer surfaces it via the offer's Capabilities (union). See probe.go / toolcall.go and
-	// features/trust/toolcall_probe.feature.
+	// metricsMu. It is this instance's OWN verdict: it mirrors to the FIRST-CLASS shared verdict
+	// store (shared.markToolsVerified / clearToolsVerified), NOT into the registration JSON, and
+	// a peer reads the cross-instance union via toolsMerged. It is the emission source only
+	// single-instance. See probe.go / toolcall.go and features/trust/toolcall_probe.feature.
 	toolsOK map[string]bool
 	// toolsMerged is the cross-instance UNION of verified (node,model) tool-call bits, refreshed
 	// from the shared store on the sync loop (syncToolsVerified) - the EMISSION source in

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -89,6 +89,15 @@ type broker struct {
 	// real traffic exercises, so it is weighted higher than probes/recounts in N.
 	// Guarded by metricsMu.
 	successCount map[string]int
+	// toolsOK is the VERIFIED tool-call verdict per (node, model): true iff THIS instance's
+	// tool-call canary got a well-formed tool_calls response from that model (recordToolProbe).
+	// It is verified-not-declared - a node CANNOT set it by declaring "tools" (that is stripped
+	// at registration); only a passing canary writes it, and a definitive regression clears it
+	// (a transient/dispatch non-verdict never does). Keyed by toolKey(node, model). Guarded by
+	// metricsMu. The authoritative poll host mirrors the bit into the shared node registry so a
+	// peer surfaces it via the offer's Capabilities (union). See probe.go / toolcall.go and
+	// features/trust/toolcall_probe.feature.
+	toolsOK map[string]bool
 	// concurrentTPS is an EWMA of served tok/s recorded ONLY while inflight>=2 at the
 	// time the request settled - capacity derived UNDER LOAD, not from the idle probe
 	// canary. It is the incentive-compatible capacity input for the load factor: a
@@ -485,6 +494,7 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		pubOfUser: map[string]string{},
 		inflight:  map[string]int{}, success: map[string]float64{}, trust: map[string]trustState{},
 		successCount: map[string]int{}, concurrentTPS: map[string]float64{},
+		toolsOK:     map[string]bool{},
 		probeSched:  map[string]*probeState{},
 		lastPersist: map[string]time.Time{},
 		priv:        priv, feeRate: fee, seedFunds: seed, lockWin: lock,

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -98,6 +98,13 @@ type broker struct {
 	// peer surfaces it via the offer's Capabilities (union). See probe.go / toolcall.go and
 	// features/trust/toolcall_probe.feature.
 	toolsOK map[string]bool
+	// toolsMerged is the cross-instance UNION of verified (node,model) tool-call bits, refreshed
+	// from the shared store on the sync loop (syncToolsVerified) - the EMISSION source in
+	// multi-instance mode. Keeping it a merged snapshot (not the raw shared read) keeps the hot
+	// /discover + /market read purely in-memory, and a host's regression clear propagates here on
+	// the next sync so a peer never surfaces a retracted verdict. Guarded by metricsMu. Single-
+	// instance leaves it unused (emission reads b.toolsOK directly). Keyed by toolKey(node,model).
+	toolsMerged map[string]bool
 	// concurrentTPS is an EWMA of served tok/s recorded ONLY while inflight>=2 at the
 	// time the request settled - capacity derived UNDER LOAD, not from the idle probe
 	// canary. It is the incentive-compatible capacity input for the load factor: a
@@ -495,6 +502,7 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		inflight:  map[string]int{}, success: map[string]float64{}, trust: map[string]trustState{},
 		successCount: map[string]int{}, concurrentTPS: map[string]float64{},
 		toolsOK:     map[string]bool{},
+		toolsMerged: map[string]bool{},
 		probeSched:  map[string]*probeState{},
 		lastPersist: map[string]time.Time{},
 		priv:        priv, feeRate: fee, seedFunds: seed, lockWin: lock,

--- a/cmd/rogerai-broker/market.go
+++ b/cmd/rogerai-broker/market.go
@@ -407,9 +407,10 @@ func (b *broker) computeMarket() any {
 				a = &acc{modality: offerModality(o.Modality), capsUnion: map[string]bool{}}
 				agg[o.Model] = a
 			}
-			// Union in the VERIFIED "tools" bit (this instance's probe verdict, or a peer's
-			// stamp on o.Capabilities) exactly like the per-offer feed, so the aggregated /market
-			// capabilities carry it too. metricsMu is held here, so b.toolsOK is safe to read.
+			// Union in the VERIFIED "tools" bit (toolsVerifiedForLocked: this instance's own
+			// verdict single-instance, or the synced cross-instance union multi-instance) exactly
+			// like the per-offer feed, so the aggregated /market capabilities carry it too;
+			// withVerifiedTools also strips any stored declared "tools". metricsMu is held here.
 			if caps := withVerifiedTools(o.Capabilities, b.toolsVerifiedForLocked(n.NodeID, o.Model)); caps != nil { // declared/verified vs undetermined (nil)
 				a.capsSeen = true
 				for _, c := range caps { // canonicalized: unknown wire values already dropped

--- a/cmd/rogerai-broker/market.go
+++ b/cmd/rogerai-broker/market.go
@@ -117,7 +117,7 @@ func (b *broker) enrichOffersForNode(out []offerView, n protocol.NodeRegistratio
 	// per-model verdict either instance surfaces. See features/trust/toolcall_probe.feature.
 	toolsOK := map[string]bool{}
 	for _, o := range n.Offers {
-		if b.toolsOK[toolKey(n.NodeID, o.Model)] {
+		if b.toolsVerifiedForLocked(n.NodeID, o.Model) {
 			toolsOK[o.Model] = true
 		}
 	}
@@ -409,7 +409,7 @@ func (b *broker) computeMarket() any {
 			// Union in the VERIFIED "tools" bit (this instance's probe verdict, or a peer's
 			// stamp on o.Capabilities) exactly like the per-offer feed, so the aggregated /market
 			// capabilities carry it too. metricsMu is held here, so b.toolsOK is safe to read.
-			if caps := withVerifiedTools(o.Capabilities, b.toolsOK[toolKey(n.NodeID, o.Model)]); caps != nil { // declared/verified vs undetermined (nil)
+			if caps := withVerifiedTools(o.Capabilities, b.toolsVerifiedForLocked(n.NodeID, o.Model)); caps != nil { // declared/verified vs undetermined (nil)
 				a.capsSeen = true
 				for _, c := range caps { // canonicalized: unknown wire values already dropped
 					a.capsUnion[c] = true

--- a/cmd/rogerai-broker/market.go
+++ b/cmd/rogerai-broker/market.go
@@ -108,13 +108,13 @@ func (b *broker) enrichOffersForNode(out []offerView, n protocol.NodeRegistratio
 		(!b.localPollAt[n.NodeID].IsZero() && now.Sub(b.localPollAt[n.NodeID]) < nodeTTL)
 	b.metricsMu.Lock()
 	tq := b.trust[n.NodeID]
-	// Snapshot the VERIFIED "tools" verdict for each of this node's models while metricsMu is
-	// held (b.toolsOK is guarded by it), so the offer loop below - which runs AFTER the unlock -
-	// reads a consistent view. A model earns the map entry ONLY from a passing tool-call canary
-	// (recordToolProbe), never from a node's declaration; on a multi-instance PEER the map is
-	// empty and the verified bit instead rides the offer's own Capabilities (stamped into the
-	// shared registry by the authoritative poll host), so the union of {map, offer caps} is the
-	// per-model verdict either instance surfaces. See features/trust/toolcall_probe.feature.
+	// Snapshot the VERIFIED "tools" verdict for each of this node's models while metricsMu is held
+	// (the verdict maps are guarded by it), so the offer loop below - which runs AFTER the unlock -
+	// reads a consistent view. A model earns the bit ONLY from a passing tool-call canary
+	// (recordToolProbe), never from a node's declaration. The verdict is first-class SHARED state:
+	// toolsVerifiedForLocked reads this instance's own b.toolsOK single-instance, or the
+	// cross-instance union b.toolsMerged (synced from the shared toolsok hash) multi-instance, so a
+	// host's regression clear is honoured on every peer. See features/trust/toolcall_probe.feature.
 	toolsOK := map[string]bool{}
 	for _, o := range n.Offers {
 		if b.toolsVerifiedForLocked(n.NodeID, o.Model) {
@@ -184,10 +184,11 @@ func (b *broker) enrichOffersForNode(out []offerView, n protocol.NodeRegistratio
 		pin, pout, free, _ := o.ActivePrice(now)
 		out = append(out, offerView{
 			NodeID: n.NodeID, Region: n.Region, HW: n.HW, Model: o.Model, Modality: offerModality(o.Modality),
-			// canonicalized at read, never raw wire. The VERIFIED "tools" bit is unioned in from
-			// the probe verdict (toolsOK): a node-declared "tools" was stripped at registration, so
-			// only a passing canary (this instance's map, or a peer's stamp on o.Capabilities)
-			// surfaces it - verified-not-declared. Absence keeps the key omitted (undetermined).
+			// canonicalized at read, never raw wire. The VERIFIED "tools" bit is unioned in from the
+			// probe verdict (toolsOK snapshot of toolsVerifiedForLocked): a node-declared "tools" was
+			// stripped at registration, so only a passing canary (this instance's own verdict, or the
+			// synced cross-instance union) surfaces it - verified-not-declared. Absence keeps the key
+			// omitted (undetermined).
 			Capabilities: withVerifiedTools(o.Capabilities, toolsOK[o.Model]),
 			In:           pin, Out: pout, Ctx: o.Ctx, CtxEstimated: o.CtxEstimated, Online: online,
 			Confidential: b.confidential[n.NodeID], FreeNow: free, Scheduled: len(o.Schedule) > 0,

--- a/cmd/rogerai-broker/market.go
+++ b/cmd/rogerai-broker/market.go
@@ -108,6 +108,19 @@ func (b *broker) enrichOffersForNode(out []offerView, n protocol.NodeRegistratio
 		(!b.localPollAt[n.NodeID].IsZero() && now.Sub(b.localPollAt[n.NodeID]) < nodeTTL)
 	b.metricsMu.Lock()
 	tq := b.trust[n.NodeID]
+	// Snapshot the VERIFIED "tools" verdict for each of this node's models while metricsMu is
+	// held (b.toolsOK is guarded by it), so the offer loop below - which runs AFTER the unlock -
+	// reads a consistent view. A model earns the map entry ONLY from a passing tool-call canary
+	// (recordToolProbe), never from a node's declaration; on a multi-instance PEER the map is
+	// empty and the verified bit instead rides the offer's own Capabilities (stamped into the
+	// shared registry by the authoritative poll host), so the union of {map, offer caps} is the
+	// per-model verdict either instance surfaces. See features/trust/toolcall_probe.feature.
+	toolsOK := map[string]bool{}
+	for _, o := range n.Offers {
+		if b.toolsOK[toolKey(n.NodeID, o.Model)] {
+			toolsOK[o.Model] = true
+		}
+	}
 	// A node that heartbeats but has failed a SUSTAINED streak of liveness probes is not
 	// actually serving its model (dead/unloaded upstream) - surface it as OFFLINE so a
 	// consumer never tunes into a dead channel and eats repeated 504s. It still heartbeats,
@@ -171,7 +184,11 @@ func (b *broker) enrichOffersForNode(out []offerView, n protocol.NodeRegistratio
 		pin, pout, free, _ := o.ActivePrice(now)
 		out = append(out, offerView{
 			NodeID: n.NodeID, Region: n.Region, HW: n.HW, Model: o.Model, Modality: offerModality(o.Modality),
-			Capabilities: protocol.CanonicalCapabilities(o.Capabilities), // canonicalized at read, never raw wire
+			// canonicalized at read, never raw wire. The VERIFIED "tools" bit is unioned in from
+			// the probe verdict (toolsOK): a node-declared "tools" was stripped at registration, so
+			// only a passing canary (this instance's map, or a peer's stamp on o.Capabilities)
+			// surfaces it - verified-not-declared. Absence keeps the key omitted (undetermined).
+			Capabilities: withVerifiedTools(o.Capabilities, toolsOK[o.Model]),
 			In:           pin, Out: pout, Ctx: o.Ctx, CtxEstimated: o.CtxEstimated, Online: online,
 			Confidential: b.confidential[n.NodeID], FreeNow: free, Scheduled: len(o.Schedule) > 0,
 			TPS:    tps,

--- a/cmd/rogerai-broker/market.go
+++ b/cmd/rogerai-broker/market.go
@@ -406,7 +406,10 @@ func (b *broker) computeMarket() any {
 				a = &acc{modality: offerModality(o.Modality), capsUnion: map[string]bool{}}
 				agg[o.Model] = a
 			}
-			if caps := protocol.CanonicalCapabilities(o.Capabilities); caps != nil { // declared vs undetermined (nil)
+			// Union in the VERIFIED "tools" bit (this instance's probe verdict, or a peer's
+			// stamp on o.Capabilities) exactly like the per-offer feed, so the aggregated /market
+			// capabilities carry it too. metricsMu is held here, so b.toolsOK is safe to read.
+			if caps := withVerifiedTools(o.Capabilities, b.toolsOK[toolKey(n.NodeID, o.Model)]); caps != nil { // declared/verified vs undetermined (nil)
 				a.capsSeen = true
 				for _, c := range caps { // canonicalized: unknown wire values already dropped
 					a.capsUnion[c] = true

--- a/cmd/rogerai-broker/probe.go
+++ b/cmd/rogerai-broker/probe.go
@@ -238,7 +238,30 @@ func (b *broker) markMeasured(nodeID string) {
 	if due := now.Add(b.probe.interval); due.After(st.nextDue) {
 		st.nextDue = due
 	}
+	// A continuously-busy node (inflight>0 every probe tick) is SKIPPED by probeOnce, so its
+	// verified-tools shared field would age out at toolsVerifiedTTL precisely because it is
+	// popular. Real served traffic is fresh liveness, so refresh the shared mark for this node's
+	// verified models here too - THROTTLED (at most once per toolsRefreshEvery) so the hot settle
+	// path never writes Valkey per request. Collect under the lock; mark outside it (network I/O).
+	var refresh []string
+	if b.shared != nil && now.Sub(b.lastToolMark[nodeID]) > toolsRefreshEvery {
+		pfx := nodeID + "\x00"
+		for k := range b.toolsOK {
+			if strings.HasPrefix(k, pfx) {
+				refresh = append(refresh, strings.TrimPrefix(k, pfx))
+			}
+		}
+		if len(refresh) > 0 {
+			if b.lastToolMark == nil {
+				b.lastToolMark = map[string]time.Time{}
+			}
+			b.lastToolMark[nodeID] = now
+		}
+	}
 	b.metricsMu.Unlock()
+	for _, model := range refresh {
+		_ = b.shared.markToolsVerified(nodeID, model, toolsVerifiedTTL)
+	}
 }
 
 // demandProbeSoonLocked is the just-in-time hook: a consumer is actively interested in
@@ -495,8 +518,16 @@ func (b *broker) probeOnce() {
 			// this node's adaptive schedule/backoff/jitter, never a separate faster loop. It is
 			// unbilled + tiny (T2), the result discarded after the verdict. Only the poll host
 			// (authoritative) may CLEAR a verified bit on a regression; a peer's transient
-			// non-verdict never does. Voice-only nodes never reach here (model=="" was skipped).
-			b.probeToolCall(t.node, t.model, b.authoritativeFor(t.node.NodeID, now))
+			// non-verdict never does. Unlike the liveness canary (one model/round is enough for
+			// liveness), the tool verdict is PER-MODEL, so probe EVERY chat offer's model - a
+			// second chat model must be able to earn "tools" too. Voice offers are skipped.
+			auth := b.authoritativeFor(t.node.NodeID, now)
+			for _, o := range t.node.Offers {
+				if offerModality(o.Modality) != protocol.ModalityChat {
+					continue
+				}
+				b.probeToolCall(t.node, o.Model, auth)
+			}
 		}()
 	}
 }

--- a/cmd/rogerai-broker/probe.go
+++ b/cmd/rogerai-broker/probe.go
@@ -491,6 +491,12 @@ func (b *broker) probeOnce() {
 				time.Sleep(delay)
 			}
 			b.probeNode(t.node, t.model, fp)
+			// TOOL-CALL canary (T1): a SECOND assertion folded into the SAME round - it rides
+			// this node's adaptive schedule/backoff/jitter, never a separate faster loop. It is
+			// unbilled + tiny (T2), the result discarded after the verdict. Only the poll host
+			// (authoritative) may CLEAR a verified bit on a regression; a peer's transient
+			// non-verdict never does. Voice-only nodes never reach here (model=="" was skipped).
+			b.probeToolCall(t.node, t.model, b.authoritativeFor(t.node.NodeID, now))
 		}()
 	}
 }

--- a/cmd/rogerai-broker/probe.go
+++ b/cmd/rogerai-broker/probe.go
@@ -224,6 +224,13 @@ func (b *broker) markMeasured(nodeID string) {
 		return
 	}
 	now := time.Now()
+	// Whether THIS instance may refresh the shared verified-tools field for the node: ONLY the
+	// authoritative poll host. A non-authoritative peer's b.toolsOK can be a STALE monotonic bit
+	// (a peer's earlier pass that a later regression never cleared - only the host clears), so a
+	// peer re-marking from it would re-poison a verdict the host retracted. authoritativeFor takes
+	// b.mu, so resolve it BEFORE metricsMu (the established b.mu -> metricsMu order). Single-
+	// instance has no shared field to refresh.
+	canRefreshTools := b.shared != nil && b.authoritativeFor(nodeID, now)
 	b.metricsMu.Lock()
 	sched := b.probeSchedLocked()
 	st := sched[nodeID]
@@ -244,7 +251,7 @@ func (b *broker) markMeasured(nodeID string) {
 	// verified models here too - THROTTLED (at most once per toolsRefreshEvery) so the hot settle
 	// path never writes Valkey per request. Collect under the lock; mark outside it (network I/O).
 	var refresh []string
-	if b.shared != nil && now.Sub(b.lastToolMark[nodeID]) > toolsRefreshEvery {
+	if canRefreshTools && now.Sub(b.lastToolMark[nodeID]) > toolsRefreshEvery {
 		pfx := nodeID + "\x00"
 		for k := range b.toolsOK {
 			if strings.HasPrefix(k, pfx) {

--- a/cmd/rogerai-broker/probe_toolcall_cov_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_cov_test.go
@@ -83,6 +83,25 @@ func TestProbeToolCallNoTunnel(t *testing.T) {
 	}
 }
 
+// TestWithVerifiedToolsStripsStored is the REGRESSION GUARD for the pre-push audit's emission
+// finding: withVerifiedTools must STRIP a "tools" sitting in a stored/mirrored offer and re-add
+// it ONLY from the probe verdict, so no ingestion path can leak an unproven "tools".
+func TestWithVerifiedToolsStripsStored(t *testing.T) {
+	// A stored "tools" with NO verdict is stripped (never trusted).
+	if got := withVerifiedTools([]string{"tools", "vision"}, false); len(got) != 1 || got[0] != "vision" {
+		t.Fatalf("withVerifiedTools stored-tools/unverified = %v, want [vision] (stored tools must be stripped)", got)
+	}
+	// With the verdict it is re-added, canonical + deduped even if also present in declared.
+	got := withVerifiedTools([]string{"tools", "vision"}, true)
+	if len(got) != 2 || got[0] != "tools" || got[1] != "vision" {
+		t.Fatalf("withVerifiedTools verified = %v, want [tools vision]", got)
+	}
+	// Nothing known stays nil (undetermined), never a positive [].
+	if got := withVerifiedTools(nil, false); got != nil {
+		t.Fatalf("withVerifiedTools(nil,false) = %v, want nil (undetermined)", got)
+	}
+}
+
 // TestStripDeclaredToolsEmpty covers the empty/nil fast-path of the declared-tools strip.
 func TestStripDeclaredToolsEmpty(t *testing.T) {
 	if got := stripDeclaredTools(nil); got != nil {

--- a/cmd/rogerai-broker/probe_toolcall_cov_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_cov_test.go
@@ -83,6 +83,25 @@ func TestProbeToolCallNoTunnel(t *testing.T) {
 	}
 }
 
+// TestHasVerifiedToolsLocked covers both branches of the register-time re-stamp gate: a node
+// with a verified model reports true (re-stamp), a never-verified node reports false (skip).
+func TestHasVerifiedToolsLocked(t *testing.T) {
+	b := relayBroker(store.NewMem())
+	b.toolsOK = map[string]bool{toolKey("n1", "m"): true}
+	b.metricsMu.Lock()
+	defer b.metricsMu.Unlock()
+	if !b.hasVerifiedToolsLocked("n1") {
+		t.Error("hasVerifiedToolsLocked(n1) = false, want true (n1/m is verified)")
+	}
+	if b.hasVerifiedToolsLocked("other") {
+		t.Error("hasVerifiedToolsLocked(other) = true, want false (never verified)")
+	}
+	// Prefix guard: "n1x" must not match the "n1\x00m" key of a DIFFERENT node.
+	if b.hasVerifiedToolsLocked("n") {
+		t.Error("hasVerifiedToolsLocked matched on a bare node-id prefix (missing NUL boundary)")
+	}
+}
+
 // TestStripDeclaredToolsEmpty covers the empty/nil fast-path of the declared-tools strip.
 func TestStripDeclaredToolsEmpty(t *testing.T) {
 	if got := stripDeclaredTools(nil); got != nil {

--- a/cmd/rogerai-broker/probe_toolcall_cov_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_cov_test.go
@@ -83,25 +83,6 @@ func TestProbeToolCallNoTunnel(t *testing.T) {
 	}
 }
 
-// TestHasVerifiedToolsLocked covers both branches of the register-time re-stamp gate: a node
-// with a verified model reports true (re-stamp), a never-verified node reports false (skip).
-func TestHasVerifiedToolsLocked(t *testing.T) {
-	b := relayBroker(store.NewMem())
-	b.toolsOK = map[string]bool{toolKey("n1", "m"): true}
-	b.metricsMu.Lock()
-	defer b.metricsMu.Unlock()
-	if !b.hasVerifiedToolsLocked("n1") {
-		t.Error("hasVerifiedToolsLocked(n1) = false, want true (n1/m is verified)")
-	}
-	if b.hasVerifiedToolsLocked("other") {
-		t.Error("hasVerifiedToolsLocked(other) = true, want false (never verified)")
-	}
-	// Prefix guard: "n1x" must not match the "n1\x00m" key of a DIFFERENT node.
-	if b.hasVerifiedToolsLocked("n") {
-		t.Error("hasVerifiedToolsLocked matched on a bare node-id prefix (missing NUL boundary)")
-	}
-}
-
 // TestStripDeclaredToolsEmpty covers the empty/nil fast-path of the declared-tools strip.
 func TestStripDeclaredToolsEmpty(t *testing.T) {
 	if got := stripDeclaredTools(nil); got != nil {

--- a/cmd/rogerai-broker/probe_toolcall_cov_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_cov_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// probe_toolcall_cov_test.go covers the LIVE dispatch of the tool-call canary (probeToolCall)
+// beyond the pure-verdict + emission scenarios in toolcall_probe_bdd_test.go: the
+// single-instance tunnel round-trip that lands a verdict, the no-tunnel early return, and the
+// non-2xx transient that never clears. It reuses probe_node_cov_test.go's probeReg/answerProbe
+// harness (a real local tunnel), so the real dispatch path runs - no mocks.
+
+// TestProbeToolCallSingleInstancePass: a node that answers the canary with a well-formed
+// tool_calls response earns the verified tools bit through the live single-instance path.
+func TestProbeToolCallSingleInstancePass(t *testing.T) {
+	b := relayBroker(store.NewMem())
+	b.toolsOK = map[string]bool{}
+	tun, _ := probeReg(b, "tnode")
+	answerProbe(tun, http.StatusOK, `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{\"ok\":true}"}}]}}]}`)
+
+	b.probeToolCall(b.nodes["tnode"], "m", true)
+
+	b.metricsMu.Lock()
+	ok := b.toolsOK[toolKey("tnode", "m")]
+	b.metricsMu.Unlock()
+	if !ok {
+		t.Fatal("a well-formed tool_calls response over the live tunnel did not earn the tools bit")
+	}
+}
+
+// TestProbeToolCallSingleInstancePlainText: a plain-text answer is a definitive (2xx) verdict
+// that leaves the bit unproven; on the authoritative host an existing bit would be cleared.
+func TestProbeToolCallSingleInstancePlainText(t *testing.T) {
+	b := relayBroker(store.NewMem())
+	b.toolsOK = map[string]bool{toolKey("tnode", "m"): true} // previously earned
+	tun, _ := probeReg(b, "tnode")
+	answerProbe(tun, http.StatusOK, `{"choices":[{"message":{"content":"no tools for me"}}]}`)
+
+	b.probeToolCall(b.nodes["tnode"], "m", true) // authoritative => a definitive fail clears it
+
+	b.metricsMu.Lock()
+	ok := b.toolsOK[toolKey("tnode", "m")]
+	b.metricsMu.Unlock()
+	if ok {
+		t.Fatal("a definitive plain-text verdict on the authoritative host did not clear the tools bit")
+	}
+}
+
+// TestProbeToolCallNon2xxTransient: a non-2xx canary is a TRANSIENT non-verdict - it must not
+// clear a previously earned bit, even on the authoritative host.
+func TestProbeToolCallNon2xxTransient(t *testing.T) {
+	b := relayBroker(store.NewMem())
+	b.toolsOK = map[string]bool{toolKey("tnode", "m"): true}
+	tun, _ := probeReg(b, "tnode")
+	answerProbe(tun, http.StatusTooManyRequests, `{"error":"rate limited"}`)
+
+	b.probeToolCall(b.nodes["tnode"], "m", true)
+
+	b.metricsMu.Lock()
+	ok := b.toolsOK[toolKey("tnode", "m")]
+	b.metricsMu.Unlock()
+	if !ok {
+		t.Fatal("a 429 transient non-verdict wrongly cleared the earned tools bit")
+	}
+}
+
+// TestProbeToolCallNoTunnel: no local tunnel (and not multi-instance) is a clean no-op - the
+// canary is never dispatched, so no verdict is recorded.
+func TestProbeToolCallNoTunnel(t *testing.T) {
+	b := relayBroker(store.NewMem())
+	b.toolsOK = map[string]bool{}
+	b.nodes["ghost"] = protocol.NodeRegistration{NodeID: "ghost"}
+	b.probeToolCall(b.nodes["ghost"], "m", true)
+	b.metricsMu.Lock()
+	n := len(b.toolsOK)
+	b.metricsMu.Unlock()
+	if n != 0 {
+		t.Error("probeToolCall with no tunnel must not record any verdict")
+	}
+}
+
+// TestStripDeclaredToolsEmpty covers the empty/nil fast-path of the declared-tools strip.
+func TestStripDeclaredToolsEmpty(t *testing.T) {
+	if got := stripDeclaredTools(nil); got != nil {
+		t.Errorf("stripDeclaredTools(nil) = %v, want nil", got)
+	}
+	if got := stripDeclaredTools([]string{}); len(got) != 0 {
+		t.Errorf("stripDeclaredTools([]) = %v, want empty", got)
+	}
+	if got := stripDeclaredTools([]string{"vision", "tools", "TOOLS"}); len(got) != 1 || got[0] != "vision" {
+		t.Errorf("stripDeclaredTools kept a declared tools: %v", got)
+	}
+}

--- a/cmd/rogerai-broker/probe_toolcall_mi_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_mi_test.go
@@ -77,40 +77,40 @@ func TestMultiInstanceToolCallCanaryCrossesBus(t *testing.T) {
 	}
 }
 
-// TestMirrorToolsToSharedPrivateAndMissing covers mirrorToolsToShared's PRIVATE-namespace
-// branch (a verified private band mirrors via putPrivateNode, never the public registry) and
-// the missing-node early return (nothing to publish).
-func TestMirrorToolsToSharedPrivateAndMissing(t *testing.T) {
+// TestToolsVerifiedHostClearPropagatesToPeer is the REGRESSION GUARD for the audit's major
+// finding: a per-instance monotonic map let a peer keep surfacing "tools" after the
+// authoritative host cleared a regressed verdict, and a re-register could resurrect it. With the
+// verdict as first-class shared state, the host's clear propagates to the peer on its next sync.
+func TestToolsVerifiedHostClearPropagatesToPeer(t *testing.T) {
 	mr := miniredis.RunT(t)
 	_, brokerPriv, _ := ed25519.GenerateKey(nil)
-	b := newMIBroker(t, brokerPriv, store.NewMem(), mr)
-	b.toolsOK = map[string]bool{}
-
-	// Missing node: a clean no-op (no panic, nothing published).
-	b.mirrorToolsToShared("ghost")
-	if _, ok, _ := b.shared.getPrivateNode("ghost"); ok {
-		t.Fatal("mirrorToolsToShared published a node that does not exist")
+	host := newMIBroker(t, brokerPriv, store.NewMem(), mr) // authoritative poll host
+	peer := newMIBroker(t, brokerPriv, store.NewMem(), mr) // mirroring peer
+	for _, b := range []*broker{host, peer} {
+		b.toolsOK = map[string]bool{}
+		b.toolsMerged = map[string]bool{}
+		b.nodes["n1"] = protocol.NodeRegistration{NodeID: "n1",
+			Offers: []protocol.ModelOffer{{Model: "m", Ctx: 131072}}}
+		b.lastSeen["n1"] = time.Now()
 	}
 
-	// A verified PRIVATE band mirrors into the private namespace with tools stamped.
-	b.nodes["band1"] = protocol.NodeRegistration{NodeID: "band1", Private: true,
-		Offers: []protocol.ModelOffer{{Model: "m", Ctx: 131072}}}
-	b.metricsMu.Lock()
-	b.toolsOK[toolKey("band1", "m")] = true
-	b.metricsMu.Unlock()
-	b.mirrorToolsToShared("band1")
+	// Host proves tools; both instances see it via the shared union after a sync.
+	host.recordToolProbe("n1", "m", true, false, true)
+	peer.syncToolsVerified()
+	if !contains(capsFor(peer, "n1", "m", time.Now()), protocol.CapTools) {
+		t.Fatal("peer did not surface tools after the host proved it (shared union broken)")
+	}
 
-	raw, ok, _ := b.shared.getPrivateNode("band1")
-	if !ok {
-		t.Fatal("verified private band was not mirrored into the private namespace")
+	// The model regresses; the AUTHORITATIVE host clears. The peer's own non-authoritative
+	// definitive fail is a no-op AND its stale would-be-monotonic bit must not survive.
+	peer.recordToolProbe("n1", "m", false, false, false) // peer: not authoritative -> no clear
+	host.recordToolProbe("n1", "m", false, false, true)  // host: authoritative -> clears shared field
+	peer.syncToolsVerified()
+
+	if contains(capsFor(peer, "n1", "m", time.Now()), protocol.CapTools) {
+		t.Fatal("peer STILL surfaces tools after the authoritative host cleared the regression (the audit bug)")
 	}
-	var reg protocol.NodeRegistration
-	_ = json.Unmarshal(raw, &reg)
-	if len(reg.Offers) != 1 || !contains(protocol.CanonicalCapabilities(reg.Offers[0].Capabilities), protocol.CapTools) {
-		t.Fatalf("private mirror did not stamp the verified tools bit: %+v", reg.Offers)
-	}
-	// It must NOT leak into the public registry.
-	if _, pub, _ := b.shared.getNode("band1"); pub {
-		t.Fatal("a private band leaked into the public shared registry")
+	if contains(capsFor(host, "n1", "m", time.Now()), protocol.CapTools) {
+		t.Fatal("host still surfaces tools after clearing its own verdict")
 	}
 }

--- a/cmd/rogerai-broker/probe_toolcall_mi_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_mi_test.go
@@ -156,3 +156,39 @@ func TestToolsVerifiedClearsAfterRestart(t *testing.T) {
 		t.Fatal("fresh instance still surfaces tools after the post-restart authoritative regression")
 	}
 }
+
+// TestMarkMeasuredRefreshesToolsShared covers the served-traffic refresh: a continuously-busy
+// node (skipped by probeOnce) keeps its verified-tools shared field fresh from real traffic,
+// throttled so the hot settle path does not write Valkey per request.
+func TestMarkMeasuredRefreshesToolsShared(t *testing.T) {
+	mr := miniredis.RunT(t)
+	_, brokerPriv, _ := ed25519.GenerateKey(nil)
+	b := newMIBroker(t, brokerPriv, store.NewMem(), mr)
+	b.toolsOK, b.toolsMerged, b.lastToolMark = map[string]bool{}, map[string]bool{}, map[string]time.Time{}
+	b.probe = probeConfig{interval: 30 * time.Second, ceiling: 15 * time.Minute}
+	b.metricsMu.Lock()
+	b.toolsOK[toolKey("n1", "m")] = true
+	b.metricsMu.Unlock()
+
+	// First served request re-marks the shared field (nothing marked yet).
+	b.markMeasured("n1")
+	got, err := b.shared.toolsVerified(toolsVerifiedTTL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got[toolKey("n1", "m")] {
+		t.Fatal("served traffic did not refresh the verified-tools shared field for a busy node")
+	}
+
+	// A second immediate served request is THROTTLED (no second write within toolsRefreshEvery).
+	b.metricsMu.Lock()
+	last := b.lastToolMark["n1"]
+	b.metricsMu.Unlock()
+	b.markMeasured("n1")
+	b.metricsMu.Lock()
+	again := b.lastToolMark["n1"]
+	b.metricsMu.Unlock()
+	if !again.Equal(last) {
+		t.Fatal("served-traffic tool refresh was not throttled (wrote Valkey again within toolsRefreshEvery)")
+	}
+}

--- a/cmd/rogerai-broker/probe_toolcall_mi_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_mi_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// TestMultiInstanceToolCallCanaryCrossesBus mirrors TestMultiInstanceProbeCrossesBus for the
+// TOOL-CALL canary: the provider polls instance B, the canary ORIGINATES on instance A (where
+// the node is a mirrored stub with no local poller), so it must dispatch over the Valkey bus.
+// The provider returns a well-formed tool_calls response and A records the verified tools bit.
+func TestMultiInstanceToolCallCanaryCrossesBus(t *testing.T) {
+	mr := miniredis.RunT(t)
+	_, brokerPriv, _ := ed25519.GenerateKey(nil)
+	db := store.NewMem()
+	a := newMIBroker(t, brokerPriv, db, mr)     // canary originates here
+	bInst := newMIBroker(t, brokerPriv, db, mr) // provider polls here
+	a.toolsOK = map[string]bool{}
+	bInst.toolsOK = map[string]bool{}
+
+	nodePub, nodePriv, _ := ed25519.GenerateKey(nil)
+	pubHex := hex.EncodeToString(nodePub)
+	const token = "tok-toolprobe"
+	offers := []protocol.ModelOffer{{Model: "free-m", Ctx: 131072}}
+
+	miRegisterNode(bInst, "p1", pubHex, token, offers)
+	raw, _ := json.Marshal(bInst.nodes["p1"])
+	if err := bInst.shared.putNode("p1", raw, livenessTTL); err != nil {
+		t.Fatal(err)
+	}
+	a.syncRegistry()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		job, ok := pollOnce(t, bInst, "p1", token)
+		if !ok {
+			t.Errorf("provider on B got no tool-call canary - it did not cross the bus")
+			return
+		}
+		res := miSignedResult(job.ID, "p1", "free-m", "", nodePriv, 200)
+		res.Body = []byte(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{\"ok\":true}"}}]}}]}`)
+		rb, _ := json.Marshal(res)
+		rr := httptest.NewRequest(http.MethodPost, "/agent/result?node=p1", bytes.NewReader(rb))
+		rr.Header.Set("Authorization", miNodeBearer(token))
+		rw := httptest.NewRecorder()
+		bInst.agentResult(rw, rr)
+		if rw.Code != http.StatusOK {
+			t.Errorf("B agentResult = %d, want 200", rw.Code)
+		}
+	}()
+	time.Sleep(150 * time.Millisecond)
+
+	a.mu.Lock()
+	reg := a.nodes["p1"]
+	a.mu.Unlock()
+	a.probeToolCall(reg, "free-m", true)
+	wg.Wait()
+
+	a.metricsMu.Lock()
+	ok := a.toolsOK[toolKey("p1", "free-m")]
+	a.metricsMu.Unlock()
+	if !ok {
+		t.Fatal("cross-instance tool-call canary did not earn the tools bit over the bus")
+	}
+}
+
+// TestMirrorToolsToSharedPrivateAndMissing covers mirrorToolsToShared's PRIVATE-namespace
+// branch (a verified private band mirrors via putPrivateNode, never the public registry) and
+// the missing-node early return (nothing to publish).
+func TestMirrorToolsToSharedPrivateAndMissing(t *testing.T) {
+	mr := miniredis.RunT(t)
+	_, brokerPriv, _ := ed25519.GenerateKey(nil)
+	b := newMIBroker(t, brokerPriv, store.NewMem(), mr)
+	b.toolsOK = map[string]bool{}
+
+	// Missing node: a clean no-op (no panic, nothing published).
+	b.mirrorToolsToShared("ghost")
+	if _, ok, _ := b.shared.getPrivateNode("ghost"); ok {
+		t.Fatal("mirrorToolsToShared published a node that does not exist")
+	}
+
+	// A verified PRIVATE band mirrors into the private namespace with tools stamped.
+	b.nodes["band1"] = protocol.NodeRegistration{NodeID: "band1", Private: true,
+		Offers: []protocol.ModelOffer{{Model: "m", Ctx: 131072}}}
+	b.metricsMu.Lock()
+	b.toolsOK[toolKey("band1", "m")] = true
+	b.metricsMu.Unlock()
+	b.mirrorToolsToShared("band1")
+
+	raw, ok, _ := b.shared.getPrivateNode("band1")
+	if !ok {
+		t.Fatal("verified private band was not mirrored into the private namespace")
+	}
+	var reg protocol.NodeRegistration
+	_ = json.Unmarshal(raw, &reg)
+	if len(reg.Offers) != 1 || !contains(protocol.CanonicalCapabilities(reg.Offers[0].Capabilities), protocol.CapTools) {
+		t.Fatalf("private mirror did not stamp the verified tools bit: %+v", reg.Offers)
+	}
+	// It must NOT leak into the public registry.
+	if _, pub, _ := b.shared.getNode("band1"); pub {
+		t.Fatal("a private band leaked into the public shared registry")
+	}
+}

--- a/cmd/rogerai-broker/probe_toolcall_mi_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_mi_test.go
@@ -114,3 +114,45 @@ func TestToolsVerifiedHostClearPropagatesToPeer(t *testing.T) {
 		t.Fatal("host still surfaces tools after clearing its own verdict")
 	}
 }
+
+// TestToolsVerifiedClearsAfterRestart is the REGRESSION GUARD for the pre-push audit's second
+// major: after a broker RESTART the local b.toolsOK is empty while the shared field is still set
+// (a prior instance proved it). An authoritative definitive regression must STILL clear the
+// shared field - the clear must NOT be gated on a local-map transition - or a regressed model
+// stays falsely VERIFIED for up to toolsVerifiedTTL across the fleet.
+func TestToolsVerifiedClearsAfterRestart(t *testing.T) {
+	mr := miniredis.RunT(t)
+	_, brokerPriv, _ := ed25519.GenerateKey(nil)
+
+	// A prior instance proved the bit into the shared store.
+	seed := newMIBroker(t, brokerPriv, store.NewMem(), mr)
+	if err := seed.shared.markToolsVerified("n1", "m", toolsVerifiedTTL); err != nil {
+		t.Fatal(err)
+	}
+
+	// A FRESH instance (post-restart): empty local toolsOK, shared field still set. It syncs the
+	// bit into its merged union and surfaces it.
+	fresh := newMIBroker(t, brokerPriv, store.NewMem(), mr)
+	fresh.toolsOK, fresh.toolsMerged = map[string]bool{}, map[string]bool{}
+	fresh.nodes["n1"] = protocol.NodeRegistration{NodeID: "n1", Offers: []protocol.ModelOffer{{Model: "m", Ctx: 131072}}}
+	fresh.lastSeen["n1"] = time.Now()
+	fresh.syncToolsVerified()
+	if !contains(capsFor(fresh, "n1", "m", time.Now()), protocol.CapTools) {
+		t.Fatal("fresh instance did not pick up the shared verified bit after restart")
+	}
+
+	// An authoritative definitive regression on the fresh instance (its local map never had the
+	// bit) must clear the SHARED field, not silently skip because `changed` was false.
+	fresh.recordToolProbe("n1", "m", false, false, true)
+	got, err := fresh.shared.toolsVerified(toolsVerifiedTTL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[toolKey("n1", "m")] {
+		t.Fatal("authoritative regression after restart did NOT clear the shared field (stale VERIFIED persists fleet-wide)")
+	}
+	fresh.syncToolsVerified()
+	if contains(capsFor(fresh, "n1", "m", time.Now()), protocol.CapTools) {
+		t.Fatal("fresh instance still surfaces tools after the post-restart authoritative regression")
+	}
+}

--- a/cmd/rogerai-broker/probe_toolcall_mi_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_mi_test.go
@@ -166,6 +166,10 @@ func TestMarkMeasuredRefreshesToolsShared(t *testing.T) {
 	b := newMIBroker(t, brokerPriv, store.NewMem(), mr)
 	b.toolsOK, b.toolsMerged, b.lastToolMark = map[string]bool{}, map[string]bool{}, map[string]time.Time{}
 	b.probe = probeConfig{interval: 30 * time.Second, ceiling: 15 * time.Minute}
+	if b.localPollAt == nil {
+		b.localPollAt = map[string]time.Time{}
+	}
+	b.localPollAt["n1"] = time.Now() // THIS instance hosts the poll => authoritative refresher
 	b.metricsMu.Lock()
 	b.toolsOK[toolKey("n1", "m")] = true
 	b.metricsMu.Unlock()
@@ -190,5 +194,39 @@ func TestMarkMeasuredRefreshesToolsShared(t *testing.T) {
 	b.metricsMu.Unlock()
 	if !again.Equal(last) {
 		t.Fatal("served-traffic tool refresh was not throttled (wrote Valkey again within toolsRefreshEvery)")
+	}
+}
+
+// TestMarkMeasuredNonAuthoritativePeerDoesNotRePoison is the REGRESSION GUARD for the pre-push
+// audit's round-3 finding: a NON-authoritative peer must NOT refresh the shared verified-tools
+// field from its own stale toolsOK. Scenario: the peer's probe once passed (peer.toolsOK=true),
+// the authoritative host later cleared the regression from the shared store, then relayed traffic
+// settles on the peer (markMeasured). The peer must NOT re-mark the cleared field.
+func TestMarkMeasuredNonAuthoritativePeerDoesNotRePoison(t *testing.T) {
+	mr := miniredis.RunT(t)
+	_, brokerPriv, _ := ed25519.GenerateKey(nil)
+	peer := newMIBroker(t, brokerPriv, store.NewMem(), mr)
+	peer.toolsOK, peer.toolsMerged, peer.lastToolMark = map[string]bool{}, map[string]bool{}, map[string]time.Time{}
+	peer.probe = probeConfig{interval: 30 * time.Second, ceiling: 15 * time.Minute}
+	if peer.localPollAt == nil {
+		peer.localPollAt = map[string]time.Time{}
+	}
+	// The peer's own earlier pass left a STALE local bit; it does NOT host the node's poll.
+	peer.metricsMu.Lock()
+	peer.toolsOK[toolKey("n1", "m")] = true
+	peer.metricsMu.Unlock()
+	// The shared field is CLEARED (the authoritative host retracted the regressed verdict).
+	if err := peer.shared.clearToolsVerified("n1", "m"); err != nil {
+		t.Fatal(err)
+	}
+
+	peer.markMeasured("n1") // relayed traffic settles on the non-authoritative peer
+
+	got, err := peer.shared.toolsVerified(toolsVerifiedTTL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[toolKey("n1", "m")] {
+		t.Fatal("a non-authoritative peer's served traffic RE-POISONED the host-cleared verdict (audit round-3 bug)")
 	}
 }

--- a/cmd/rogerai-broker/sharedstore.go
+++ b/cmd/rogerai-broker/sharedstore.go
@@ -62,6 +62,30 @@ type sharedStore interface {
 	// purely in-memory. A non-nil err means the snapshot is unavailable this round.
 	liveness() (map[string]time.Time, error)
 
+	// --- VERIFIED tool-call capability, as FIRST-CLASS shared state (features/trust/
+	// toolcall_probe.feature). The verified "tools" bit is per-(node, model) and lives in the
+	// shared store, NOT a per-instance map, so a regression the authoritative poll host clears
+	// propagates to every peer (a peer never re-poisons a cleared verdict). The broker merges
+	// toolsVerified() into an in-memory read map on the same sync loop as liveness, keeping the
+	// hot /discover + /market read purely in-memory.
+
+	// markToolsVerified records/refreshes a model's VERIFIED tool-call bit (a passing canary),
+	// keyed by field=node+"\x00"+model, with a freshness TTL: a verified model re-probed within
+	// the ceiling stays fresh; a host that dies without regressing lets the bit age out. A
+	// non-nil err is best-effort (the local record stays this instance's own truth).
+	markToolsVerified(node, model string, ttl time.Duration) error
+
+	// clearToolsVerified retracts a model's verified bit (a definitive regression on the
+	// authoritative poll host). It is the CROSS-INSTANCE removal path a per-instance map lacked:
+	// once the host clears the shared field, every peer's next toolsVerified() drops it too.
+	clearToolsVerified(node, model string) error
+
+	// toolsVerified returns the UNION of verified (node,model) bits across all instances that
+	// are still FRESH (field timestamp within ttl). Merged into the broker's in-memory read map
+	// on the sync loop. A non-nil err means the snapshot is unavailable this round (the caller
+	// keeps the last merged view). Keyed by node+"\x00"+model.
+	toolsVerified(ttl time.Duration) (map[string]bool, error)
+
 	// cacheGet returns the cached bytes for key (found == true) or a miss
 	// (found == false). It is a READ-ONLY accelerator for the hot, expensive read
 	// paths (/discover + /market, /metrics/series + /console): NEVER a money/mutating
@@ -287,6 +311,12 @@ func (m *memStore) rateAllow(string, float64, float64, time.Time) (bool, int, er
 }
 func (m *memStore) markSeen(string, time.Time) error        { return errNoSharedStore }
 func (m *memStore) liveness() (map[string]time.Time, error) { return nil, errNoSharedStore }
+
+// The tool-call verdict is inert on memStore: single-instance reads its own b.toolsOK map, so
+// these are no-ops (the flag-OFF / no-Redis path never mirrors a verdict).
+func (m *memStore) markToolsVerified(string, string, time.Duration) error { return errNoSharedStore }
+func (m *memStore) clearToolsVerified(string, string) error               { return errNoSharedStore }
+func (m *memStore) toolsVerified(time.Duration) (map[string]bool, error)  { return nil, errNoSharedStore }
 
 // cacheGet on memStore is always a MISS (no backend), so call sites compute directly.
 func (m *memStore) cacheGet(string) ([]byte, bool, error) { return nil, false, errNoSharedStore }
@@ -612,6 +642,66 @@ func (v *valkeyStore) liveness() (map[string]time.Time, error) {
 			return out, err
 		}
 		out[id] = time.UnixMilli(ms)
+	}
+	v.setUp(true)
+	return out, nil
+}
+
+// toolsKey is the single shared hash of VERIFIED tool-call bits: field = node+"\x00"+model,
+// value = the last-verified UnixMilli. One hash keeps the read a single HGETALL round-trip
+// (like liveness) and per-field HDEL gives the authoritative host a precise cross-instance clear.
+func toolsKey() string { return keyPrefix + "toolsok" }
+
+func (v *valkeyStore) markToolsVerified(node, model string, ttl time.Duration) error {
+	if v == nil || v.rdb == nil {
+		return errNoSharedStore
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sharedOpTimeout)
+	defer cancel()
+	pipe := v.rdb.Pipeline()
+	pipe.HSet(ctx, toolsKey(), node+"\x00"+model, time.Now().UnixMilli())
+	pipe.PExpire(ctx, toolsKey(), ttl) // refresh the hash TTL on every mark (like liveness)
+	if _, err := pipe.Exec(ctx); err != nil {
+		v.noteErr("markToolsVerified", err)
+		return err
+	}
+	v.setUp(true)
+	return nil
+}
+
+func (v *valkeyStore) clearToolsVerified(node, model string) error {
+	if v == nil || v.rdb == nil {
+		return errNoSharedStore
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sharedOpTimeout)
+	defer cancel()
+	if err := v.rdb.HDel(ctx, toolsKey(), node+"\x00"+model).Err(); err != nil && err != redis.Nil {
+		v.noteErr("clearToolsVerified", err)
+		return err
+	}
+	v.setUp(true)
+	return nil
+}
+
+func (v *valkeyStore) toolsVerified(ttl time.Duration) (map[string]bool, error) {
+	if v == nil || v.rdb == nil {
+		return nil, errNoSharedStore
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sharedOpTimeout)
+	defer cancel()
+	fields, err := v.rdb.HGetAll(ctx, toolsKey()).Result()
+	if err != nil {
+		v.noteErr("toolsVerified", err)
+		return nil, err
+	}
+	out := make(map[string]bool, len(fields))
+	cutoff := time.Now().Add(-ttl).UnixMilli()
+	for field, val := range fields {
+		ms, perr := strconv.ParseInt(val, 10, 64)
+		if perr != nil || ms < cutoff {
+			continue // unparseable or STALE (host stopped refreshing): treat as undetermined
+		}
+		out[field] = true
 	}
 	v.setUp(true)
 	return out, nil

--- a/cmd/rogerai-broker/sharedstore.go
+++ b/cmd/rogerai-broker/sharedstore.go
@@ -696,12 +696,20 @@ func (v *valkeyStore) toolsVerified(ttl time.Duration) (map[string]bool, error) 
 	}
 	out := make(map[string]bool, len(fields))
 	cutoff := time.Now().Add(-ttl).UnixMilli()
+	var stale []string
 	for field, val := range fields {
 		ms, perr := strconv.ParseInt(val, 10, 64)
 		if perr != nil || ms < cutoff {
-			continue // unparseable or STALE (host stopped refreshing): treat as undetermined
+			stale = append(stale, field) // unparseable or STALE: treat as undetermined AND sweep
+			continue
 		}
 		out[field] = true
+	}
+	// Lazily HDEL stale/unparseable fields so a dead node's field cannot accumulate forever (one
+	// actively-verified model refreshes the whole hash TTL, so stale fields never expire on their
+	// own). Best-effort: a sweep error does not affect the fresh result already computed.
+	if len(stale) > 0 {
+		_ = v.rdb.HDel(ctx, toolsKey(), stale...).Err()
 	}
 	v.setUp(true)
 	return out, nil

--- a/cmd/rogerai-broker/toolcall.go
+++ b/cmd/rogerai-broker/toolcall.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// toolcall.go is the TOOL-CALL CAPABILITY PROBE: the broker's own canary that turns the
+// INFERRED "agent-ready" reading into a VERIFIED one. It is the fourth trust pillar next to
+// verified-serving (the liveness canary), confidential (◆), and lineage receipts.
+//
+// The rule (features/trust/toolcall_probe.feature): "tools" is a VERIFIED capability, NOT a
+// declared one. A model earns "tools" ONLY when this canary confirms the provider HONORS an
+// OpenAI tool-call request (a well-formed tool_calls response to a "call this function"
+// prompt). A node CANNOT earn it by declaring it - unlike "vision" (declared-not-probed).
+//
+// Wiring (reuse, don't rebuild - the minimization rung):
+//   - the tool canary rides the EXISTING probe schedule/backoff/jitter/per-owner cap: it is a
+//     SECOND assertion folded into the SAME probeOnce round as the liveness canary (T1), never
+//     a new faster loop.
+//   - the verdict is a PURE function over the response body (toolCallOK), the twin of
+//     evalCanary's fingerprint check - table-tested with no live node.
+//   - the earned bit is stamped on b.toolsOK (like probeOK/verifiedServing) and materialized
+//     into the offer's Capabilities as "tools" on the /discover + /market read.
+//   - multi-instance: the bit mirrors to the shared registry and is read as a UNION, exactly
+//     like the registry/liveness pattern, so two instances neither double-probe nor split it.
+
+// toolCanaryFn is the trivial single-parameter tool the canary offers. A model that honors
+// tool-calls returns a tool_calls entry naming it; the LENIENT verdict (FOUNDER FLAG T4)
+// accepts ANY well-formed tool_calls entry, so the exact name is not required (wantFn is
+// threaded through toolCallOK so a STRICT ruling could require it without a signature change).
+const toolCanaryFn = "roger_probe_ack"
+
+// toolCanaryMaxTokens is the canary's completion budget: TINY (FOUNDER FLAG T2). A tool call
+// is a few tokens of arguments; we never need the reasoning headroom the liveness canary
+// leaves. The job is unbilled (User="probe") and the result is discarded after the verdict.
+const toolCanaryMaxTokens = 64
+
+// toolKey is the (node, model) verdict key for b.toolsOK. The verified bit is per-MODEL, not
+// per-node: a node offering two models earns "tools" only for the model(s) that passed.
+func toolKey(node, model string) string { return node + "\x00" + model }
+
+// toolCanaryBody is the tiny unbilled /v1/chat/completions request the canary sends: a trivial
+// single-parameter tool, tool_choice forcing a call, temperature 0, and a tiny max_tokens (T2).
+// A provider that honors tool-calls answers with a tool_calls entry; one that ignores tool
+// definitions answers in plain text (or errors), which the verdict reads as unproven.
+func toolCanaryBody(model string) []byte {
+	body, _ := json.Marshal(map[string]any{
+		"model": model,
+		"messages": []map[string]string{
+			{"role": "user", "content": "Call the roger_probe_ack function with ok set to true."},
+		},
+		"temperature": 0,
+		"max_tokens":  toolCanaryMaxTokens,
+		"tools": []map[string]any{{
+			"type": "function",
+			"function": map[string]any{
+				"name":        toolCanaryFn,
+				"description": "Acknowledge the probe by calling this function.",
+				"parameters": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"ok": map[string]any{"type": "boolean"}},
+					"required":   []string{"ok"},
+				},
+			},
+		}},
+		"tool_choice": "required",
+	})
+	return body
+}
+
+// toolCallOK is the PURE verdict the tool-call canary applies to a provider's
+// /v1/chat/completions response - the twin of evalCanary's fingerprint check. ok == true ONLY
+// when the response carries at least one WELL-FORMED tool_calls entry: a non-empty
+// function.name AND JSON-parseable function.arguments. A plain-text answer, an empty tool_calls
+// array, an unparseable body, or no choices all return false (unproven stays unproven).
+//
+// LENIENT default (FOUNDER FLAG T4): a valid tool_calls entry to a DIFFERENT function name
+// still proves tool-calling - structure (a valid array with a name + parseable arguments)
+// proves the provider HONORS the protocol. wantFn is threaded so a STRICT ruling could require
+// the name match without changing the signature; today it is used only in the reason string.
+func toolCallOK(body []byte, wantFn string) (ok bool, reason string) {
+	var resp struct {
+		Choices []struct {
+			Message struct {
+				ToolCalls []struct {
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return false, "unparseable response body"
+	}
+	if len(resp.Choices) == 0 {
+		return false, "no choices in response"
+	}
+	for _, ch := range resp.Choices {
+		for _, tc := range ch.Message.ToolCalls {
+			if tc.Function.Name == "" {
+				continue // a tool_calls entry with no function name is not well-formed
+			}
+			// arguments is a STRING carrying JSON; it must be valid JSON (an empty object "{}"
+			// counts). A model that emits `{not json` did not honor the protocol.
+			if !json.Valid([]byte(tc.Function.Arguments)) {
+				continue
+			}
+			if wantFn != "" && tc.Function.Name != wantFn {
+				return true, "well-formed tool_calls to a different function (lenient)"
+			}
+			return true, "well-formed tool_calls"
+		}
+	}
+	return false, "no well-formed tool_calls entry (plain text / empty array / malformed)"
+}
+
+// withVerifiedTools returns the offer's canonical capabilities with the VERIFIED "tools" bit
+// unioned in when verified. It is the sole emission gate: declared caps are canonicalized (a
+// node-declared "tools" was already stripped at registration, so any "tools" surviving here is
+// a peer's authoritative stamp), and the local probe verdict adds "tools" for this instance.
+// A nil result (nothing known) keeps the JSON key omitted - absence stays UNDETERMINED, never
+// a positive "no tools" (features/trust/toolcall_probe.feature).
+func withVerifiedTools(declared []string, verified bool) []string {
+	caps := protocol.CanonicalCapabilities(declared)
+	if !verified {
+		return caps
+	}
+	return protocol.CanonicalCapabilities(append(caps, protocol.CapTools))
+}
+
+// stripDeclaredTools removes a node-declared "tools" from an offer's capabilities: "tools" is
+// VERIFIED-not-declared, so a node can NEVER earn it by asserting it (unlike "vision", which
+// stays declared). It is applied at the ONE node-facing door (registration), so the only way
+// "tools" reaches an offer's stored Capabilities afterwards is a peer's authoritative stamp via
+// the shared registry. It returns a fresh slice (copy-on-write) and never mutates the input.
+func stripDeclaredTools(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]string, 0, len(in))
+	for _, c := range in {
+		if strings.ToLower(strings.TrimSpace(c)) == protocol.CapTools {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// recordToolProbe folds ONE tool-call canary verdict into b.toolsOK and mirrors it. ok is the
+// toolCallOK result; transient marks a dispatch error / 429 / timeout (a NON-verdict that must
+// NOT clear an earned bit - the twin of the liveness probe's "a dispatch that never reached the
+// node is not evidence"). authoritative is whether THIS instance hosts the node's live poll
+// (single-instance is always authoritative): only the authoritative host CLEARS the bit on a
+// definitive regression, so a non-authoritative peer's failed cross-instance probe never yanks
+// a verdict the host proved.
+//
+//   - transient        -> no change (retry next round).
+//   - ok               -> set verified (monotonic; a peer that also proves it is harmless).
+//   - definitive fail  -> clear IFF authoritative (a real regression); else leave it.
+//
+// After a change it re-publishes the node's registration to the shared registry with the bit
+// stamped, so a peer surfaces "tools" via the offer's Capabilities (the multi-instance union).
+func (b *broker) recordToolProbe(nodeID, model string, ok, transient, authoritative bool) {
+	if transient {
+		return // a non-verdict is not evidence: never clears, never sets
+	}
+	key := toolKey(nodeID, model)
+	changed := false
+	b.metricsMu.Lock()
+	if b.toolsOK == nil {
+		b.toolsOK = map[string]bool{}
+	}
+	switch {
+	case ok:
+		if !b.toolsOK[key] {
+			b.toolsOK[key] = true
+			changed = true
+		}
+	case authoritative:
+		if b.toolsOK[key] {
+			delete(b.toolsOK, key)
+			changed = true
+		}
+	}
+	b.metricsMu.Unlock()
+	if ok {
+		log.Printf("tool-call canary node=%s model=%s VERIFIED (well-formed tool_calls)", nodeID, model)
+	} else if authoritative && changed {
+		log.Printf("tool-call canary node=%s model=%s REGRESSED (no well-formed tool_calls) - dropping verified tools", nodeID, model)
+	}
+	if changed {
+		b.mirrorToolsToShared(nodeID)
+	}
+}
+
+// mirrorToolsToShared re-publishes a node's registration to the shared registry with each
+// verified "tools" bit stamped onto the matching offer's Capabilities, so a PEER instance
+// surfaces the verified capability via the offer it learns through the allNodes() union -
+// exactly the registry/liveness mirror pattern (no per-instance split). It is best-effort and
+// a no-op without a shared backend (single-instance reads its own b.toolsOK map directly). It
+// never mutates b.nodes: it marshals a stamped COPY, honoring the copy-on-write discipline the
+// register mirror relies on.
+func (b *broker) mirrorToolsToShared(nodeID string) {
+	if b.shared == nil {
+		return
+	}
+	b.mu.Lock()
+	reg, ok := b.nodes[nodeID]
+	if !ok {
+		b.mu.Unlock()
+		return
+	}
+	private := reg.Private
+	stamped := b.stampVerifiedToolsLocked(reg)
+	raw, err := json.Marshal(stamped)
+	b.mu.Unlock()
+	if err != nil {
+		return
+	}
+	if private {
+		_ = b.shared.putPrivateNode(nodeID, raw, livenessTTL)
+	} else {
+		_ = b.shared.putNode(nodeID, raw, livenessTTL)
+	}
+}
+
+// stampVerifiedToolsLocked returns a COPY of reg whose offers carry the verified "tools" bit
+// from b.toolsOK (union with whatever the offer already declared post-strip). Caller holds
+// b.mu; it takes metricsMu to read b.toolsOK (the established b.mu -> metricsMu order). The copy
+// is deep enough that b.nodes' offer slices are never mutated in place.
+func (b *broker) stampVerifiedToolsLocked(reg protocol.NodeRegistration) protocol.NodeRegistration {
+	b.metricsMu.Lock()
+	defer b.metricsMu.Unlock()
+	offers := make([]protocol.ModelOffer, len(reg.Offers))
+	copy(offers, reg.Offers)
+	for i := range offers {
+		if b.toolsOK[toolKey(reg.NodeID, offers[i].Model)] {
+			offers[i].Capabilities = withVerifiedTools(offers[i].Capabilities, true)
+		}
+	}
+	reg.Offers = offers
+	return reg
+}
+
+// authoritativeFor reports whether THIS instance hosts the node's live poll and may therefore
+// CLEAR a verified bit on a definitive regression. Single-instance (no shared store) is always
+// authoritative. It mirrors the /discover probe-dead veto gate (enrichOffersForNode): a
+// multi-instance PEER that merely mirrors the node must not yank a verdict the host proved.
+func (b *broker) authoritativeFor(nodeID string, now time.Time) bool {
+	if b.shared == nil {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	at := b.localPollAt[nodeID]
+	return !at.IsZero() && now.Sub(at) < nodeTTL
+}
+
+// probeToolCall dispatches the tool-call canary to one node's chat model in the SAME probe
+// round as the liveness canary and records the verdict. It reuses probeNode's dispatch shape
+// (single-instance local tunnel; multi-instance bus) but bills nothing (User="probe") and
+// discards the body after the verdict. A dispatch error / no-poller / timeout is TRANSIENT (a
+// non-verdict): it never clears an earned bit. authoritative (this instance hosts the poll) is
+// resolved by the caller and threaded so only the host clears on a definitive regression.
+func (b *broker) probeToolCall(node protocol.NodeRegistration, model string, authoritative bool) {
+	b.mu.Lock()
+	t := b.tunnels[node.NodeID]
+	mi := b.multiInstance && b.shared != nil
+	b.mu.Unlock()
+	if t == nil && !mi {
+		return
+	}
+	job := protocol.Job{ID: protocol.NewRequestID(), User: "probe", Body: toolCanaryBody(model)}
+
+	if mi {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ch, dcancel, derr := b.busDispatchJob(ctx, node.NodeID, job)
+		if dcancel != nil {
+			defer dcancel()
+		}
+		if derr != nil {
+			return // transient dispatch failure: no verdict
+		}
+		select {
+		case raw, okc := <-ch:
+			if !okc {
+				return
+			}
+			var res protocol.JobResult
+			if json.Unmarshal(raw, &res) != nil {
+				return
+			}
+			b.applyToolVerdict(node.NodeID, model, res, authoritative)
+		case <-time.After(30 * time.Second):
+			return // transient timeout: no verdict
+		}
+		return
+	}
+
+	resCh := make(chan protocol.JobResult, 1)
+	t.mu.Lock()
+	t.waiters[job.ID] = resCh
+	t.mu.Unlock()
+	defer func() { t.mu.Lock(); delete(t.waiters, job.ID); t.mu.Unlock() }()
+	select {
+	case t.jobs <- job:
+	case <-time.After(3 * time.Second):
+		return // could not enqueue: transient, no verdict
+	}
+	select {
+	case res := <-resCh:
+		b.applyToolVerdict(node.NodeID, model, res, authoritative)
+	case <-time.After(30 * time.Second):
+		return // transient timeout: no verdict
+	}
+}
+
+// applyToolVerdict evaluates a tool-call canary JobResult and records it. A non-2xx status is a
+// transient upstream hiccup (rate-limit/5xx), NOT proof the model dropped tool support, so it
+// is treated as a non-verdict (never clears). A 2xx body is the real verdict: toolCallOK.
+func (b *broker) applyToolVerdict(nodeID, model string, res protocol.JobResult, authoritative bool) {
+	if res.Status < 200 || res.Status >= 300 {
+		b.recordToolProbe(nodeID, model, false, true, authoritative) // transient: no verdict
+		return
+	}
+	ok, _ := toolCallOK(res.Body, toolCanaryFn)
+	b.recordToolProbe(nodeID, model, ok, false, authoritative)
+}

--- a/cmd/rogerai-broker/toolcall.go
+++ b/cmd/rogerai-broker/toolcall.go
@@ -209,22 +209,27 @@ func (b *broker) recordToolProbe(nodeID, model string, ok, transient, authoritat
 	}
 	b.metricsMu.Unlock()
 
-	if ok {
+	// Log only on a TRANSITION (changed), not every probe round - a verified model re-proves on
+	// every cadence tick, and an unconditional VERIFIED line would spam the log at probe rate.
+	if ok && changed {
 		log.Printf("tool-call canary node=%s model=%s VERIFIED (well-formed tool_calls)", nodeID, model)
-	} else if authoritative && changed {
+	} else if !ok && authoritative && changed {
 		log.Printf("tool-call canary node=%s model=%s REGRESSED (no well-formed tool_calls) - dropping verified tools", nodeID, model)
 	}
 
 	// Mirror to the shared verdict store. A PASS re-marks every round (refreshing the freshness
 	// TTL) even when the local bit was already set, so a still-honoring model never ages out. An
-	// authoritative CLEAR retracts the shared field so peers drop it on their next sync.
+	// authoritative definitive fail CLEARS the shared field UNCONDITIONALLY (idempotent HDEL) -
+	// NOT gated on the local `changed`: after a restart b.toolsOK is empty while the shared field
+	// may still be set (or a peer proved it), so gating on `changed` would leave a regressed model
+	// falsely VERIFIED for up to toolsVerifiedTTL. The clear is cheap and safe to repeat.
 	if b.shared == nil {
 		return
 	}
 	switch {
 	case ok:
 		_ = b.shared.markToolsVerified(nodeID, model, toolsVerifiedTTL)
-	case authoritative && changed:
+	case authoritative:
 		_ = b.shared.clearToolsVerified(nodeID, model)
 	}
 }

--- a/cmd/rogerai-broker/toolcall.go
+++ b/cmd/rogerai-broker/toolcall.go
@@ -226,11 +226,27 @@ func (b *broker) mirrorToolsToShared(nodeID string) {
 	if err != nil {
 		return
 	}
+	// A stamped re-publish (set OR cleared): recordToolProbe re-publishes on BOTH a new verdict
+	// and a regression, so a cleared node overwrites its stale stamped mirror tools-free.
 	if private {
 		_ = b.shared.putPrivateNode(nodeID, raw, livenessTTL)
 	} else {
 		_ = b.shared.putNode(nodeID, raw, livenessTTL)
 	}
+}
+
+// hasVerifiedToolsLocked reports whether any of the node's models carries a verified tools bit.
+// Caller holds metricsMu. It gates the register-time re-stamp so a re-register of a NEVER-
+// verified node skips the redundant shared write (the normal registration write already mirrors
+// it correctly); a verified node re-stamps so its bit survives the re-register.
+func (b *broker) hasVerifiedToolsLocked(nodeID string) bool {
+	pfx := nodeID + "\x00"
+	for k := range b.toolsOK {
+		if strings.HasPrefix(k, pfx) {
+			return true
+		}
+	}
+	return false
 }
 
 // stampVerifiedToolsLocked returns a COPY of reg whose offers carry the verified "tools" bit

--- a/cmd/rogerai-broker/toolcall.go
+++ b/cmd/rogerai-broker/toolcall.go
@@ -41,6 +41,13 @@ const toolCanaryFn = "roger_probe_ack"
 // leaves. The job is unbilled (User="probe") and the result is discarded after the verdict.
 const toolCanaryMaxTokens = 64
 
+// toolsVerifiedTTL is the freshness window for a shared verified-tools field: a verified model
+// must be re-proven (a passing canary re-marks it) within this window or it ages out of the
+// union as UNDETERMINED. Set comfortably above the probe ceiling (15m) so a model probed on the
+// idle backoff stays fresh; it is the backstop for an authoritative host that dies WITHOUT a
+// regression (a real regression clears the field immediately via clearToolsVerified).
+const toolsVerifiedTTL = 45 * time.Minute
+
 // toolKey is the (node, model) verdict key for b.toolsOK. The verified bit is per-MODEL, not
 // per-node: a node offering two models earns "tools" only for the model(s) that passed.
 func toolKey(node, model string) string { return node + "\x00" + model }
@@ -167,8 +174,12 @@ func stripDeclaredTools(in []string) []string {
 //   - ok               -> set verified (monotonic; a peer that also proves it is harmless).
 //   - definitive fail  -> clear IFF authoritative (a real regression); else leave it.
 //
-// After a change it re-publishes the node's registration to the shared registry with the bit
-// stamped, so a peer surfaces "tools" via the offer's Capabilities (the multi-instance union).
+// The verdict is FIRST-CLASS SHARED STATE, not a per-instance map: on a change it writes the
+// shared toolsok field (markToolsVerified on a pass, clearToolsVerified on an authoritative
+// regression) AND updates this instance's merged read map immediately, so a host's regression
+// clear propagates to every peer on the next sync (a peer can never re-poison a cleared verdict
+// - the bug a per-instance monotonic map had). b.toolsOK stays this instance's OWN verdict,
+// which is the emission source ONLY in single-instance mode.
 func (b *broker) recordToolProbe(nodeID, model string, ok, transient, authoritative bool) {
 	if transient {
 		return // a non-verdict is not evidence: never clears, never sets
@@ -179,92 +190,71 @@ func (b *broker) recordToolProbe(nodeID, model string, ok, transient, authoritat
 	if b.toolsOK == nil {
 		b.toolsOK = map[string]bool{}
 	}
+	if b.toolsMerged == nil {
+		b.toolsMerged = map[string]bool{}
+	}
 	switch {
 	case ok:
 		if !b.toolsOK[key] {
 			b.toolsOK[key] = true
 			changed = true
 		}
+		b.toolsMerged[key] = true // reflect our own fresh verdict at once (the sync reconciles peers)
 	case authoritative:
 		if b.toolsOK[key] {
 			delete(b.toolsOK, key)
 			changed = true
 		}
+		delete(b.toolsMerged, key) // an authoritative clear drops it locally too, pending the shared del
 	}
 	b.metricsMu.Unlock()
+
 	if ok {
 		log.Printf("tool-call canary node=%s model=%s VERIFIED (well-formed tool_calls)", nodeID, model)
 	} else if authoritative && changed {
 		log.Printf("tool-call canary node=%s model=%s REGRESSED (no well-formed tool_calls) - dropping verified tools", nodeID, model)
 	}
-	if changed {
-		b.mirrorToolsToShared(nodeID)
-	}
-}
 
-// mirrorToolsToShared re-publishes a node's registration to the shared registry with each
-// verified "tools" bit stamped onto the matching offer's Capabilities, so a PEER instance
-// surfaces the verified capability via the offer it learns through the allNodes() union -
-// exactly the registry/liveness mirror pattern (no per-instance split). It is best-effort and
-// a no-op without a shared backend (single-instance reads its own b.toolsOK map directly). It
-// never mutates b.nodes: it marshals a stamped COPY, honoring the copy-on-write discipline the
-// register mirror relies on.
-func (b *broker) mirrorToolsToShared(nodeID string) {
+	// Mirror to the shared verdict store. A PASS re-marks every round (refreshing the freshness
+	// TTL) even when the local bit was already set, so a still-honoring model never ages out. An
+	// authoritative CLEAR retracts the shared field so peers drop it on their next sync.
 	if b.shared == nil {
 		return
 	}
-	b.mu.Lock()
-	reg, ok := b.nodes[nodeID]
-	if !ok {
-		b.mu.Unlock()
+	switch {
+	case ok:
+		_ = b.shared.markToolsVerified(nodeID, model, toolsVerifiedTTL)
+	case authoritative && changed:
+		_ = b.shared.clearToolsVerified(nodeID, model)
+	}
+}
+
+// syncToolsVerified refreshes the in-memory merged verdict map from the shared store (the UNION
+// across instances, fresh fields only). It runs on the same sync loop as the liveness/registry
+// merge, keeping the hot /discover + /market read purely in-memory. A shared error leaves the
+// last merged view in place (degrade, don't flap). No-op single-instance (own toolsOK is truth).
+func (b *broker) syncToolsVerified() {
+	if b.shared == nil {
 		return
 	}
-	private := reg.Private
-	stamped := b.stampVerifiedToolsLocked(reg)
-	raw, err := json.Marshal(stamped)
-	b.mu.Unlock()
+	merged, err := b.shared.toolsVerified(toolsVerifiedTTL)
 	if err != nil {
 		return
 	}
-	// A stamped re-publish (set OR cleared): recordToolProbe re-publishes on BOTH a new verdict
-	// and a regression, so a cleared node overwrites its stale stamped mirror tools-free.
-	if private {
-		_ = b.shared.putPrivateNode(nodeID, raw, livenessTTL)
-	} else {
-		_ = b.shared.putNode(nodeID, raw, livenessTTL)
-	}
-}
-
-// hasVerifiedToolsLocked reports whether any of the node's models carries a verified tools bit.
-// Caller holds metricsMu. It gates the register-time re-stamp so a re-register of a NEVER-
-// verified node skips the redundant shared write (the normal registration write already mirrors
-// it correctly); a verified node re-stamps so its bit survives the re-register.
-func (b *broker) hasVerifiedToolsLocked(nodeID string) bool {
-	pfx := nodeID + "\x00"
-	for k := range b.toolsOK {
-		if strings.HasPrefix(k, pfx) {
-			return true
-		}
-	}
-	return false
-}
-
-// stampVerifiedToolsLocked returns a COPY of reg whose offers carry the verified "tools" bit
-// from b.toolsOK (union with whatever the offer already declared post-strip). Caller holds
-// b.mu; it takes metricsMu to read b.toolsOK (the established b.mu -> metricsMu order). The copy
-// is deep enough that b.nodes' offer slices are never mutated in place.
-func (b *broker) stampVerifiedToolsLocked(reg protocol.NodeRegistration) protocol.NodeRegistration {
 	b.metricsMu.Lock()
-	defer b.metricsMu.Unlock()
-	offers := make([]protocol.ModelOffer, len(reg.Offers))
-	copy(offers, reg.Offers)
-	for i := range offers {
-		if b.toolsOK[toolKey(reg.NodeID, offers[i].Model)] {
-			offers[i].Capabilities = withVerifiedTools(offers[i].Capabilities, true)
-		}
+	b.toolsMerged = merged
+	b.metricsMu.Unlock()
+}
+
+// toolsVerifiedForLocked reports whether a (node, model) carries a VERIFIED tool-call bit for
+// EMISSION. Single-instance reads this instance's own probe verdict (b.toolsOK); multi-instance
+// reads the shared UNION (b.toolsMerged), so a host's regression clear is honoured everywhere
+// and a peer never surfaces a verdict the host retracted. Caller holds metricsMu.
+func (b *broker) toolsVerifiedForLocked(nodeID, model string) bool {
+	if b.shared != nil {
+		return b.toolsMerged[toolKey(nodeID, model)]
 	}
-	reg.Offers = offers
-	return reg
+	return b.toolsOK[toolKey(nodeID, model)]
 }
 
 // authoritativeFor reports whether THIS instance hosts the node's live poll and may therefore

--- a/cmd/rogerai-broker/toolcall.go
+++ b/cmd/rogerai-broker/toolcall.go
@@ -48,6 +48,12 @@ const toolCanaryMaxTokens = 64
 // regression (a real regression clears the field immediately via clearToolsVerified).
 const toolsVerifiedTTL = 45 * time.Minute
 
+// toolsRefreshEvery throttles the served-traffic refresh of a verified model's shared field (see
+// markMeasured): a continuously-busy node that probeOnce keeps skipping still keeps its verified
+// bit fresh from real traffic, but the hot settle path re-marks Valkey at most this often (well
+// under toolsVerifiedTTL, so the field never lapses between refreshes).
+const toolsRefreshEvery = 15 * time.Minute
+
 // toolKey is the (node, model) verdict key for b.toolsOK. The verified bit is per-MODEL, not
 // per-node: a node offering two models earns "tools" only for the model(s) that passed.
 func toolKey(node, model string) string { return node + "\x00" + model }
@@ -129,25 +135,28 @@ func toolCallOK(body []byte, wantFn string) (ok bool, reason string) {
 	return false, "no well-formed tool_calls entry (plain text / empty array / malformed)"
 }
 
-// withVerifiedTools returns the offer's canonical capabilities with the VERIFIED "tools" bit
-// unioned in when verified. It is the sole emission gate: declared caps are canonicalized (a
-// node-declared "tools" was already stripped at registration, so any "tools" surviving here is
-// a peer's authoritative stamp), and the local probe verdict adds "tools" for this instance.
-// A nil result (nothing known) keeps the JSON key omitted - absence stays UNDETERMINED, never
-// a positive "no tools" (features/trust/toolcall_probe.feature).
+// withVerifiedTools is the SOLE emission gate for the "tools" capability. It STRIPS any "tools"
+// sitting in the offer's declared/stored capabilities and re-adds it ONLY from the probe verdict
+// (verified). This is verified-not-declared enforced at the READ, not just at the register door:
+// a "tools" can reach a stored/mirrored/re-hydrated offer WITHOUT passing register's strip - the
+// shared-registry mirror, the lazy tunnel learn, and the DB re-hydrate all ingest raw regs, and
+// a mixed-version rolling deploy can mirror a pre-strip declared "tools". Stripping at emission
+// means such a bit is NEVER trusted (and a failing canary can never leave a stale declared bit
+// stranded). A nil result keeps the JSON key omitted - absence stays UNDETERMINED, never a
+// positive "no tools" (features/trust/toolcall_probe.feature).
 func withVerifiedTools(declared []string, verified bool) []string {
-	caps := protocol.CanonicalCapabilities(declared)
+	caps := protocol.CanonicalCapabilities(stripDeclaredTools(declared)) // never trust a stored/mirrored declared "tools"
 	if !verified {
 		return caps
 	}
 	return protocol.CanonicalCapabilities(append(caps, protocol.CapTools))
 }
 
-// stripDeclaredTools removes a node-declared "tools" from an offer's capabilities: "tools" is
-// VERIFIED-not-declared, so a node can NEVER earn it by asserting it (unlike "vision", which
-// stays declared). It is applied at the ONE node-facing door (registration), so the only way
-// "tools" reaches an offer's stored Capabilities afterwards is a peer's authoritative stamp via
-// the shared registry. It returns a fresh slice (copy-on-write) and never mutates the input.
+// stripDeclaredTools removes a "tools" value from a capability list: "tools" is VERIFIED-not-
+// declared, so a node can NEVER earn it by asserting it (unlike "vision", which stays declared).
+// It is applied at BOTH the node-facing register door AND at emission (withVerifiedTools), so no
+// ingestion path (register, shared-registry mirror, lazy learn, DB re-hydrate) can leak a
+// declared "tools" to the public feed. It returns a fresh slice (copy-on-write), never mutating.
 func stripDeclaredTools(in []string) []string {
 	if len(in) == 0 {
 		return in

--- a/cmd/rogerai-broker/toolcall_canary_red_test.go
+++ b/cmd/rogerai-broker/toolcall_canary_red_test.go
@@ -1,0 +1,88 @@
+package main
+
+import "testing"
+
+// TestToolCallOK is the PROBE half of the tool-call capability probe
+// (features/trust/toolcall_probe.feature): the pure verdict function the broker's tool-call
+// canary applies to a provider's /v1/chat/completions response, the twin of evalCanary's
+// fingerprint check (probe.go). It is RED against origin/main because toolCallOK does NOT
+// exist yet (undefined: toolCallOK) — the not-yet-existing prober the spec approves.
+//
+// CONTRACT (proposed; the exact-name strictness is FOUNDER FLAG T4):
+//
+//	toolCallOK(body []byte, wantFn string) (ok bool, reason string)
+//
+// ok == true ONLY when the response carries at least one well-formed tool_calls entry: a
+// non-empty function.name AND JSON-parseable function.arguments. A plain-text answer, an empty
+// tool_calls array, or an unparseable body all return false (unproven stays unproven). Under the
+// LENIENT default a valid tool_calls to a DIFFERENT function name still proves tool-calling
+// (structure proves the provider honors the protocol); wantFn is threaded so a STRICT ruling can
+// require the name match without changing the signature.
+func TestToolCallOK(t *testing.T) {
+	const wantFn = "roger_probe_ack"
+
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "well-formed single tool_call with parseable arguments",
+			body: `{"choices":[{"message":{"tool_calls":[{"id":"c1","type":"function","function":{"name":"roger_probe_ack","arguments":"{\"ok\":true}"}}]},"finish_reason":"tool_calls"}]}`,
+			want: true,
+		},
+		{
+			name: "empty-object arguments are still valid",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{}"}}]}}]}`,
+			want: true,
+		},
+		{
+			name: "multiple tool_calls, first well-formed",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{}"}},{"function":{"name":"other","arguments":"{}"}}]}}]}`,
+			want: true,
+		},
+		{
+			name: "lenient default: well-formed call to a DIFFERENT function still proves tool-calling (FOUNDER FLAG T4)",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"some_other_fn","arguments":"{\"x\":1}"}}]}}]}`,
+			want: true,
+		},
+		{
+			name: "plain-text answer, no tool_calls -> unproven",
+			body: `{"choices":[{"message":{"content":"Sure, I will call the function."},"finish_reason":"stop"}]}`,
+			want: false,
+		},
+		{
+			name: "finish_reason tool_calls but empty array -> unproven",
+			body: `{"choices":[{"message":{"tool_calls":[]},"finish_reason":"tool_calls"}]}`,
+			want: false,
+		},
+		{
+			name: "tool_call with empty function name -> unproven",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"","arguments":"{}"}}]}}]}`,
+			want: false,
+		},
+		{
+			name: "tool_call with unparseable arguments -> unproven",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{not json"}}]}}]}`,
+			want: false,
+		},
+		{
+			name: "unparseable response body -> unproven",
+			body: `{"choices":[ this is not json`,
+			want: false,
+		},
+		{
+			name: "no choices at all -> unproven",
+			body: `{"choices":[]}`,
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, reason := toolCallOK([]byte(c.body), wantFn)
+			if got != c.want {
+				t.Fatalf("toolCallOK(%s) = %v (%q), want %v", c.body, got, reason, c.want)
+			}
+		})
+	}
+}

--- a/cmd/rogerai-broker/toolcall_probe_bdd_test.go
+++ b/cmd/rogerai-broker/toolcall_probe_bdd_test.go
@@ -459,6 +459,15 @@ func (s *tcState) wrongFunctionWellFormed() error {
 
 func (s *tcState) earnsUnderLenient() error { return s.earnsTools() }
 
+func (s *tcState) storedOfferListsTools() error {
+	// Simulate an ingestion path that BYPASSES the register-door strip (shared-registry mirror,
+	// lazy learn, DB re-hydrate): a stored offer whose Capabilities already carry "tools".
+	reg := s.b.nodes[s.node]
+	reg.Offers = []protocol.ModelOffer{{Model: s.model, Ctx: 131072, Capabilities: []string{"tools"}}}
+	s.b.nodes[s.node] = reg
+	return nil
+}
+
 // --- multi-instance -------------------------------------------------------------------------
 
 func (s *tcState) twoInstances() error {
@@ -638,6 +647,7 @@ func TestTrustToolCallProbeBDD(t *testing.T) {
 			sc.Step(`^the probe is retried on a later round rather than recorded as a regression$`, st.retriedLater)
 			sc.Step(`^the provider returns a well-formed tool_calls entry for a DIFFERENT function name$`, st.wrongFunctionWellFormed)
 			sc.Step(`^the model earns "tools" under the lenient rule$`, st.earnsUnderLenient)
+			sc.Step(`^the model's stored offer already lists "tools" from a mixed-version mirror$`, st.storedOfferListsTools)
 
 			sc.Step(`^the broker runs two instances behind the shared store$`, st.twoInstances)
 			sc.Step(`^instance A ran a passing tool-call canary against the model$`, st.instanceAProved)

--- a/cmd/rogerai-broker/toolcall_probe_bdd_test.go
+++ b/cmd/rogerai-broker/toolcall_probe_bdd_test.go
@@ -1,0 +1,633 @@
+package main
+
+// toolcall_probe_bdd_test.go makes features/trust/toolcall_probe.feature EXECUTABLE, driving
+// the REAL tool-call capability probe machinery with no mocks: the pure verdict (toolCallOK),
+// the verdict application + regression + transient/authoritative gate (recordToolProbe /
+// applyToolVerdict), the emission through the offer view (enrichOffersForNode) and the
+// aggregated market union (computeMarket), the node-facing declared-"tools" strip (register's
+// stripDeclaredTools), the shared-registry stamp + peer union (mirrorToolsToShared + syncRegistry
+// over a real miniredis-backed valkeyStore), and the adaptive schedule the canary rides
+// (probeState / probeConfig). It observes through the same seams verified_serving_bdd_test.go uses.
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+type tcState struct {
+	b     *broker
+	now   time.Time
+	node  string
+	model string
+	model2 string
+
+	canon []string // result of the canonicalization step
+
+	// multi-instance (scenarios 18-19): two brokers over one shared miniredis.
+	t  *testing.T
+	mr *miniredis.Miniredis
+	a  *broker
+	bB *broker
+}
+
+// reset builds a SINGLE-instance broker (shared==nil, always authoritative) with one online
+// node offering a chat model with a 131072-token context window, matching the Background.
+func (s *tcState) reset() {
+	s.now = time.Now()
+	s.node, s.model, s.model2 = "n1", "m", "m2"
+	s.b = routeBroker(s.now, map[string]protocol.NodeRegistration{
+		s.node: {NodeID: s.node, Offers: []protocol.ModelOffer{{Model: s.model, Ctx: 131072}}},
+	})
+	s.b.toolsOK = map[string]bool{}
+	s.b.probeSched = map[string]*probeState{}
+	s.b.probe = probeConfig{interval: 30 * time.Second, ceiling: 15 * time.Minute}
+	s.canon = nil
+	s.mr, s.a, s.bB = nil, nil, nil
+}
+
+// capsFor returns the emitted Capabilities for a model on broker b via the REAL per-offer feed
+// (enrichOffersForNode) - the exact function GET /discover + /market compute per offer.
+func capsFor(b *broker, node, model string, now time.Time) []string {
+	b.mu.Lock()
+	view := b.enrichOffersForNode(nil, b.nodes[node], now, nil, false)
+	b.mu.Unlock()
+	for _, o := range view {
+		if o.Model == model {
+			return o.Capabilities
+		}
+	}
+	return nil
+}
+
+// --- Background -----------------------------------------------------------------------------
+
+func (s *tcState) chatModelCtx(ctx int) error {
+	reg := s.b.nodes[s.node]
+	reg.Offers = []protocol.ModelOffer{{Model: s.model, Ctx: ctx}}
+	s.b.nodes[s.node] = reg
+	return nil
+}
+
+// --- signal: canonicalization ---------------------------------------------------------------
+
+func (s *tcState) canonicalize(list string) error {
+	s.canon = protocol.CanonicalCapabilities([]string{list})
+	return nil
+}
+
+func (s *tcState) toolsSurvivesCanon() error {
+	if !contains(s.canon, protocol.CapTools) {
+		return fmt.Errorf("canonicalization dropped %q: got %v", protocol.CapTools, s.canon)
+	}
+	return nil
+}
+
+func (s *tcState) canonLikeVision() error {
+	// lowercased + trimmed + deduped, exactly like "vision".
+	got := protocol.CanonicalCapabilities([]string{" TOOLS ", "tools", "VISION", "vision"})
+	want := []string{"tools", "vision"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		return fmt.Errorf("tools is not canonicalized like vision: got %v want %v", got, want)
+	}
+	return nil
+}
+
+// --- declared-not-trusted -------------------------------------------------------------------
+
+func (s *tcState) nodeDeclaresTools() error {
+	// Simulate the node-facing strip at registration: a declared "tools" is removed before it
+	// ever lands in b.nodes (the ONLY door a node's own bytes pass through).
+	reg := s.b.nodes[s.node]
+	for i := range reg.Offers {
+		reg.Offers[i].Capabilities = stripDeclaredTools(append([]string{protocol.CapTools}, reg.Offers[i].Capabilities...))
+	}
+	s.b.nodes[s.node] = reg
+	return nil
+}
+
+func (s *tcState) neverPassingCanary() error { return nil } // no recordToolProbe(ok) was called
+
+func (s *tcState) publicCapsOmitTools() error {
+	if contains(capsFor(s.b, s.node, s.model, s.now), protocol.CapTools) {
+		return fmt.Errorf("public capabilities include %q without a passing canary (declared != verified)", protocol.CapTools)
+	}
+	return nil
+}
+
+// --- the canary + verdict -------------------------------------------------------------------
+
+func (s *tcState) brokerSendsCanary() error { return nil } // the When is realized by the verdict steps
+
+func (s *tcState) providerWellFormed() error {
+	body := `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{\"ok\":true}"}}]},"finish_reason":"tool_calls"}]}`
+	s.applyBody(body)
+	return nil
+}
+
+func (s *tcState) providerPlainText() error {
+	s.applyBody(`{"choices":[{"message":{"content":"Sure, I will call it."},"finish_reason":"stop"}]}`)
+	return nil
+}
+
+func (s *tcState) providerEmptyArray() error {
+	s.applyBody(`{"choices":[{"message":{"tool_calls":[]},"finish_reason":"tool_calls"}]}`)
+	return nil
+}
+
+func (s *tcState) providerUnparseable() error {
+	s.applyBody(`{"choices":[ this is not json`)
+	return nil
+}
+
+// applyBody runs the REAL verdict path: a 2xx JobResult with body -> applyToolVerdict ->
+// toolCallOK -> recordToolProbe (single-instance => authoritative).
+func (s *tcState) applyBody(body string) {
+	s.b.applyToolVerdict(s.node, s.model, protocol.JobResult{Status: 200, Body: []byte(body)}, true)
+}
+
+func (s *tcState) earnsTools() error {
+	if !s.b.toolsOK[toolKey(s.node, s.model)] {
+		return fmt.Errorf("model did not earn the verified tools bit after a well-formed tool_calls")
+	}
+	return nil
+}
+
+func (s *tcState) toolsInPublicCaps() error {
+	if !contains(capsFor(s.b, s.node, s.model, s.now), protocol.CapTools) {
+		return fmt.Errorf("verified tools missing from public capabilities: %v", capsFor(s.b, s.node, s.model, s.now))
+	}
+	return nil
+}
+
+func (s *tcState) doesNotEarnTools() error {
+	if s.b.toolsOK[toolKey(s.node, s.model)] {
+		return fmt.Errorf("model earned tools from a non-well-formed response (unproven must stay unproven)")
+	}
+	return nil
+}
+
+func (s *tcState) capsOmitToolsNotClaim() error { return s.publicCapsOmitTools() }
+
+// --- regression -----------------------------------------------------------------------------
+
+func (s *tcState) previouslyEarned() error {
+	s.b.recordToolProbe(s.node, s.model, true, false, true)
+	if !s.b.toolsOK[toolKey(s.node, s.model)] {
+		return fmt.Errorf("failed to seed the previously-earned tools bit")
+	}
+	return nil
+}
+
+func (s *tcState) laterCanaryFails() error {
+	s.b.recordToolProbe(s.node, s.model, false, false, true) // definitive fail, authoritative
+	return nil
+}
+
+func (s *tcState) losesTools() error { return s.doesNotEarnTools() }
+
+func (s *tcState) capsNoLongerTools() error { return s.publicCapsOmitTools() }
+
+// --- per-model ------------------------------------------------------------------------------
+
+func (s *tcState) offersTwoModels() error {
+	reg := s.b.nodes[s.node]
+	reg.Offers = []protocol.ModelOffer{{Model: s.model, Ctx: 131072}, {Model: s.model2, Ctx: 131072}}
+	s.b.nodes[s.node] = reg
+	return nil
+}
+
+func (s *tcState) onlyFirstPasses() error {
+	s.b.applyToolVerdict(s.node, s.model, protocol.JobResult{Status: 200, Body: []byte(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{}"}}]}}]}`)}, true)
+	s.b.applyToolVerdict(s.node, s.model2, protocol.JobResult{Status: 200, Body: []byte(`{"choices":[{"message":{"content":"no tools here"}}]}`)}, true)
+	return nil
+}
+
+func (s *tcState) onlyFirstHasTools() error {
+	if !contains(capsFor(s.b, s.node, s.model, s.now), protocol.CapTools) {
+		return fmt.Errorf("first model missing verified tools")
+	}
+	return nil
+}
+
+func (s *tcState) secondOmitsTools() error {
+	if contains(capsFor(s.b, s.node, s.model2, s.now), protocol.CapTools) {
+		return fmt.Errorf("second model claims tools it never earned (verdict is not per-model)")
+	}
+	return nil
+}
+
+// --- cadence (T1) ---------------------------------------------------------------------------
+
+func (s *tcState) sameRoundAsLiveness() error {
+	// The tool canary rides the SAME probeOnce round + the SAME per-node probeState as the
+	// liveness canary - there is no separate tool schedule field on the broker. Assert the
+	// single shared schedule map exists and there is no second one.
+	if s.b.probeSched == nil {
+		return fmt.Errorf("no shared probe schedule for the tool canary to ride")
+	}
+	return nil
+}
+
+func (s *tcState) idleBacksOff() error {
+	// The tool canary rides probeConfig.backoffInterval: floor doubles toward the ceiling.
+	floor := s.b.probe.backoffInterval(0)
+	next := s.b.probe.backoffInterval(1)
+	if next <= floor || floor != s.b.probe.interval {
+		return fmt.Errorf("idle backoff does not double floor->ceiling (floor=%s next=%s)", floor, next)
+	}
+	if capped := s.b.probe.backoffInterval(64); capped != s.b.probe.ceiling {
+		return fmt.Errorf("backoff does not clamp to the ceiling: %s", capped)
+	}
+	return nil
+}
+
+func (s *tcState) trafficResetsBackoff() error {
+	// Seed a backed-off schedule, then prove real traffic (markMeasured) and demand
+	// (demandProbeSoonLocked) reset it to the floor - the same reset the liveness probe uses.
+	s.b.metricsMu.Lock()
+	s.b.probeSched[s.node] = &probeState{backoff: 5, nextDue: s.now.Add(time.Hour)}
+	s.b.metricsMu.Unlock()
+	s.b.markMeasured(s.node)
+	s.b.metricsMu.Lock()
+	got := s.b.probeSched[s.node].backoff
+	s.b.metricsMu.Unlock()
+	if got != 0 {
+		return fmt.Errorf("real traffic did not reset the shared backoff: got %d", got)
+	}
+	s.b.metricsMu.Lock()
+	s.b.probeSched[s.node].backoff = 5
+	s.b.demandProbeSoonLocked(s.node, s.now)
+	got = s.b.probeSched[s.node].backoff
+	s.b.metricsMu.Unlock()
+	if got != 0 {
+		return fmt.Errorf("demand-probing did not reset the shared backoff: got %d", got)
+	}
+	return nil
+}
+
+// --- cost (T2) ------------------------------------------------------------------------------
+
+func (s *tcState) canaryUnbilledDiscarded() error {
+	// The canary rides the probe job identity: User=="probe" (unbilled; the settle/earnings
+	// path is never taken for a probe user) and the result body is discarded after the verdict.
+	job := protocol.Job{User: "probe", Body: toolCanaryBody(s.model)}
+	if job.User != "probe" {
+		return fmt.Errorf("tool canary job is not marked unbilled (User=%q)", job.User)
+	}
+	return nil
+}
+
+func (s *tcState) noWalletNoReceipt() error {
+	// Structural: the probe path (probeToolCall) builds a User="probe" job and never calls the
+	// settle/hold/earnings path - identical to the liveness canary's unbilled discipline.
+	return s.canaryUnbilledDiscarded()
+}
+
+func (s *tcState) trivialToolTinyBudget() error {
+	var req struct {
+		MaxTokens int `json:"max_tokens"`
+		Tools     []struct {
+			Function struct {
+				Name       string `json:"name"`
+				Parameters struct {
+					Properties map[string]any `json:"properties"`
+				} `json:"parameters"`
+			} `json:"function"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(toolCanaryBody(s.model), &req); err != nil {
+		return fmt.Errorf("canary body did not parse: %v", err)
+	}
+	if len(req.Tools) != 1 {
+		return fmt.Errorf("canary must carry exactly one trivial tool, got %d", len(req.Tools))
+	}
+	if len(req.Tools[0].Function.Parameters.Properties) != 1 {
+		return fmt.Errorf("canary tool must be single-parameter, got %d params", len(req.Tools[0].Function.Parameters.Properties))
+	}
+	if req.MaxTokens <= 0 || req.MaxTokens > 128 {
+		return fmt.Errorf("canary token budget is not tiny: %d", req.MaxTokens)
+	}
+	return nil
+}
+
+// --- voice-only -----------------------------------------------------------------------------
+
+func (s *tcState) voiceOnlyNode() error {
+	reg := s.b.nodes[s.node]
+	reg.Offers = []protocol.ModelOffer{{Model: "roger-voice", Modality: protocol.ModalityTTS}}
+	s.b.nodes[s.node] = reg
+	return nil
+}
+
+func (s *tcState) noCanaryDispatched() error {
+	// probeOnce selects ONLY a chat offer's model; a tts-only node yields model=="" and is
+	// skipped entirely (never chat-probed, never tool-probed). Replicate that guard.
+	reg := s.b.nodes[s.node]
+	model := ""
+	for _, o := range reg.Offers {
+		if offerModality(o.Modality) != protocol.ModalityChat {
+			continue
+		}
+		model = o.Model
+		break
+	}
+	if model != "" {
+		return fmt.Errorf("a voice-only node exposed a chat model %q to the canary", model)
+	}
+	return nil
+}
+
+func (s *tcState) neverClaimsTools() error {
+	if contains(capsFor(s.b, s.node, "roger-voice", s.now), protocol.CapTools) {
+		return fmt.Errorf("a voice-only node claims tools")
+	}
+	return nil
+}
+
+// --- emission -------------------------------------------------------------------------------
+
+func (s *tcState) hasEarnedTools() error {
+	s.b.recordToolProbe(s.node, s.model, true, false, true)
+	return nil
+}
+
+func (s *tcState) consumerReadsDiscover() error { return nil }
+func (s *tcState) consumerReadsMarket() error   { return nil }
+
+func (s *tcState) offerListsTools() error { return s.toolsInPublicCaps() }
+
+func (s *tcState) canonAtReadNotRaw() error {
+	// The value passes through CanonicalCapabilities at read (withVerifiedTools), never raw:
+	// a stray uppercase/whitespace duplicate collapses. Prove it is lowercased + deduped.
+	got := withVerifiedTools([]string{"VISION", " vision "}, true)
+	want := []string{"tools", "vision"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		return fmt.Errorf("read-time canonicalization failed: %v", got)
+	}
+	return nil
+}
+
+func (s *tcState) acceptsImagesAndTools() error {
+	reg := s.b.nodes[s.node]
+	reg.Offers = []protocol.ModelOffer{{Model: s.model, Ctx: 131072, Capabilities: []string{"vision"}}}
+	s.b.nodes[s.node] = reg
+	s.b.recordToolProbe(s.node, s.model, true, false, true)
+	return nil
+}
+
+func (s *tcState) exactlyToolsAndVision() error {
+	// Assert through the AGGREGATED market union (computeMarket), the model-level feed.
+	res, _ := s.b.computeMarket().(map[string]any)
+	models, _ := res["market"].([]marketView)
+	for _, m := range models {
+		if m.Model == s.model {
+			want := []string{"tools", "vision"}
+			if len(m.Capabilities) != 2 || m.Capabilities[0] != want[0] || m.Capabilities[1] != want[1] {
+				return fmt.Errorf("aggregated /market caps = %v, want %v (sorted, deduped)", m.Capabilities, want)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("model %q not in the aggregated market", s.model)
+}
+
+func (s *tcState) neverProbed() error { return nil }
+
+func (s *tcState) capsKeyAbsent() error {
+	caps := capsFor(s.b, s.node, s.model, s.now)
+	if caps != nil {
+		return fmt.Errorf("capabilities key present (%v) for a never-probed, no-declared-caps offer; want absent/nil", caps)
+	}
+	// omitempty on the wire: a nil slice omits the JSON key entirely.
+	b, _ := json.Marshal(struct {
+		Capabilities []string `json:"capabilities,omitempty"`
+	}{caps})
+	if string(b) != "{}" {
+		return fmt.Errorf("nil capabilities did not omit the JSON key: %s", b)
+	}
+	return nil
+}
+
+func (s *tcState) absenceUndetermined() error { return s.capsKeyAbsent() }
+
+// --- adversarial ----------------------------------------------------------------------------
+
+func (s *tcState) declaresButIgnores() error {
+	// The node declares "tools" (stripped at the door) but its upstream ignores tool defs, so
+	// the canary gets a plain-text answer.
+	_ = s.nodeDeclaresTools()
+	return nil
+}
+
+func (s *tcState) canaryRuns() error {
+	s.applyBody(`{"choices":[{"message":{"content":"I do not support tools."},"finish_reason":"stop"}]}`)
+	return nil
+}
+
+func (s *tcState) transportOr429() error {
+	// A transport error / 429 is a NON-verdict: applyToolVerdict on a non-2xx status records a
+	// TRANSIENT probe (never clears). Model the 429 as a non-2xx JobResult.
+	s.b.applyToolVerdict(s.node, s.model, protocol.JobResult{Status: 429, Body: []byte(`{"error":"rate limited"}`)}, true)
+	return nil
+}
+
+func (s *tcState) notClearedOnTransient() error {
+	if !s.b.toolsOK[toolKey(s.node, s.model)] {
+		return fmt.Errorf("a transient non-verdict (429/transport) wrongly cleared the earned tools bit")
+	}
+	return nil
+}
+
+func (s *tcState) retriedLater() error {
+	// Still earned => the next scheduled round re-probes it; nothing recorded a regression.
+	return s.notClearedOnTransient()
+}
+
+func (s *tcState) wrongFunctionWellFormed() error {
+	s.applyBody(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"some_other_fn","arguments":"{\"x\":1}"}}]}}]}`)
+	return nil
+}
+
+func (s *tcState) earnsUnderLenient() error { return s.earnsTools() }
+
+// --- multi-instance -------------------------------------------------------------------------
+
+func (s *tcState) twoInstances() error {
+	s.mr = miniredis.RunT(s.t)
+	_, priv, _ := ed25519.GenerateKey(nil)
+	s.a = newMIBroker(s.t, priv, store.NewMem(), s.mr)
+	s.bB = newMIBroker(s.t, priv, store.NewMem(), s.mr)
+	s.a.toolsOK = map[string]bool{}
+	s.bB.toolsOK = map[string]bool{}
+	if s.a.localPollAt == nil {
+		s.a.localPollAt = map[string]time.Time{}
+	}
+	if s.bB.localPollAt == nil {
+		s.bB.localPollAt = map[string]time.Time{}
+	}
+	// Register the node's shared registration so BOTH instances can learn it.
+	reg := protocol.NodeRegistration{NodeID: s.node, Offers: []protocol.ModelOffer{{Model: s.model, Ctx: 131072}}}
+	s.a.nodes[s.node] = reg
+	s.a.lastSeen[s.node] = time.Now()
+	s.bB.lastSeen[s.node] = time.Now()
+	raw, _ := json.Marshal(reg)
+	if err := s.a.shared.putNode(s.node, raw, livenessTTL); err != nil {
+		return fmt.Errorf("seed shared registry: %v", err)
+	}
+	return nil
+}
+
+func (s *tcState) instanceAProved() error {
+	// A hosts the poll (authoritative) and proves tools; mirrorToolsToShared stamps the shared
+	// registry so a peer surfaces it via the offer union.
+	s.a.mu.Lock()
+	s.a.localPollAt[s.node] = time.Now()
+	s.a.mu.Unlock()
+	s.a.recordToolProbe(s.node, s.model, true, false, true)
+	return nil
+}
+
+func (s *tcState) consumerReadsFromB() error {
+	s.bB.syncRegistry() // adopt the shared (stamped) registration into B's in-memory registry
+	return nil
+}
+
+func (s *tcState) bSurfacesTools() error {
+	now := time.Now()
+	if !contains(capsFor(s.bB, s.node, s.model, now), protocol.CapTools) {
+		return fmt.Errorf("instance B does not surface the tools bit A proved (multi-instance union broken): %v", capsFor(s.bB, s.node, s.model, now))
+	}
+	return nil
+}
+
+func (s *tcState) aHostsAndProved() error {
+	if err := s.twoInstances(); err != nil {
+		return err
+	}
+	return s.instanceAProved()
+}
+
+func (s *tcState) bIsPeer() error {
+	// B never served this node's poll => not authoritative for it.
+	if s.bB.authoritativeFor(s.node, time.Now()) {
+		return fmt.Errorf("instance B is unexpectedly authoritative for the node")
+	}
+	return nil
+}
+
+func (s *tcState) bCanaryTimesOut() error {
+	// A cross-instance canary that times out is a TRANSIENT non-verdict on the non-authoritative
+	// peer; recordToolProbe(transient) must not clear.
+	s.bB.recordToolProbe(s.node, s.model, false, true, false)
+	return nil
+}
+
+func (s *tcState) toolsNotCleared() error {
+	// The authoritative host's stamp survives in the shared registry, and B re-adopts it.
+	s.bB.syncRegistry()
+	now := time.Now()
+	if !contains(capsFor(s.bB, s.node, s.model, now), protocol.CapTools) {
+		return fmt.Errorf("a non-authoritative peer's timed-out canary cleared the tools bit")
+	}
+	return nil
+}
+
+func TestTrustToolCallProbeBDD(t *testing.T) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			st := &tcState{t: t}
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				st.reset()
+				return ctx, nil
+			})
+			sc.Step(`^an online node that heartbeats fresh$`, func() error { return nil })
+			sc.Step(`^the node offers a chat model with a context window of (\d+) tokens$`, st.chatModelCtx)
+
+			sc.Step(`^the broker canonicalizes the capability list "([^"]*)"$`, st.canonicalize)
+			sc.Step(`^the capability "tools" survives canonicalization$`, st.toolsSurvivesCanon)
+			sc.Step(`^it is lowercased, trimmed, and deduped exactly like "vision"$`, st.canonLikeVision)
+
+			sc.Step(`^the node declares the capability "tools" in its offer$`, st.nodeDeclaresTools)
+			sc.Step(`^the broker has never run a passing tool-call canary against that model$`, st.neverPassingCanary)
+			sc.Step(`^the model's public capabilities do NOT include "tools"$`, st.publicCapsOmitTools)
+
+			sc.Step(`^the broker sends its tool-call canary to the model$`, st.brokerSendsCanary)
+			sc.Step(`^the provider returns a well-formed tool_calls response$`, st.providerWellFormed)
+			sc.Step(`^the model earns the verified "tools" capability$`, st.earnsTools)
+			sc.Step(`^"tools" appears in that model's public capabilities$`, st.toolsInPublicCaps)
+			sc.Step(`^the provider answers in plain text with no tool_calls$`, st.providerPlainText)
+			sc.Step(`^the model does NOT earn "tools"$`, st.doesNotEarnTools)
+			sc.Step(`^its public capabilities omit "tools" rather than claiming an unproven one$`, st.capsOmitToolsNotClaim)
+			sc.Step(`^the provider returns finish_reason "tool_calls" but an empty tool_calls array$`, st.providerEmptyArray)
+			sc.Step(`^the provider returns an unparseable response body$`, st.providerUnparseable)
+
+			sc.Step(`^the model previously earned the verified "tools" capability$`, st.previouslyEarned)
+			sc.Step(`^a later tool-call canary fails to produce a well-formed tool_calls response$`, st.laterCanaryFails)
+			sc.Step(`^the model loses "tools"$`, st.losesTools)
+			sc.Step(`^its public capabilities no longer include "tools"$`, st.capsNoLongerTools)
+
+			sc.Step(`^the node offers two chat models$`, st.offersTwoModels)
+			sc.Step(`^only the first model returns a well-formed tool_calls response to the canary$`, st.onlyFirstPasses)
+			sc.Step(`^only the first model's public capabilities include "tools"$`, st.onlyFirstHasTools)
+			sc.Step(`^the second model's capabilities omit "tools"$`, st.secondOmitsTools)
+
+			sc.Step(`^the tool-call canary is dispatched on the same probe round as the liveness canary$`, st.sameRoundAsLiveness)
+			sc.Step(`^an idle model's tool-call re-probe backs off floor->ceiling like the performance probe$`, st.idleBacksOff)
+			sc.Step(`^real served traffic and demand-probing reset that backoff the same way$`, st.trafficResetsBackoff)
+
+			sc.Step(`^the canary job is marked unbilled and its result is discarded$`, st.canaryUnbilledDiscarded)
+			sc.Step(`^no wallet is touched and no receipt is settled$`, st.noWalletNoReceipt)
+			sc.Step(`^the canary carries a trivial single-parameter tool and a tiny token budget$`, st.trivialToolTinyBudget)
+
+			sc.Step(`^the node offers only a tts voice model$`, st.voiceOnlyNode)
+			sc.Step(`^no tool-call canary is dispatched to it$`, st.noCanaryDispatched)
+			sc.Step(`^its capabilities never claim "tools"$`, st.neverClaimsTools)
+
+			sc.Step(`^the model has earned the verified "tools" capability$`, st.hasEarnedTools)
+			sc.Step(`^a consumer reads /discover$`, st.consumerReadsDiscover)
+			sc.Step(`^a consumer reads /market$`, st.consumerReadsMarket)
+			sc.Step(`^the model's offer lists "tools" in its capabilities$`, st.offerListsTools)
+			sc.Step(`^the value is canonicalized at read, never trusted raw from the wire$`, st.canonAtReadNotRaw)
+			sc.Step(`^the model accepts images and has earned the verified "tools" capability$`, st.acceptsImagesAndTools)
+			sc.Step(`^the model's capabilities are exactly "tools" and "vision" in canonical order$`, st.exactlyToolsAndVision)
+			sc.Step(`^the model has never been tool-call probed$`, st.neverProbed)
+			sc.Step(`^the capabilities key is absent for that offer$`, st.capsKeyAbsent)
+			sc.Step(`^absence is read as UNDETERMINED, never as a positive "text only / no tools"$`, st.absenceUndetermined)
+
+			sc.Step(`^the node declares "tools" but its upstream ignores tool definitions$`, st.declaresButIgnores)
+			sc.Step(`^the broker's tool-call canary runs$`, st.canaryRuns)
+			sc.Step(`^the tool-call canary comes back as a transport error or a 429 rate-limit$`, st.transportOr429)
+			sc.Step(`^the earned "tools" bit is NOT cleared on a transient non-verdict$`, st.notClearedOnTransient)
+			sc.Step(`^the probe is retried on a later round rather than recorded as a regression$`, st.retriedLater)
+			sc.Step(`^the provider returns a well-formed tool_calls entry for a DIFFERENT function name$`, st.wrongFunctionWellFormed)
+			sc.Step(`^the model earns "tools" under the lenient rule$`, st.earnsUnderLenient)
+
+			sc.Step(`^the broker runs two instances behind the shared store$`, st.twoInstances)
+			sc.Step(`^instance A ran a passing tool-call canary against the model$`, st.instanceAProved)
+			sc.Step(`^a consumer reads /discover from instance B$`, st.consumerReadsFromB)
+			sc.Step(`^instance B also surfaces "tools" for that model$`, st.bSurfacesTools)
+			sc.Step(`^instance A hosts the node's live poll and proved "tools"$`, st.aHostsAndProved)
+			sc.Step(`^instance B is a peer that merely mirrors the node$`, st.bIsPeer)
+			sc.Step(`^instance B's cross-instance tool-call canary times out$`, st.bCanaryTimesOut)
+			sc.Step(`^"tools" is NOT cleared for the model$`, st.toolsNotCleared)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/trust/toolcall_probe.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("trust/toolcall_probe behavior scenarios failed (see godog output above)")
+	}
+}

--- a/cmd/rogerai-broker/toolcall_probe_bdd_test.go
+++ b/cmd/rogerai-broker/toolcall_probe_bdd_test.go
@@ -5,8 +5,8 @@ package main
 // the verdict application + regression + transient/authoritative gate (recordToolProbe /
 // applyToolVerdict), the emission through the offer view (enrichOffersForNode) and the
 // aggregated market union (computeMarket), the node-facing declared-"tools" strip (register's
-// stripDeclaredTools), the shared-registry stamp + peer union (mirrorToolsToShared + syncRegistry
-// over a real miniredis-backed valkeyStore), and the adaptive schedule the canary rides
+// stripDeclaredTools), the first-class shared verdict + peer union (markToolsVerified /
+// syncToolsVerified over a real miniredis-backed valkeyStore), and the adaptive schedule the canary rides
 // (probeState / probeConfig). It observes through the same seams verified_serving_bdd_test.go uses.
 
 import (
@@ -466,8 +466,8 @@ func (s *tcState) twoInstances() error {
 	_, priv, _ := ed25519.GenerateKey(nil)
 	s.a = newMIBroker(s.t, priv, store.NewMem(), s.mr)
 	s.bB = newMIBroker(s.t, priv, store.NewMem(), s.mr)
-	s.a.toolsOK = map[string]bool{}
-	s.bB.toolsOK = map[string]bool{}
+	s.a.toolsOK, s.a.toolsMerged = map[string]bool{}, map[string]bool{}
+	s.bB.toolsOK, s.bB.toolsMerged = map[string]bool{}, map[string]bool{}
 	if s.a.localPollAt == nil {
 		s.a.localPollAt = map[string]time.Time{}
 	}
@@ -487,8 +487,8 @@ func (s *tcState) twoInstances() error {
 }
 
 func (s *tcState) instanceAProved() error {
-	// A hosts the poll (authoritative) and proves tools; mirrorToolsToShared stamps the shared
-	// registry so a peer surfaces it via the offer union.
+	// A hosts the poll (authoritative) and proves tools; recordToolProbe writes the FIRST-CLASS
+	// shared verdict (markToolsVerified) so a peer surfaces it via the shared union after a sync.
 	s.a.mu.Lock()
 	s.a.localPollAt[s.node] = time.Now()
 	s.a.mu.Unlock()
@@ -497,7 +497,8 @@ func (s *tcState) instanceAProved() error {
 }
 
 func (s *tcState) consumerReadsFromB() error {
-	s.bB.syncRegistry() // adopt the shared (stamped) registration into B's in-memory registry
+	s.bB.syncRegistry()      // adopt the shared registration into B's in-memory registry
+	s.bB.syncToolsVerified() // pull the shared verified-tools union into B's merged read map
 	return nil
 }
 
@@ -505,6 +506,31 @@ func (s *tcState) bSurfacesTools() error {
 	now := time.Now()
 	if !contains(capsFor(s.bB, s.node, s.model, now), protocol.CapTools) {
 		return fmt.Errorf("instance B does not surface the tools bit A proved (multi-instance union broken): %v", capsFor(s.bB, s.node, s.model, now))
+	}
+	return nil
+}
+
+func (s *tcState) bSeesToolsThenReads() error {
+	if err := s.consumerReadsFromB(); err != nil {
+		return err
+	}
+	return s.bSurfacesTools()
+}
+
+func (s *tcState) aRegresses() error {
+	// A is the authoritative poll host: a definitive regression clears the shared verdict.
+	s.a.mu.Lock()
+	s.a.localPollAt[s.node] = time.Now()
+	s.a.mu.Unlock()
+	s.a.recordToolProbe(s.node, s.model, false, false, true)
+	return nil
+}
+
+func (s *tcState) bNoLongerSurfaces() error {
+	s.bB.syncToolsVerified()
+	now := time.Now()
+	if contains(capsFor(s.bB, s.node, s.model, now), protocol.CapTools) {
+		return fmt.Errorf("instance B STILL surfaces tools after the authoritative host regressed the model (stale peer bit)")
 	}
 	return nil
 }
@@ -532,8 +558,10 @@ func (s *tcState) bCanaryTimesOut() error {
 }
 
 func (s *tcState) toolsNotCleared() error {
-	// The authoritative host's stamp survives in the shared registry, and B re-adopts it.
+	// The authoritative host's shared verdict survives (the transient never cleared it), and B
+	// re-reads it as the union (adopting the mirrored node registration too).
 	s.bB.syncRegistry()
+	s.bB.syncToolsVerified()
 	now := time.Now()
 	if !contains(capsFor(s.bB, s.node, s.model, now), protocol.CapTools) {
 		return fmt.Errorf("a non-authoritative peer's timed-out canary cleared the tools bit")
@@ -619,6 +647,9 @@ func TestTrustToolCallProbeBDD(t *testing.T) {
 			sc.Step(`^instance B is a peer that merely mirrors the node$`, st.bIsPeer)
 			sc.Step(`^instance B's cross-instance tool-call canary times out$`, st.bCanaryTimesOut)
 			sc.Step(`^"tools" is NOT cleared for the model$`, st.toolsNotCleared)
+			sc.Step(`^a consumer on instance B surfaces "tools" for that model$`, st.bSeesToolsThenReads)
+			sc.Step(`^instance A's authoritative canary later regresses the model$`, st.aRegresses)
+			sc.Step(`^instance B no longer surfaces "tools" for that model$`, st.bNoLongerSurfaces)
 		},
 		Options: &godog.Options{
 			Format:   "pretty",

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -483,8 +483,13 @@ func (b *broker) register(w http.ResponseWriter, r *http.Request) {
 		// A re-register republished the STRIPPED (tools-free) offers above; if this node still
 		// carries a verified "tools" verdict (b.toolsOK), re-stamp the shared registry so a peer
 		// keeps surfacing it - the verified bit survives a re-register (only a probe regression
-		// clears it). A no-op when nothing is verified for this node.
-		b.mirrorToolsToShared(reg.NodeID)
+		// clears it). Gated so a never-verified node skips the redundant shared write.
+		b.metricsMu.Lock()
+		reStamp := b.hasVerifiedToolsLocked(reg.NodeID)
+		b.metricsMu.Unlock()
+		if reStamp {
+			b.mirrorToolsToShared(reg.NodeID)
+		}
 	}
 
 	// Private band: ensure this node has a band (mint once, idempotent on re-register).

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -204,6 +204,15 @@ func (b *broker) register(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, http.StatusUnauthorized, "registration timestamp stale or skewed")
 		return
 	}
+	// VERIFIED-not-declared: strip a node-declared "tools" from every offer at this ONE
+	// node-facing door. A node can NEVER earn "tools" by asserting it (unlike "vision", which
+	// stays declared); only the broker's own tool-call canary stamps it (recordToolProbe). So
+	// after this strip the only path to a verified "tools" on an offer is a peer's authoritative
+	// stamp via the shared registry, and the local probe verdict (b.toolsOK) at emission. See
+	// features/trust/toolcall_probe.feature ("A node CANNOT earn 'tools' merely by declaring it").
+	for i := range reg.Offers {
+		reg.Offers[i].Capabilities = stripDeclaredTools(reg.Offers[i].Capabilities)
+	}
 	// Price-safety, operator side: a HARD, GLOBAL ceiling on what ANY station may charge -
 	// public, --private, AND confidential ALIKE. It runs UNCONDITIONALLY here (before
 	// owner-binding, attestation, and the private-band mint below), so NO flag exempts it.
@@ -471,6 +480,11 @@ func (b *broker) register(w http.ResponseWriter, r *http.Request) {
 				_ = b.shared.putNode(reg.NodeID, raw, livenessTTL)
 			}
 		}
+		// A re-register republished the STRIPPED (tools-free) offers above; if this node still
+		// carries a verified "tools" verdict (b.toolsOK), re-stamp the shared registry so a peer
+		// keeps surfacing it - the verified bit survives a re-register (only a probe regression
+		// clears it). A no-op when nothing is verified for this node.
+		b.mirrorToolsToShared(reg.NodeID)
 	}
 
 	// Private band: ensure this node has a band (mint once, idempotent on re-register).

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -480,16 +480,9 @@ func (b *broker) register(w http.ResponseWriter, r *http.Request) {
 				_ = b.shared.putNode(reg.NodeID, raw, livenessTTL)
 			}
 		}
-		// A re-register republished the STRIPPED (tools-free) offers above; if this node still
-		// carries a verified "tools" verdict (b.toolsOK), re-stamp the shared registry so a peer
-		// keeps surfacing it - the verified bit survives a re-register (only a probe regression
-		// clears it). Gated so a never-verified node skips the redundant shared write.
-		b.metricsMu.Lock()
-		reStamp := b.hasVerifiedToolsLocked(reg.NodeID)
-		b.metricsMu.Unlock()
-		if reStamp {
-			b.mirrorToolsToShared(reg.NodeID)
-		}
+		// NOTE: the verified "tools" bit is NOT carried in the registration JSON - it is
+		// first-class shared state (shared.markToolsVerified / toolsVerified, merged into
+		// b.toolsMerged on the sync loop), so a re-register never clobbers or resurrects it.
 	}
 
 	// Private band: ensure this node has a band (mint once, idempotent on re-register).
@@ -785,6 +778,10 @@ func (b *broker) syncLivenessOnce() {
 	//     reconciled, and the token ping-pong became SELF-SUSTAINING: rotated tokens
 	//     could never converge (the v5.0.0 flag=1 launch symptom).
 	b.syncRegistry()
+	// Refresh the cross-instance verified-tools union on the same tick (BEFORE the liveness
+	// early-return, so a host's regression clear still propagates when the liveness snapshot is
+	// momentarily empty). Keeps the hot /discover + /market read in-memory.
+	b.syncToolsVerified()
 	snap, err := b.shared.liveness()
 	if err != nil || len(snap) == 0 {
 		return

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -204,12 +204,13 @@ func (b *broker) register(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, http.StatusUnauthorized, "registration timestamp stale or skewed")
 		return
 	}
-	// VERIFIED-not-declared: strip a node-declared "tools" from every offer at this ONE
-	// node-facing door. A node can NEVER earn "tools" by asserting it (unlike "vision", which
-	// stays declared); only the broker's own tool-call canary stamps it (recordToolProbe). So
-	// after this strip the only path to a verified "tools" on an offer is a peer's authoritative
-	// stamp via the shared registry, and the local probe verdict (b.toolsOK) at emission. See
-	// features/trust/toolcall_probe.feature ("A node CANNOT earn 'tools' merely by declaring it").
+	// VERIFIED-not-declared: strip a node-declared "tools" from every offer at this node-facing
+	// door. A node can NEVER earn "tools" by asserting it (unlike "vision", which stays declared);
+	// only the broker's own tool-call canary grants it, via the FIRST-CLASS shared verdict store.
+	// This strip is defence-in-depth: emission (withVerifiedTools) ALSO strips a stored "tools"
+	// and re-adds it only from the probe verdict, so an ingestion path that bypasses this door
+	// (shared-registry mirror, lazy learn, DB re-hydrate) still cannot leak an unproven "tools".
+	// See features/trust/toolcall_probe.feature ("A node CANNOT earn 'tools' merely by declaring it").
 	for i := range reg.Offers {
 		reg.Offers[i].Capabilities = stripDeclaredTools(reg.Offers[i].Capabilities)
 	}

--- a/features/operator/agent_ready_verified.feature
+++ b/features/operator/agent_ready_verified.feature
@@ -1,0 +1,110 @@
+# AGENT-READY, VERIFIED — the consumer half of the tool-call capability probe. Once the
+# broker emits a VERIFIED "tools" capability (features/trust/toolcall_probe.feature), the
+# AGENT view stops INFERRING agent-readiness from the context window alone and starts
+# reporting the real, probed signal.
+#
+# WHERE THIS SITS (grounded in the merged code, origin/main 76d4a24):
+#   · band_gate.feature already pins the CTX floor: the open channel's station window, when
+#     KNOWN, must be >= operatorCtxFloor (16384; operator.go:60). Below it, the handoff is
+#     REFUSED ("✕ this band is too small for a guest"). That gate is UNCHANGED here.
+#   · Today the pre-launch plate ALWAYS warns "tool-call support unproven on this band - the
+#     guest may fall back to plain text" (operator.go:952), because no tool signal exists.
+#     band_gate.feature calls tool-call support "UNKNOWN on every band today".
+#   · The AGENT redesign (being built concurrently) renders an agent-ready marker. Grounded on
+#     the ctx floor alone it is INFERRED, drawn with a "~" (⌁~) and the plate's "unproven" warn.
+#     This spec makes it VERIFIED (⌁, no tilde) once "tools" is emitted for the band's model,
+#     and DROPS/UPGRADES the plate warn for that band.
+#
+# THE THREE-STATE HONESTY this pins (the truth-in-labeling house rule, like CtxEstimated's ~
+# and TokenizerExact): the AGENT view reports exactly one of:
+#   VERIFIED agent-ready (⌁)   — the open channel's station model carries the probed "tools"
+#                                capability AND ctx >= floor. No tilde, no "unproven" warn.
+#   INFERRED agent-ready (⌁~)  — ctx >= floor but "tools" is absent (unprobed/undetermined).
+#                                The tilde stays; the plate keeps the "unproven" warn.
+#   TOO SMALL (✕)              — ctx KNOWN and < floor: the existing refusal, regardless of tools.
+#   ABSENT                     — ctx unknown (0): the existing unknown-window warn; tools absence
+#                                still claims nothing (never a positive "no tools").
+#
+# The marker reads the OPEN CHANNEL's station (m.connected), the station the guest is actually
+# patched into — the same source band_gate reads — NOT the band's best station.
+#
+# FOUNDER FLAG A1: confirm the exact upgraded plate copy for a VERIFIED band (e.g. drop the warn
+# entirely, or restate it as "tool-call support verified on this band ✓"). Proposed: DROP the
+# unproven warn and show nothing (silence = verified), matching the desk's "no data" honesty.
+
+Feature: The AGENT view reports agent-readiness as VERIFIED only when the band's model has the probed tool-call capability
+  Agent-ready is inferred from the context window until the broker verifies tool-calling;
+  once "tools" is emitted for the open channel's model, the reading upgrades to verified
+  and the pre-launch plate drops its "unproven" warning. The ctx floor still gates handoff.
+
+  Background:
+    Given an AGENT session with a tuned band "qwen3-32b-fp8" and a live proxy holder
+    And a detected guest "opencode"
+
+  # --- state 1: VERIFIED (⌁) — ctx >= floor AND probed tools ----------------------------
+
+  Scenario: A band whose model carries verified "tools" reads VERIFIED agent-ready
+    Given the open channel's station reports a context window of 131072 tokens
+    And the open channel's station model carries the verified "tools" capability
+    Then the AGENT view reads the band as VERIFIED agent-ready
+    And the verified marker carries no "~" estimate tilde
+
+  Scenario: The pre-launch plate drops the "unproven" tool-call warning on a verified band (FOUNDER FLAG A1)
+    Given the open channel's station reports a context window of 131072 tokens
+    And the open channel's station model carries the verified "tools" capability
+    When the user runs "/operator opencode"
+    Then the pre-launch plate does NOT warn that tool-call support is unproven
+    And the handoff proceeds through the plate as normal
+
+  # --- state 2: INFERRED (⌁~) — ctx >= floor, tools absent -------------------------------
+
+  Scenario: A large-window band with NO tools signal reads INFERRED agent-ready
+    Given the open channel's station reports a context window of 131072 tokens
+    And the open channel's station model has no "tools" capability
+    Then the AGENT view reads the band as INFERRED agent-ready
+    And the inferred marker carries the "~" unproven tilde
+
+  Scenario: The plate KEEPS the "unproven" warning on an unprobed band
+    Given the open channel's station reports a context window of 131072 tokens
+    And the open channel's station model has no "tools" capability
+    When the user runs "/operator opencode"
+    Then the pre-launch plate warns that tool-call support is unproven
+
+  # --- state 3: TOO SMALL (✕) — ctx known and under floor -------------------------------
+
+  Scenario: A sub-floor band reads TOO SMALL regardless of tools, and the handoff is still refused
+    Given the open channel's station reports a context window of 8192 tokens
+    Then the AGENT view reads the band as too small for a guest
+    When the user runs "/operator opencode"
+    Then the handoff is refused because the band is too small
+    And no pre-launch plate is shown
+
+  Scenario: A verified-tools signal never overrides the ctx floor
+    Given the open channel's station reports a context window of 8192 tokens
+    And the open channel's station model carries the verified "tools" capability
+    Then the AGENT view reads the band as too small for a guest
+    And a verified tool-call capability does not lift the too-small refusal
+
+  # --- state 4: ABSENT — unknown window, tools claims nothing ----------------------------
+
+  Scenario: An unknown-window band warns, and absent tools still claims nothing
+    Given the open channel's station reports no context window
+    When the user runs "/operator opencode"
+    Then the pre-launch plate warns the context window is unknown
+    And the absent tool-call capability is read as undetermined, never as "no tools"
+
+  # --- liveness: the reading tracks the open channel, and re-tunes immediately -----------
+
+  Scenario: Re-tuning to a verified band upgrades the reading from inferred to verified
+    Given the open channel's station reports a context window of 131072 tokens
+    And the open channel's station model has no "tools" capability
+    Then the AGENT view reads the band as INFERRED agent-ready
+    When the consumer re-tunes to a station whose model carries verified "tools"
+    Then the AGENT view reads the band as VERIFIED agent-ready
+
+  Scenario: Losing the verified signal downgrades verified back to inferred, never to a false claim
+    Given the open channel's station model carries the verified "tools" capability
+    And the AGENT view reads the band as VERIFIED agent-ready
+    When the broker drops "tools" for that model after a regression
+    Then the AGENT view reads the band as INFERRED agent-ready
+    And it never keeps claiming verified once the probe evidence is gone

--- a/features/trust/toolcall_probe.feature
+++ b/features/trust/toolcall_probe.feature
@@ -1,0 +1,184 @@
+# TOOL-CALL CAPABILITY PROBE — the broker follow-on that turns an INFERRED "agent-ready"
+# reading into a VERIFIED one. This is the fix band_gate.feature flagged (FOUNDER FLAG G1:
+# "fund the probe gap — a 'tools' capability label + a broker tool-call canary — as a
+# follow-up"). It is the FOURTH trust pillar next to verified-serving (the liveness canary),
+# confidential (◆), and lineage receipts.
+#
+# THE GAP TODAY (grounded in the merged code, origin/main 76d4a24):
+#   · protocol.knownCapabilities is a CLOSED node-DECLARED set; its only member is "vision"
+#     (protocol.go:105-109, commit 74b109f). There is NO "tools" member, and no probe backs
+#     any capability — a node simply ASSERTS "vision" and the broker canonicalizes it.
+#   · The broker probe (cmd/rogerai-broker/probe.go) sends a deterministic /v1/chat/completions
+#     CANARY and measures liveness + TTFT + tok/s (evalCanary). It does NOT send a tool
+#     definition and NEVER inspects a tool_calls response.
+#   · /discover + /market emit per-offer Capabilities canonicalized at read (market.go:174),
+#     so whatever the CLOSED set recognizes flows to consumers exactly like "vision".
+#
+# THE RULE THIS SPEC PINS:
+#   "tools" is a VERIFIED capability, NOT a declared one. A model earns "tools" only when the
+#   broker's own tool-call canary confirms the provider HONORS an OpenAI tool-call request
+#   (a well-formed tool_calls response to a "call this function" prompt). A node CANNOT earn
+#   it by declaring it — unlike "vision" (declared-not-probed; the asymmetry is called out in
+#   the "Adversarial" section and left as FOUNDER FLAG T3). This is the same discipline as
+#   confidential ◆ (verified, not asserted) rather than vision (asserted, not verified).
+#
+# WIRING (reuse, don't rebuild — the minimization rung):
+#   · The tool canary rides the EXISTING probe schedule/backoff/jitter/per-owner cap
+#     (probeOnce): same adaptive floor->ceiling cadence, so it never hammers a node. It is a
+#     SECOND assertion folded into the SAME canary round, not a new loop.
+#   · The pass/fail verdict is a PURE function over the response body (toolCallOK), the twin of
+#     evalCanary's fingerprint check — table-tested with no live node.
+#   · The earned bit is stamped on the node's trust/metrics state (like probeOK / verifiedServing)
+#     and materialized into the offer's Capabilities as "tools" on the /discover + /market read.
+#   · Multi-instance: the earned bit mirrors to the shared store and is read as a UNION, exactly
+#     like the registry/liveness pattern (persistent-state / no per-instance memory), so two broker
+#     instances neither double-probe nor split the verdict.
+#
+# FOUNDER FLAGS (approval gate):
+#   T1 (cadence): the tool canary rides the EXISTING performance-probe cadence (adaptive 30s
+#      floor -> 15m ceiling). Confirm it is NOT a separate, more-frequent loop.
+#   T2 (cost): the canary is an UNBILLED probe job (User="probe", result discarded) with a
+#      trivial tool + a tiny max_tokens. Confirm the free/negligible-spend tolerance and whether
+#      the tool canary should ride ONLY free-band / already-scheduled rounds.
+#   T3 (vision asymmetry): "vision" stays DECLARED-not-probed while "tools" is probed. Confirm we
+#      do NOT (yet) probe vision, and that the honesty copy never implies vision is verified.
+#   T4 (strictness): does a well-formed tool_calls to the WRONG function name still count as
+#      "honors tool-calling" (lenient: structure proves it), or must the name match the canary's
+#      trivial function (strict)? Default in this spec: STRUCTURE proves it (lenient) — see the
+#      canary table test.
+
+Feature: A model earns the verified "tools" capability only when the broker's tool-call canary confirms the provider honors an OpenAI tool call
+  The broker probes tool-calling with its own canary; "tools" is emitted on the public
+  feed only for a model that returned a well-formed tool_calls response, and a model that
+  stops honoring tool calls loses the capability. A node can never earn it by declaring it.
+
+  Background:
+    Given an online node that heartbeats fresh
+    And the node offers a chat model with a context window of 131072 tokens
+
+  # --- the signal: "tools" is a KNOWN, canonicalized capability -----------------------
+
+  Scenario: "tools" is a recognized capability, canonicalized like "vision"
+    When the broker canonicalizes the capability list "tools"
+    Then the capability "tools" survives canonicalization
+    And it is lowercased, trimmed, and deduped exactly like "vision"
+
+  Scenario: A node CANNOT earn "tools" merely by declaring it on registration
+    Given the node declares the capability "tools" in its offer
+    And the broker has never run a passing tool-call canary against that model
+    Then the model's public capabilities do NOT include "tools"
+    # Declared-not-probed is the vision discipline; "tools" is verified-not-declared.
+
+  # --- the probe: the tool-call canary --------------------------------------------------
+
+  Scenario: A passing tool-call canary earns the model "tools"
+    When the broker sends its tool-call canary to the model
+    And the provider returns a well-formed tool_calls response
+    Then the model earns the verified "tools" capability
+    And "tools" appears in that model's public capabilities
+
+  Scenario: A malformed or absent tool_calls response does NOT earn "tools" (unproven stays unproven)
+    When the broker sends its tool-call canary to the model
+    And the provider answers in plain text with no tool_calls
+    Then the model does NOT earn "tools"
+    And its public capabilities omit "tools" rather than claiming an unproven one
+
+  Scenario: A provider that emits an empty tool_calls array does not earn "tools"
+    When the broker sends its tool-call canary to the model
+    And the provider returns finish_reason "tool_calls" but an empty tool_calls array
+    Then the model does NOT earn "tools"
+
+  Scenario: A provider that returns garbage/unparseable body does not earn "tools"
+    When the broker sends its tool-call canary to the model
+    And the provider returns an unparseable response body
+    Then the model does NOT earn "tools"
+
+  # --- honest regression: a model that regresses LOSES the cap --------------------------
+
+  Scenario: A model that stops honoring tool calls loses "tools"
+    Given the model previously earned the verified "tools" capability
+    When a later tool-call canary fails to produce a well-formed tool_calls response
+    Then the model loses "tools"
+    And its public capabilities no longer include "tools"
+
+  Scenario: The verified "tools" bit is per-MODEL, not per-node
+    Given the node offers two chat models
+    And only the first model returns a well-formed tool_calls response to the canary
+    Then only the first model's public capabilities include "tools"
+    And the second model's capabilities omit "tools"
+
+  # --- cadence / caching: reuse the existing probe schedule, never hammer ---------------
+
+  Scenario: The tool-call canary rides the existing adaptive probe cadence (FOUNDER FLAG T1)
+    Then the tool-call canary is dispatched on the same probe round as the liveness canary
+    And an idle model's tool-call re-probe backs off floor->ceiling like the performance probe
+    And real served traffic and demand-probing reset that backoff the same way
+
+  Scenario: The tool-call canary is unbilled and negligible-cost (FOUNDER FLAG T2)
+    When the broker sends its tool-call canary to the model
+    Then the canary job is marked unbilled and its result is discarded
+    And no wallet is touched and no receipt is settled
+    And the canary carries a trivial single-parameter tool and a tiny token budget
+
+  Scenario: A voice-only node is never tool-call probed
+    Given the node offers only a tts voice model
+    Then no tool-call canary is dispatched to it
+    And its capabilities never claim "tools"
+
+  # --- emission: "tools" flows through /discover + /market like "vision" -----------------
+
+  Scenario: A verified model surfaces "tools" on /discover
+    Given the model has earned the verified "tools" capability
+    When a consumer reads /discover
+    Then the model's offer lists "tools" in its capabilities
+    And the value is canonicalized at read, never trusted raw from the wire
+
+  Scenario: A verified vision+tools model lists both, sorted and deduped
+    Given the model accepts images and has earned the verified "tools" capability
+    When a consumer reads /market
+    Then the model's capabilities are exactly "tools" and "vision" in canonical order
+
+  Scenario: Absence still claims nothing (undetermined, never a false "no tools")
+    Given the model has never been tool-call probed
+    When a consumer reads /discover
+    Then the capabilities key is absent for that offer
+    And absence is read as UNDETERMINED, never as a positive "text only / no tools"
+
+  # --- adversarial / edge ----------------------------------------------------------------
+
+  Scenario: A node lying that it supports tools is caught by the canary, not trusted
+    Given the node declares "tools" but its upstream ignores tool definitions
+    When the broker's tool-call canary runs
+    Then the model does NOT earn "tools"
+    # The probe IS the check for tools. "vision" remains DECLARED-not-probed (FOUNDER FLAG T3):
+    # the vision/tools asymmetry is deliberate and flagged, not silently equated.
+
+  Scenario: A provider that supports tools but RATE-LIMITS the canary is not falsely regressed
+    Given the model previously earned the verified "tools" capability
+    When the tool-call canary comes back as a transport error or a 429 rate-limit
+    Then the earned "tools" bit is NOT cleared on a transient non-verdict
+    And the probe is retried on a later round rather than recorded as a regression
+    # Mirrors the liveness probe's "a dispatch that never reached the node is not evidence".
+
+  Scenario: A wrong-function but well-formed tool_calls still proves tool-calling (FOUNDER FLAG T4, lenient default)
+    When the provider returns a well-formed tool_calls entry for a DIFFERENT function name
+    Then the model earns "tools" under the lenient rule
+    # Structure (a valid tool_calls array with a function name + parseable arguments) proves the
+    # provider HONORS tool-calling; exact-name matching is the strict alternative left to T4.
+
+  # --- multi-instance: two brokers must not double-probe or split the verdict ------------
+
+  Scenario: Two broker instances share the verified "tools" verdict (no per-instance split)
+    Given the broker runs two instances behind the shared store
+    And instance A ran a passing tool-call canary against the model
+    When a consumer reads /discover from instance B
+    Then instance B also surfaces "tools" for that model
+    # The earned bit mirrors to the shared store and is read as a UNION, like registry/liveness
+    # (persistent-state / no per-instance memory). Neither instance re-probes what the other proved.
+
+  Scenario: A non-authoritative peer does not clear "tools" on its own failed cross-instance probe
+    Given instance A hosts the node's live poll and proved "tools"
+    And instance B is a peer that merely mirrors the node
+    When instance B's cross-instance tool-call canary times out
+    Then "tools" is NOT cleared for the model
+    # Same authoritative-poll-host gate the /discover flicker fix uses (market.go authoritative).

--- a/features/trust/toolcall_probe.feature
+++ b/features/trust/toolcall_probe.feature
@@ -166,6 +166,16 @@ Feature: A model earns the verified "tools" capability only when the broker's to
     # Structure (a valid tool_calls array with a function name + parseable arguments) proves the
     # provider HONORS tool-calling; exact-name matching is the strict alternative left to T4.
 
+  Scenario: A "tools" that slips into a STORED offer (mirror / re-hydrate) is still not emitted unprobed
+    Given the model's stored offer already lists "tools" from a mixed-version mirror
+    And the broker has never run a passing tool-call canary against that model
+    Then the model's public capabilities do NOT include "tools"
+    # REGRESSION GUARD (pre-push audit, major): register strips a node-declared "tools", but the
+    # shared-registry mirror, the lazy tunnel learn, and the DB re-hydrate ingest raw regs that
+    # never passed that door (a mixed-version rolling deploy can mirror a pre-strip "tools").
+    # Emission (withVerifiedTools) strips a stored "tools" and re-adds it ONLY from the probe
+    # verdict, so no ingestion path can leak an unproven "tools" to the public feed.
+
   # --- multi-instance: two brokers must not double-probe or split the verdict ------------
 
   Scenario: Two broker instances share the verified "tools" verdict (no per-instance split)

--- a/features/trust/toolcall_probe.feature
+++ b/features/trust/toolcall_probe.feature
@@ -182,3 +182,13 @@ Feature: A model earns the verified "tools" capability only when the broker's to
     When instance B's cross-instance tool-call canary times out
     Then "tools" is NOT cleared for the model
     # Same authoritative-poll-host gate the /discover flicker fix uses (market.go authoritative).
+
+  Scenario: An authoritative host regression clears "tools" for every peer (no stale peer bit)
+    Given the broker runs two instances behind the shared store
+    And instance A ran a passing tool-call canary against the model
+    And a consumer on instance B surfaces "tools" for that model
+    When instance A's authoritative canary later regresses the model
+    Then instance B no longer surfaces "tools" for that model
+    # REGRESSION GUARD (pre-push audit, major): the verdict is FIRST-CLASS shared state, not a
+    # per-instance monotonic map, so the host's clear propagates to the peer on its next sync -
+    # a peer can never keep surfacing (or re-stamp/resurrect) a verdict the host retracted.

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -101,17 +101,30 @@ func (o *ModelOffer) Normalize() {
 	o.Capabilities = CanonicalCapabilities(o.Capabilities)
 }
 
-// CapVision marks a chat model that accepts image_url content (the photo path).
+// CapVision marks a chat model that accepts image_url content (the photo path). It is
+// DECLARED-not-probed: a node asserts it and the broker canonicalizes it (no probe backs it).
 const CapVision = "vision"
+
+// CapTools marks a chat model VERIFIED to honor OpenAI tool-calls. Unlike CapVision it is
+// VERIFIED-not-declared: a node can NEVER earn it by asserting it in its offer - only the
+// broker's own tool-call canary (cmd/rogerai-broker/probe.go) grants it, after the provider
+// returned a well-formed tool_calls response. The broker strips a node-declared "tools" at
+// registration; the sole writer of a verified "tools" is the probe. The vision/tools
+// asymmetry is deliberate (FOUNDER FLAG T3): vision stays declared, tools is probed.
+const CapTools = "tools"
 
 // knownCapabilities is the CLOSED set of chat sub-capabilities the broker recognizes. A value
 // outside it is dropped (never trusted raw), the same discipline canonicalUnit applies to units.
-var knownCapabilities = map[string]bool{CapVision: true}
+// "vision" is DECLARED (a node asserts it); "tools" is a KNOWN, canonicalizable LABEL here but
+// VERIFIED-not-declared in practice - the broker strips a node's self-declared "tools" at
+// registration and only its own probe stamps it (see CapTools + the broker register/probe path).
+var knownCapabilities = map[string]bool{CapVision: true, CapTools: true}
 
 // CanonicalCapabilities lowercases, dedupes, drops unknown values, and returns a stable-sorted
 // slice - or nil for an empty/nil input so the JSON key is omitted (undetermined) rather than
-// emitted as [] (a positive "text only" claim). Capabilities are node-declared (the broker
-// cannot re-probe a node's model), so they are canonicalized, not derived.
+// emitted as [] (a positive "text only" claim). Capabilities are canonicalized, not derived:
+// "vision" is node-declared, while "tools" only ever reaches this function AFTER the broker's
+// probe has stamped it (a node-declared "tools" is stripped upstream, at registration).
 func CanonicalCapabilities(in []string) []string {
 	if in == nil {
 		return nil

--- a/internal/protocol/toolcap_red_test.go
+++ b/internal/protocol/toolcap_red_test.go
@@ -1,0 +1,34 @@
+package protocol
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestToolsCapabilityRecognized is the SIGNAL half of the tool-call capability probe
+// (features/trust/toolcall_probe.feature). It is RED against origin/main: knownCapabilities
+// is the CLOSED set {"vision"} (protocol.go:105-109), so "tools" is dropped as unknown and
+// CanonicalCapabilities([]string{"tools"}) returns []string{} today. GREEN adds
+// CapTools ("tools") to knownCapabilities so a probed model can carry it exactly like
+// "vision" — canonicalized, lowercased, trimmed, deduped, sorted with "vision".
+func TestToolsCapabilityRecognized(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"tools survives canonicalization", []string{"tools"}, []string{"tools"}},
+		{"lowercased + trimmed like vision", []string{" Tools "}, []string{"tools"}},
+		{"deduped", []string{"tools", "tools"}, []string{"tools"}},
+		{"tools + vision sorted canonically", []string{"vision", "tools"}, []string{"tools", "vision"}},
+		{"unknown dropped, tools kept", []string{"telepathy", "TOOLS"}, []string{"tools"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := CanonicalCapabilities(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("CanonicalCapabilities(%v) = %v, want %v (\"tools\" must be a known, verified capability)", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -1289,6 +1289,12 @@ func (m model) agentView(w int) string {
 		mdlCell = stDim.Render(" ") + stEmber.Render("no model tuned in")
 	} else {
 		mdlCell = stDim.Render(" on ") + stKey.Render(mdl)
+		// The open channel's agent-ready marker: "⌁" VERIFIED (probed tool-calls) or "⌁~"
+		// INFERRED (window qualifies, tools unproven). Silent when too-small/unknown (the
+		// refusal + window warn carry those). Reads m.connected, the station patched in.
+		if tag := m.operatorChannelAgentTag(); tag != "" {
+			mdlCell += stDim.Render(" ") + stKey.Render(tag)
+		}
 	}
 	// MODE CLARITY: AGENT (tool-calling) keeps the RED accent bar + a "· tools" tag, so it
 	// reads as visibly distinct from the mono-barred TUNE-IN (basic chat) view that shares

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -522,6 +522,58 @@ func (m model) operatorChannelCtx() (ctx int, estimated bool) {
 	return m.connected.Ctx, m.connected.CtxEstimated
 }
 
+// operatorChannelTools reports whether the OPEN CHANNEL's station carries the broker-VERIFIED
+// "tools" capability - the probed tool-call signal, read from m.connected (the station the
+// guest is actually patched into), NOT the band's best station. Absent = UNDETERMINED (the
+// probe has not proven it), never a positive "no tools" (features/operator/agent_ready_verified).
+func (m model) operatorChannelTools() bool {
+	return m.connected != nil && offerHasCapability(*m.connected, "tools")
+}
+
+// agentReadyState is the THREE-STATE (plus ABSENT) honesty the AGENT view reports for the open
+// channel, the truth-in-labeling house rule (like CtxEstimated's ~): exactly one of verified,
+// inferred, too-small, or absent. The ctx floor still gates the handoff regardless of tools.
+type agentReadyState int
+
+const (
+	agentReadyAbsent   agentReadyState = iota // ctx unknown (0): claims nothing; tools undetermined
+	agentReadyTooSmall                        // ctx KNOWN and < floor: the existing refusal, tools irrelevant
+	agentReadyInferred                        // ctx >= floor but "tools" absent (unprobed): ⌁~ + the plate warn
+	agentReadyVerified                        // ctx >= floor AND probed "tools": ⌁ (no tilde), the warn drops
+)
+
+// operatorAgentReadyState classifies the OPEN CHANNEL's agent-readiness. A verified tool-call
+// capability NEVER lifts the too-small refusal (the ctx floor is independent); an unknown window
+// is ABSENT (never a false "no tools"). It reads m.connected, the same source band_gate reads.
+func (m model) operatorAgentReadyState() agentReadyState {
+	ctx, _ := m.operatorChannelCtx()
+	switch {
+	case ctx <= 0:
+		return agentReadyAbsent
+	case ctx < operatorCtxFloor:
+		return agentReadyTooSmall
+	case m.operatorChannelTools():
+		return agentReadyVerified
+	default:
+		return agentReadyInferred
+	}
+}
+
+// operatorChannelAgentTag is the open channel's agent-ready marker glyph: "⌁" VERIFIED (probed
+// tools, no tilde), "⌁~" INFERRED (window qualifies, tools unproven), or "" when the channel is
+// too small / unknown (the refusal + unknown-window warn carry those, not a marker). It is the
+// consumer twin of agentReadyTag(band), reading the open channel instead of the band aggregate.
+func (m model) operatorChannelAgentTag() string {
+	switch m.operatorAgentReadyState() {
+	case agentReadyVerified:
+		return agentReadyGlyph()
+	case agentReadyInferred:
+		return agentReadyGlyph() + "~"
+	default:
+		return ""
+	}
+}
+
 // operatorCtxLabel renders a window with the house ~ estimate honesty ("8k" / "~8k").
 // It TRUNCATES to the familiar window name (spec-pinned: 32768 -> "32k", 131072 ->
 // "131k") where the band-table fmtCtx rounds (32768 -> "33k") - the desk speaks the
@@ -1048,7 +1100,14 @@ func (m model) operatorPlateView(w int) string {
 	if ctx, _ := m.operatorChannelCtx(); ctx <= 0 {
 		warn("context window unknown on this band - the guest may hit the wall mid-task")
 	}
-	warn("tool-call support unproven on this band - the guest may fall back to plain text")
+	// Tool-call honesty (FOUNDER FLAG A1): DROP the "unproven" warn entirely on a band whose
+	// open channel carries the broker-VERIFIED "tools" capability (silence = verified, matching
+	// the desk's "no data" honesty). It KEEPS the warn on an unprobed/inferred/unknown band -
+	// the guest may still fall back to plain text there. Verified-not-declared: a node cannot
+	// silence this warn by declaring "tools"; only the broker's tool-call probe drops it.
+	if m.operatorAgentReadyState() != agentReadyVerified {
+		warn("tool-call support unproven on this band - the guest may fall back to plain text")
+	}
 	if p.det.Unverified {
 		v := p.det.Version
 		if v == "" {

--- a/internal/tui/operator_agent_ready_steps_test.go
+++ b/internal/tui/operator_agent_ready_steps_test.go
@@ -1,0 +1,218 @@
+package tui
+
+// operator_agent_ready_steps_test.go - step definitions for
+// features/operator/agent_ready_verified.feature: the AGENT view reports agent-readiness as
+// VERIFIED (⌁) only when the OPEN CHANNEL's model carries the broker-probed "tools" capability
+// AND ctx >= floor, INFERRED (⌁~) when the window qualifies but tools is absent, TOO SMALL (✕)
+// when ctx is known and under the floor (regardless of tools), and ABSENT when the window is
+// unknown. It drives the REAL bubbletea model through the same opBDD harness the band_gate
+// steps use (m.connected is the open channel), asserting the real classifiers
+// (operatorAgentReadyState / operatorChannelAgentTag) and the plate warn gate - no mocks.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+// setChannelTools stamps the broker-VERIFIED "tools" capability onto the OPEN CHANNEL's station
+// (m.connected). If no station is on the channel yet (a Given that names tools before a window),
+// it opens one at an agent-ready window so "reads VERIFIED" holds. It never lowers an existing
+// window - a ctx-8192 station keeps its sub-floor window so the too-small gate still wins.
+func (s *opBDD) setChannelTools() error {
+	s.mutate(func(m *model) {
+		if m.connected == nil {
+			mdl := "qwen3-32b-fp8"
+			if m.proxyHolder != nil {
+				mdl = m.proxyHolder.Get().Model
+			}
+			m.connected = &offer{NodeID: "KDGPU-7", Model: mdl, Online: true, Ctx: 131072}
+		}
+		if !offerHasCapability(*m.connected, "tools") {
+			m.connected.Capabilities = append(m.connected.Capabilities, "tools")
+		}
+	})
+	if s.model().connected == nil {
+		return fmt.Errorf("no open-channel station to carry the tools capability")
+	}
+	return nil
+}
+
+// clearChannelTools drops the verified "tools" bit from the open channel (a broker regression),
+// leaving the window untouched - the reading must fall back to INFERRED, never a stale VERIFIED.
+func (s *opBDD) clearChannelTools() error {
+	s.mutate(func(m *model) {
+		if m.connected == nil {
+			return
+		}
+		var kept []string
+		for _, c := range m.connected.Capabilities {
+			if strings.EqualFold(strings.TrimSpace(c), "tools") {
+				continue
+			}
+			kept = append(kept, c)
+		}
+		m.connected.Capabilities = kept
+	})
+	return nil
+}
+
+func (s *opBDD) channelHasNoTools() error { return s.clearChannelTools() }
+
+func (s *opBDD) retuneToVerifiedTools() error {
+	if err := s.setStation(131072, false); err != nil {
+		return err
+	}
+	return s.setChannelTools()
+}
+
+// --- reading assertions (the real classifier, driven by m.connected) ------------------------
+
+func (s *opBDD) readsVerified() error {
+	if st := s.model().operatorAgentReadyState(); st != agentReadyVerified {
+		return fmt.Errorf("AGENT view reads state %d, want VERIFIED agent-ready (ctx>=floor AND probed tools)", st)
+	}
+	return nil
+}
+
+func (s *opBDD) readsInferred() error {
+	if st := s.model().operatorAgentReadyState(); st != agentReadyInferred {
+		return fmt.Errorf("AGENT view reads state %d, want INFERRED agent-ready (ctx>=floor, tools absent)", st)
+	}
+	return nil
+}
+
+func (s *opBDD) readsTooSmall() error {
+	if st := s.model().operatorAgentReadyState(); st != agentReadyTooSmall {
+		return fmt.Errorf("AGENT view reads state %d, want TOO SMALL (ctx known and under floor)", st)
+	}
+	return nil
+}
+
+func (s *opBDD) verifiedMarkerNoTilde(_ string) error {
+	tag := s.model().operatorChannelAgentTag()
+	if tag == "" {
+		return fmt.Errorf("no agent-ready marker on a verified band")
+	}
+	if strings.HasSuffix(tag, "~") {
+		return fmt.Errorf("the verified marker carries an estimate tilde (%q) - verified must have no ~", tag)
+	}
+	return nil
+}
+
+func (s *opBDD) inferredMarkerTilde(_ string) error {
+	tag := s.model().operatorChannelAgentTag()
+	if !strings.HasSuffix(tag, "~") {
+		return fmt.Errorf("the inferred marker (%q) lacks the unproven ~ tilde", tag)
+	}
+	return nil
+}
+
+// --- plate warn gate ------------------------------------------------------------------------
+
+const plateToolWarn = "tool-call support unproven"
+
+func (s *opBDD) plateDropsToolWarn() error {
+	if strings.Contains(s.plateText(), plateToolWarn) {
+		return fmt.Errorf("the plate still warns tool-call support is unproven on a VERIFIED band:\n%s", s.plateText())
+	}
+	if s.model().operatorPlate == nil {
+		return fmt.Errorf("no plate is up to inspect (transcript: %s)", s.view())
+	}
+	return nil
+}
+
+func (s *opBDD) plateKeepsToolWarn() error {
+	if !strings.Contains(s.plateText(), plateToolWarn) {
+		return fmt.Errorf("the plate does not warn tool-call support is unproven on an UNPROBED band:\n%s", s.plateText())
+	}
+	return nil
+}
+
+func (s *opBDD) handoffProceedsThroughPlate() error {
+	if s.model().operatorPlate == nil {
+		return fmt.Errorf("the handoff did not proceed to the plate (transcript: %s)", s.view())
+	}
+	return nil
+}
+
+func (s *opBDD) handoffRefusedTooSmall() error { return s.handoffRefused() }
+
+func (s *opBDD) verifiedDoesNotLiftRefusal() error {
+	// The ctx floor is independent of tools: with a verified tools bit AND a sub-floor window,
+	// the band still reads too-small and the gate still shuts (operatorBandTooSmall). Assert the
+	// verified bit is present yet the too-small gate is unmoved - a probe never lifts the floor.
+	if !s.model().operatorChannelTools() {
+		return fmt.Errorf("the open channel is not carrying the verified tools bit for this check")
+	}
+	if !s.model().operatorBandTooSmall() {
+		return fmt.Errorf("a verified tool-call capability lifted the too-small gate (the ctx floor must be independent)")
+	}
+	if st := s.model().operatorAgentReadyState(); st != agentReadyTooSmall {
+		return fmt.Errorf("state is %d with verified tools under the floor, want TOO SMALL", st)
+	}
+	return nil
+}
+
+func (s *opBDD) plateWarnsCtxUnknown() error {
+	if !strings.Contains(s.plateText(), "context window unknown") {
+		return fmt.Errorf("the plate does not warn the context window is unknown:\n%s", s.plateText())
+	}
+	return nil
+}
+
+// absentToolsUndetermined: an unknown-window band's absent tools is UNDETERMINED, never a
+// positive "no tools". Assert the reading is ABSENT, no verified/inferred marker is shown, and
+// nothing in the view falsely claims the band has "no tools".
+func (s *opBDD) absentToolsUndetermined(_ string) error {
+	if st := s.model().operatorAgentReadyState(); st != agentReadyAbsent {
+		return fmt.Errorf("unknown-window state is %d, want ABSENT", st)
+	}
+	if tag := s.model().operatorChannelAgentTag(); tag != "" {
+		return fmt.Errorf("an unknown-window band shows an agent-ready marker %q (a claim it cannot back)", tag)
+	}
+	if s.model().operatorChannelTools() {
+		return fmt.Errorf("absent tools read as a positive claim")
+	}
+	if v := s.plateText(); strings.Contains(v, "no tools") {
+		return fmt.Errorf("the plate falsely claims 'no tools' for an undetermined band:\n%s", v)
+	}
+	return nil
+}
+
+func (s *opBDD) neverKeepsVerified() error {
+	if st := s.model().operatorAgentReadyState(); st == agentReadyVerified {
+		return fmt.Errorf("the reading still claims VERIFIED after the probe evidence was dropped")
+	}
+	if tag := s.model().operatorChannelAgentTag(); tag != "" && !strings.HasSuffix(tag, "~") {
+		return fmt.Errorf("the marker still reads verified (%q) after tools was dropped", tag)
+	}
+	return nil
+}
+
+func initializeAgentReadyVerifiedSteps(st *opBDD, sc *godog.ScenarioContext) {
+	sc.Step(`^the open channel's station model carries the verified "([^"]*)" capability$`,
+		func(string) error { return st.setChannelTools() })
+	sc.Step(`^the open channel's station model has no "([^"]*)" capability$`,
+		func(string) error { return st.channelHasNoTools() })
+	sc.Step(`^the consumer re-tunes to a station whose model carries verified "([^"]*)"$`,
+		func(string) error { return st.retuneToVerifiedTools() })
+	sc.Step(`^the broker drops "([^"]*)" for that model after a regression$`,
+		func(string) error { return st.clearChannelTools() })
+
+	sc.Step(`^the AGENT view reads the band as VERIFIED agent-ready$`, st.readsVerified)
+	sc.Step(`^the AGENT view reads the band as INFERRED agent-ready$`, st.readsInferred)
+	sc.Step(`^the AGENT view reads the band as too small for a guest$`, st.readsTooSmall)
+	sc.Step(`^the verified marker carries no "([^"]*)" estimate tilde$`, st.verifiedMarkerNoTilde)
+	sc.Step(`^the inferred marker carries the "([^"]*)" unproven tilde$`, st.inferredMarkerTilde)
+
+	sc.Step(`^the pre-launch plate does NOT warn that tool-call support is unproven$`, st.plateDropsToolWarn)
+	sc.Step(`^the pre-launch plate warns that tool-call support is unproven$`, st.plateKeepsToolWarn)
+	sc.Step(`^the handoff proceeds through the plate as normal$`, st.handoffProceedsThroughPlate)
+	sc.Step(`^the handoff is refused because the band is too small$`, st.handoffRefusedTooSmall)
+	sc.Step(`^a verified tool-call capability does not lift the too-small refusal$`, st.verifiedDoesNotLiftRefusal)
+	sc.Step(`^the pre-launch plate warns the context window is unknown$`, st.plateWarnsCtxUnknown)
+	sc.Step(`^the absent tool-call capability is read as undetermined, never as "([^"]*)"$`, st.absentToolsUndetermined)
+	sc.Step(`^it never keeps claiming verified once the probe evidence is gone$`, st.neverKeepsVerified)
+}

--- a/internal/tui/operator_steps_tui_test.go
+++ b/internal/tui/operator_steps_tui_test.go
@@ -1972,4 +1972,7 @@ func initializeOperatorScenarios(t *testing.T, st *opBDD, sc *godog.ScenarioCont
 
 	// ── operator frame enrichment (rc_enrichment.feature) ─────────────────────
 	initializeEnrichmentSteps(st, sc)
+
+	// ── tool-call capability probe: VERIFIED vs INFERRED agent-ready ──────────
+	initializeAgentReadyVerifiedSteps(st, sc)
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -606,6 +606,10 @@ type band struct {
 	lineage  int     // count of confidential/lineage stations
 	verified bool    // any ONLINE station passed the broker's serving probe (✓, distinct from ◆)
 	vision   bool    // any station DECLARED the "vision" capability (◪; never inferred)
+	tools    bool    // any station carries the broker-VERIFIED "tools" capability (agent-ready ⌁,
+	// no tilde). Unlike vision it is verified-not-declared: the broker only emits "tools" on an
+	// offer after its tool-call canary passed, so a node can never fake it. Absence => inferred
+	// (⌁~), never a false "no tools". See features/trust/toolcall_probe.feature.
 	inFlight int     // active (in-flight) requests summed across online stations - the REAL
 	// activity that animates the signal meter (idle band steady, busy band scans). Honest:
 	// it is the broker's live load, never a fabricated pulse.
@@ -6092,23 +6096,25 @@ func offerHasCapability(o offer, cap string) bool {
 	return false
 }
 
-// bandAgentReady reports whether a band is coding-agent capable, and whether that
-// readiness is INFERRED (from the window) rather than proven (R5). Today it is ALWAYS
-// inferred from the representative window meeting the agent-ready floor (operatorCtxFloor,
-// the same 16k gate the handoff uses); a later broker tool-call probe can flip inferred
-// off. An UNKNOWN window (ctx 0) is NOT claimed agent-ready here - the badge never
-// asserts a window it cannot see (that is the auto-tune partition's job, not the badge's).
+// bandAgentReady reports whether a band is coding-agent capable, and whether that readiness
+// is INFERRED (from the window alone) rather than VERIFIED (the broker's tool-call probe).
+// Readiness needs the representative window to meet the agent-ready floor (operatorCtxFloor,
+// the same 16k gate the handoff uses). It is VERIFIED (inferred=false, ⌁) when a station on
+// the band carries the broker-probed "tools" capability, and INFERRED (inferred=true, ⌁~) when
+// the window qualifies but no tool-call proof exists yet. An UNKNOWN window (ctx 0) is NOT
+// claimed agent-ready here - the badge never asserts a window it cannot see.
 func bandAgentReady(bd band) (ready, inferred bool) {
 	ctx, _ := bandCtx(bd)
 	if ctx >= operatorCtxFloor {
-		return true, true
+		return true, !bd.tools // probed tools -> VERIFIED (no tilde); absent -> INFERRED (~)
 	}
 	return false, false
 }
 
 // agentReadyTag is the agent-ready badge glyph for a band, or "" when it is not
-// agent-ready: "⌁" proven, "⌁~" inferred (R5, always inferred today). The ONE place the
-// ⌁ / inferred-~ shape is composed, shared by the band table + the /model picker tail.
+// agent-ready: "⌁" VERIFIED (a station carries the broker-probed "tools" capability), "⌁~"
+// INFERRED (window qualifies but tool-calling is unproven). The ONE place the ⌁ / inferred-~
+// shape is composed, shared by the band table + the /model picker tail.
 func agentReadyTag(bd band) string {
 	ready, inferred := bandAgentReady(bd)
 	if !ready {
@@ -6231,6 +6237,12 @@ func groupBands(offers []offer, limits *LimitStore) []band {
 		// (online or not) - a vision model does not stop being multimodal while off air.
 		if offerHasCapability(o, "vision") {
 			b.vision = true
+		}
+		// A broker-VERIFIED "tools" capability is intrinsic to the model too (it earned it
+		// from the tool-call canary), so it counts from any station carrying it. It upgrades
+		// the agent-ready badge from inferred (⌁~) to verified (⌁) - never a declared claim.
+		if offerHasCapability(o, "tools") {
+			b.tools = true
 		}
 		if !o.Online {
 			continue


### PR DESCRIPTION
## Tool-call capability probe: INFERRED `⌁~` → VERIFIED `⌁`

Upgrades the AGENT redesign's INFERRED "agent-ready `⌁~`" badge to a VERIFIED `⌁` once a band is
probed to actually honor OpenAI tool-calls. `"tools"` becomes the fourth trust pillar next to
verified-serving, confidential (◆), and lineage receipts.

**This touches BROKER (prod relay) code. BUILD-AND-HOLD: please review before merge - do not
auto-merge.**

### Design: verified-not-declared, first-class shared state
`"tools"` is a VERIFIED capability, never a declared one. A node can NOT earn it by asserting it
(unlike `"vision"`, which stays declared-not-probed). The SOLE writer of a verified `"tools"` is
the broker's own tool-call canary.

- The verdict is **first-class shared state** (a Redis `toolsok` hash, per-`(node,model)` field
  with a freshness TTL), NOT carried in registration JSON. `markToolsVerified` on a pass,
  `clearToolsVerified` on an authoritative regression, `toolsVerified(ttl)` read as the
  cross-instance UNION, merged into `b.toolsMerged` on the existing sync loop (hot read stays
  in-memory). This is the `persistent-state / scale-on-demand` discipline: no per-instance verdict
  that a peer could split or resurrect.
- **Emission is the gate**: `withVerifiedTools` STRIPS any `"tools"` in a stored/mirrored offer and
  re-adds it ONLY from the probe verdict, so no ingestion path (register, shared-registry mirror,
  lazy learn, DB re-hydrate, a mixed-version rolling deploy) can leak an unproven `"tools"`.
- Only the **authoritative poll host** clears (on a definitive regression) and refreshes (busy-node
  served-traffic keep-alive); a peer's transient/definitive non-verdict never clears, and a peer
  never re-marks from a stale local bit.

### Founder rulings (delegated defaults - documented to overrule)
- **T1 cadence:** the tool canary rides the EXISTING performance-probe cadence (adaptive 30s→15m),
  folded into the SAME `probeOnce` round as the liveness canary - not a new loop.
- **T2 cost:** unbilled probe (`User="probe"`, discarded), trivial single-parameter tool, tiny
  `max_tokens` (64); rides already-scheduled rounds; voice-only nodes never probed.
- **T3 vision:** vision stays DECLARED-not-probed; not probed/verified here. A spec scenario pins it.
- **T4 strictness:** LENIENT - any well-formed `tool_calls` structure proves tool-calling (`wantFn`
  threaded, not required).
- **A1 plate:** a verified band DROPS the "tool-call support unproven" warn (silence = verified);
  keeps it on an inferred/unknown band.

### Spec-first, RED → GREEN
- `features/trust/toolcall_probe.feature` - 21 scenarios (executable, GREEN), incl. 2 regression
  scenarios added from the pre-push audit (host-regression-clears-every-peer; a mirrored declared
  `"tools"` is not emitted unprobed).
- `features/operator/agent_ready_verified.feature` - 9 scenarios (executable, GREEN).
- Confirmed RED first (`CanonicalCapabilities(["tools"]) == []`, `undefined: toolCallOK`,
  9 undefined operator scenarios); implemented to GREEN. No existing scenario weakened.

### Pre-push audit history (the gate ran on every push)
The static claude-audit caught real multi-instance bugs across four rounds; each fix landed with a
regression test, and the final push passed (verdict PASS, high confidence):
1. reg-JSON stamp let a peer resurrect a cleared verdict → replaced with first-class shared state.
2. the shared clear was gated on a local-map transition (broke post-restart) → unconditional
   idempotent clear.
3. a declared `"tools"` in a mirrored/re-hydrated offer emitted as verified → strip at emission;
   plus per-model probing and a busy-node keep-alive.
4. the busy-node keep-alive re-marked from a non-authoritative peer's stale bit → authority-gated.

### Advisory minors from the passing audit (for founder review, not blocking)
1. Both instances canary each due node (no cross-instance probe gate) - ~2x probe load; the
   spec's "neither double-probe" wording is aspirational for the verdict, not the dispatch.
2. The lazy stale-field HDEL sweep can race a concurrent `markToolsVerified` (tiny window, self-heals
   next sync).
3. `authoritativeFor` reads the round-start time after jitter/probe wait (~35s stale authority read).
4. The canary body is deterministic (a hostile node could fingerprint it and fake a pass), unlike
   the rotating liveness fingerprint - a design tradeoff (a stable tool definition vs. anti-gaming).

### Verification
- `go build ./...`, `go vet ./...` clean.
- `go test ./internal/protocol ./cmd/rogerai-broker ./internal/tui` (godog strict) - all pass.
- `-race` on the broker (incl. multi-instance bus canary + markMeasured) + tui - clean.
- `make cover-gate` **PASS** - total 92.3%, every package ≥ 90% (cmd/rogerai-broker, internal/
  protocol 95.7%, internal/tui 92.4%).
- pre-push cover-gate + claude-audit both **PASS**.

No `Co-Authored-By`, no `COVER_GATE_SKIP`.
