### PR TITLE
proxy: reasoning->content fallback on the relay path (option A, default ON)

### DIFF
--- a/features/proxy/reasoning_fallback.feature
+++ b/features/proxy/reasoning_fallback.feature
@@ -89,6 +89,33 @@ Feature: Proxy reasoning->content fallback (relay path)
       Then the status is 200
       And the streamed content is "the answer is 42"
 
+    Scenario: The synthesized content is delivered BEFORE the finish_reason chunk
+      # a strict client that finalizes on finish_reason must still see the content
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker streams reasoning deltas "answer" and no content
+      When a chat request is made
+      Then the streamed content is "answer"
+      And the synthesized content precedes the finish_reason chunk
+
+  Rule: A tool-call turn's empty content is left intact (never filled)
+
+    Scenario: Non-streaming - an empty-content reply carrying tool_calls is not filled
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker returns a tool-call reply with empty content and reasoning "calling weather api"
+      When a chat request is made
+      Then the reply content is empty
+      And the response body is byte-for-byte the broker's body
+
+    Scenario: Streaming - a reasoning+tool_call stream gets no synthesized content delta
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker streams a reasoning delta "thinking" then a tool_call and no content
+      When a chat request is made
+      Then the streamed content is ""
+      And no content delta was synthesized
+
     Scenario: The original reasoning deltas still pass through (the double-mirror tradeoff)
       Given a tuned band whose model is "gpt-oss-120b"
       And the local proxy is bound to that band

--- a/features/proxy/reasoning_fallback.feature
+++ b/features/proxy/reasoning_fallback.feature
@@ -1,0 +1,138 @@
+Feature: Proxy reasoning->content fallback (relay path)
+  Some reasoning models emit their final answer in the message.reasoning (or
+  reasoning_content) channel and leave message.content EMPTY. Strict OpenAI clients
+  (e.g. hermes -z) read only content, see it empty, and report "no final response -
+  failed". The local relay proxy surfaces the reasoning AS content when, and only when,
+  content is genuinely empty, so every client on a reasoning-heavy band gets a usable
+  reply. This ONLY reshapes the response body text: it never changes billing, model,
+  routing, or the SSE cost-meter comment, which pass through untouched.
+
+  Founder ruling (option A, 2026-07-08): the fallback is ON by default. Because we fill
+  only EMPTY content, a client that reads reasoning separately still gets the reasoning
+  field intact AND now a content mirror - the accepted double-mirror tradeoff. A caller
+  that needs raw passthrough can disable it per session.
+
+  # NON-STREAMING (application/json): the whole body is buffered, transformed, forwarded.
+  Rule: Non-streaming - empty content is filled from reasoning
+
+    Scenario: Empty content plus reasoning surfaces the reasoning as content
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker returns message content "" and reasoning "the answer is 42"
+      When a chat request is made
+      Then the status is 200
+      And the reply content is "the answer is 42"
+
+    Scenario: Whitespace-only content counts as empty and is filled
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker returns message content "   \n" and reasoning "42"
+      When a chat request is made
+      Then the reply content is "42"
+
+    Scenario: The reasoning_content field name is also honored
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker returns message content "" and reasoning_content "deepseek says hi"
+      When a chat request is made
+      Then the reply content is "deepseek says hi"
+
+    Scenario: The reasoning field is preserved intact (the double-mirror tradeoff)
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker returns message content "" and reasoning "kept"
+      When a chat request is made
+      Then the reply content is "kept"
+      And the reply reasoning is still "kept"
+
+  Rule: Non-streaming - real content is never overwritten and never duplicated
+
+    Scenario: Non-empty content is left exactly as the provider sent it
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker returns message content "real answer" and reasoning "hidden thinking"
+      When a chat request is made
+      Then the reply content is "real answer"
+      And the response body is byte-for-byte the broker's body
+
+    Scenario: Empty content AND empty reasoning stays empty (nothing to surface)
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker returns message content "" and reasoning ""
+      When a chat request is made
+      Then the reply content is empty
+      And the response body is byte-for-byte the broker's body
+
+  Rule: Non-streaming - the money path is untouched
+
+    Scenario: The billed cost header passes through unchanged while content is filled
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker bills "0.0025" for the next non-streaming reply
+      And the broker returns message content "" and reasoning "billed answer"
+      When a chat request is made
+      Then the reply content is "billed answer"
+      And the response carries cost header "0.0025"
+
+  # STREAMING (text/event-stream): all chunks pass through live and byte-for-byte; if the
+  # stream ends having emitted reasoning deltas but ZERO content, one synthesized content
+  # delta carrying the accumulated reasoning is injected immediately before [DONE]. v1
+  # limitation: the reasoning is delivered as a single consolidated delta at stream end,
+  # not re-chunked live as it arrives.
+  Rule: Streaming - an all-reasoning stream delivers the reasoning as content
+
+    Scenario: Reasoning-only deltas are surfaced as a synthesized content delta
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker streams reasoning deltas "the ans" "wer is 42" and no content
+      When a chat request is made
+      Then the status is 200
+      And the streamed content is "the answer is 42"
+
+    Scenario: The original reasoning deltas still pass through (the double-mirror tradeoff)
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker streams reasoning deltas "the ans" "wer is 42" and no content
+      When a chat request is made
+      Then the streamed reasoning is still "the answer is 42"
+
+  Rule: Streaming - a stream with content is never touched or duplicated
+
+    Scenario: A normal content stream is delivered verbatim with no synthesized delta
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the broker streams content deltas "Hello" " world"
+      When a chat request is made
+      Then the streamed content is "Hello world"
+      And no content delta was synthesized
+
+  Rule: Streaming - the SSE cost-meter comment passes through untouched
+
+    Scenario: The rogerai-cost meter comment survives a synthesized-content stream
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the local proxy is bound to that band
+      And the stream will bill "0.0009"
+      And the broker streams reasoning deltas "done" and no content
+      When a chat request is made
+      Then the streamed content is "done"
+      And the SSE cost-meter comment for "0.0009" is present
+
+  Rule: The fallback is toggleable and defaults ON
+
+    Scenario: Disabled - a non-streaming empty-content reply passes through raw
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the reasoning fallback is disabled
+      And the local proxy is bound to that band
+      And the broker returns message content "" and reasoning "not surfaced"
+      When a chat request is made
+      Then the reply content is empty
+      And the response body is byte-for-byte the broker's body
+
+    Scenario: Disabled - a reasoning-only stream passes through raw (no synthesized delta)
+      Given a tuned band whose model is "gpt-oss-120b"
+      And the reasoning fallback is disabled
+      And the local proxy is bound to that band
+      And the broker streams reasoning deltas "hidden" and no content
+      When a chat request is made
+      Then the streamed content is ""
+      And no content delta was synthesized

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1022,6 +1022,14 @@ func reasoningFallback(content, reasoning, reasoningContent string) (string, boo
 	return "", false // nothing to surface: content stays empty
 }
 
+// hasToolCalls reports whether a message's tool_calls field is present and non-empty. On such a
+// turn the empty content is intentional (the "answer" is the tool call), so the reasoning
+// fallback must NOT fill it - mirroring internal/harness.parseCompletion's guard.
+func hasToolCalls(raw json.RawMessage) bool {
+	s := strings.TrimSpace(string(raw))
+	return s != "" && s != "null" && s != "[]"
+}
+
 // applyReasoningFallback rewrites a NON-streaming chat/completions JSON body so a choice whose
 // message.content is empty/whitespace has that content filled from its reasoning channel
 // (message.reasoning or reasoning_content). It returns the ORIGINAL bytes unchanged when
@@ -1036,9 +1044,10 @@ func applyReasoningFallback(body []byte) []byte {
 	var probe struct {
 		Choices []struct {
 			Message struct {
-				Content          string `json:"content"`
-				Reasoning        string `json:"reasoning"`
-				ReasoningContent string `json:"reasoning_content"`
+				Content          string          `json:"content"`
+				Reasoning        string          `json:"reasoning"`
+				ReasoningContent string          `json:"reasoning_content"`
+				ToolCalls        json.RawMessage `json:"tool_calls"`
 			} `json:"message"`
 		} `json:"choices"`
 	}
@@ -1047,6 +1056,9 @@ func applyReasoningFallback(body []byte) []byte {
 	}
 	need := false
 	for _, c := range probe.Choices {
+		if hasToolCalls(c.Message.ToolCalls) {
+			continue // a tool-call turn's empty content is intentional - leave it (mirrors parseCompletion)
+		}
 		if _, ok := reasoningFallback(c.Message.Content, c.Message.Reasoning, c.Message.ReasoningContent); ok {
 			need = true
 			break
@@ -1075,6 +1087,11 @@ func applyReasoningFallback(body []byte) []byte {
 		msg, ok := cm["message"].(map[string]any)
 		if !ok {
 			continue
+		}
+		if tc, ok := msg["tool_calls"]; ok && tc != nil {
+			if arr, isArr := tc.([]any); !isArr || len(arr) > 0 {
+				continue // tool-call turn: leave its content as sent
+			}
 		}
 		content, _ := msg["content"].(string)
 		reasoning, _ := msg["reasoning"].(string)
@@ -1134,6 +1151,7 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 	// Per-choice accumulation across the whole stream (index -> builders).
 	contentBuf := map[int]*strings.Builder{}
 	reasoningBuf := map[int]*strings.Builder{}
+	toolCalls := map[int]bool{} // a choice that streamed tool_calls: its empty content is BY DESIGN
 	buf := func(m map[int]*strings.Builder, idx int) *strings.Builder {
 		b := m[idx]
 		if b == nil {
@@ -1145,7 +1163,8 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 	injected := false
 
 	// synthesize writes one content delta per choice that emitted reasoning but no visible
-	// content, in ascending index order (deterministic). It is the whole fix, in one place.
+	// content (and no tool_calls - a tool turn's empty content is intentional), in ascending
+	// index order (deterministic). It is the whole fix, in one place.
 	synthesize := func() {
 		if injected {
 			return
@@ -1157,6 +1176,9 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 		}
 		sort.Ints(idxs)
 		for _, idx := range idxs {
+			if toolCalls[idx] {
+				continue // don't overwrite a tool-call turn's (legitimately empty) content
+			}
 			r := reasoningBuf[idx].String()
 			content := ""
 			if cb := contentBuf[idx]; cb != nil {
@@ -1174,32 +1196,47 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 		}
 	}
 
-	// observe parses a data: JSON line to track content/reasoning deltas per choice.
-	observe := func(payload string) {
+	// observe parses a data: JSON line to track content/reasoning/tool_calls deltas per choice,
+	// returning true when the chunk carries a finish_reason (the point to inject BEFORE, so the
+	// synthesized content lands ahead of the turn being marked finished - the strict-client fix).
+	observe := func(payload string) (finished bool) {
 		var d struct {
 			Choices []struct {
-				Index int `json:"index"`
-				Delta struct {
-					Content          string `json:"content"`
-					Reasoning        string `json:"reasoning"`
-					ReasoningContent string `json:"reasoning_content"`
+				Index        int             `json:"index"`
+				FinishReason json.RawMessage `json:"finish_reason"`
+				Delta        struct {
+					Content          string          `json:"content"`
+					Reasoning        string          `json:"reasoning"`
+					ReasoningContent string          `json:"reasoning_content"`
+					ToolCalls        json.RawMessage `json:"tool_calls"`
 				} `json:"delta"`
 			} `json:"choices"`
 		}
 		if json.Unmarshal([]byte(payload), &d) != nil {
-			return
+			return false
 		}
 		for _, c := range d.Choices {
 			if c.Delta.Content != "" {
 				buf(contentBuf, c.Index).WriteString(c.Delta.Content)
 			}
-			if c.Delta.ReasoningContent != "" {
-				buf(reasoningBuf, c.Index).WriteString(c.Delta.ReasoningContent)
+			// Cap the accumulated reasoning so a pathological multi-MB reasoning stream can't grow
+			// memory unbounded (the non-streaming path is bounded by maxTransformBody).
+			if rb := reasoningBuf[c.Index]; rb == nil || rb.Len() < maxTransformBody {
+				if c.Delta.ReasoningContent != "" {
+					buf(reasoningBuf, c.Index).WriteString(c.Delta.ReasoningContent)
+				}
+				if c.Delta.Reasoning != "" {
+					buf(reasoningBuf, c.Index).WriteString(c.Delta.Reasoning)
+				}
 			}
-			if c.Delta.Reasoning != "" {
-				buf(reasoningBuf, c.Index).WriteString(c.Delta.Reasoning)
+			if len(c.Delta.ToolCalls) > 0 && string(c.Delta.ToolCalls) != "null" {
+				toolCalls[c.Index] = true
+			}
+			if fr := strings.TrimSpace(string(c.FinishReason)); fr != "" && fr != "null" {
+				finished = true
 			}
 		}
+		return finished
 	}
 
 	// Line-buffered forwarding: hold each line so the synthesized delta can be injected BEFORE
@@ -1231,12 +1268,14 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 			if strings.HasPrefix(text, "data:") {
 				payload := strings.TrimSpace(strings.TrimPrefix(text, "data:"))
 				if payload == "[DONE]" {
-					synthesize() // inject before the terminal sentinel
+					synthesize() // inject before the terminal sentinel (fallback if no finish chunk)
 					write(line)
 					line = line[:0]
 					continue
 				}
-				observe(payload)
+				if observe(payload) {
+					synthesize() // inject BEFORE the finish chunk so content precedes finish_reason
+				}
 			}
 			write(line)
 			line = line[:0]
@@ -1258,7 +1297,7 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 		}
 		write(line)
 	}
-	synthesize() // no [DONE] seen (or already injected -> no-op): best-effort at EOF
+	synthesize() // no [DONE]/finish seen (or already injected -> no-op): best-effort at EOF
 	return meter.cost
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1163,10 +1163,21 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 		return b
 	}
 	injected := map[int]bool{} // per-choice latch: which choices we've already resolved
-	// Envelope metadata copied from the last observed chunk so a synthesized chunk is a
-	// well-formed sibling (some strict SDK parsers require id/object/model on every chunk).
-	var lastID, lastObject, lastModel string
-	var lastCreated json.Number
+	// Envelope metadata copied verbatim from the last observed chunk so a synthesized chunk is a
+	// well-formed sibling (some strict SDK parsers require id/object/model on every chunk). Held
+	// as raw JSON so a nonstandard type (a numeric id, a string created) is re-emitted as-is and
+	// can NEVER fail the chunk parse and silently drop tracking (audit finding).
+	var lastID, lastObject, lastCreated, lastModel json.RawMessage
+	keep := func(dst *json.RawMessage, v json.RawMessage) {
+		if len(v) > 0 && string(v) != "null" {
+			*dst = v
+		}
+	}
+	putRaw := func(m map[string]any, k string, v json.RawMessage) {
+		if len(v) > 0 && string(v) != "null" {
+			m[k] = v // json.RawMessage marshals verbatim (string, number, whatever it was)
+		}
+	}
 
 	// synthesizeChoice writes the reasoning->content delta for ONE choice, once. It is a no-op
 	// when the choice has real content, a tool_calls turn (empty content is intentional), or no
@@ -1195,18 +1206,10 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 		chunk := map[string]any{
 			"choices": []any{map[string]any{"index": idx, "delta": map[string]any{"content": text}}},
 		}
-		if lastID != "" {
-			chunk["id"] = lastID
-		}
-		if lastObject != "" {
-			chunk["object"] = lastObject
-		}
-		if lastCreated != "" {
-			chunk["created"] = lastCreated
-		}
-		if lastModel != "" {
-			chunk["model"] = lastModel
-		}
+		putRaw(chunk, "id", lastID)
+		putRaw(chunk, "object", lastObject)
+		putRaw(chunk, "created", lastCreated)
+		putRaw(chunk, "model", lastModel)
 		payload, _ := json.Marshal(chunk)
 		write([]byte("data: " + string(payload) + "\n\n"))
 	}
@@ -1229,10 +1232,10 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 	// point to inject BEFORE, so the synthesized content lands ahead of THAT choice finishing).
 	observe := func(payload string) (finishedIdx []int) {
 		var d struct {
-			ID      string      `json:"id"`
-			Object  string      `json:"object"`
-			Created json.Number `json:"created"`
-			Model   string      `json:"model"`
+			ID      json.RawMessage `json:"id"`
+			Object  json.RawMessage `json:"object"`
+			Created json.RawMessage `json:"created"`
+			Model   json.RawMessage `json:"model"`
 			Choices []struct {
 				Index        int             `json:"index"`
 				FinishReason json.RawMessage `json:"finish_reason"`
@@ -1247,18 +1250,10 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 		if json.Unmarshal([]byte(payload), &d) != nil {
 			return nil
 		}
-		if d.ID != "" {
-			lastID = d.ID
-		}
-		if d.Object != "" {
-			lastObject = d.Object
-		}
-		if d.Created != "" {
-			lastCreated = d.Created
-		}
-		if d.Model != "" {
-			lastModel = d.Model
-		}
+		keep(&lastID, d.ID)
+		keep(&lastObject, d.Object)
+		keep(&lastCreated, d.Created)
+		keep(&lastModel, d.Model)
 		for _, c := range d.Choices {
 			if c.Delta.Content != "" {
 				buf(contentBuf, c.Index).WriteString(c.Delta.Content)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -404,6 +405,14 @@ type ProxyOptions struct {
 	// launch sets DefaultSessionBudget.
 	Budget float64
 	Alert  AlertFunc // surfaced when failover is exhausted (nil = silent)
+	// ReasoningFallbackOff disables the reasoning->content fallback (founder ruling, option
+	// A, 2026-07-08). The fallback is ON by default (this flag's zero value): when an upstream
+	// reply leaves message.content EMPTY but carries reasoning (message.reasoning or
+	// reasoning_content), the proxy surfaces that reasoning AS content so strict clients
+	// (hermes -z) don't see a blank answer on a reasoning-heavy band. Set true for RAW
+	// passthrough (a client that wants the untouched provider body). It ONLY reshapes the
+	// response body text - billing, model, routing, and the SSE cost meter are never touched.
+	ReasoningFallbackOff bool
 }
 
 // DefaultSessionBudget is the per-session spend cap the guest-operator launch applies by
@@ -843,7 +852,7 @@ func relayWithFailover(ctx context.Context, w http.ResponseWriter, opts ProxyOpt
 			// the broker's `: rogerai-cost=` SSE meter comment (passed through unchanged) and
 			// returns it - billed at stream END, per the ceiling (the crossing stream
 			// completes; the NEXT call is refused).
-			if sc := copyRelayResponse(w, resp); sc > 0 && onStreamCost != nil {
+			if sc := copyRelayResponse(w, resp, !opts.ReasoningFallbackOff); sc > 0 && onStreamCost != nil {
 				onStreamCost(sc)
 			}
 			resp.Body.Close()
@@ -911,12 +920,19 @@ func failoverError(crit Criteria, lastStatus int, lastErr error) string {
 	return fmt.Sprintf("no provider available for %q%s - %s", crit.Model, suffix, reason)
 }
 
-// copyRelayResponse mirrors the broker's response (status, meter headers, body)
-// to the local client, flushing per chunk so SSE streaming works end-to-end. On an SSE
-// response it also scans the pass-through for the broker's `: rogerai-cost=` meter comment
-// (the ONLY cost meter a stream carries - headers were flushed before output) and returns
-// the amount; 0 when absent (an old broker: graceful degrade, never an error).
-func copyRelayResponse(w http.ResponseWriter, resp *http.Response) (sseCost float64) {
+// maxTransformBody bounds how much of a NON-streaming body we buffer to apply the
+// reasoning->content fallback. A completion body is KB-scale; anything larger is forwarded raw
+// (untransformed) rather than held in memory - a defensive ceiling, not an expected path.
+const maxTransformBody = 8 << 20
+
+// copyRelayResponse mirrors the broker's response (status, meter headers, body) to the local
+// client. On an SSE response it delegates to streamRelayBody (which passes the stream through,
+// scans the broker's `: rogerai-cost=` meter comment - the ONLY cost meter a stream carries -
+// and, when reasoningFallbackOn, injects the reasoning->content fallback). On a NON-streaming
+// body it buffers, applies applyReasoningFallback when enabled, and forwards. reasoningFallbackOn
+// only reshapes body text; status, headers (incl. the billed X-RogerAI-Cost), and the SSE meter
+// pass through untouched.
+func copyRelayResponse(w http.ResponseWriter, resp *http.Response, reasoningFallbackOn bool) (sseCost float64) {
 	ct := resp.Header.Get("Content-Type")
 	if ct == "" {
 		ct = "application/json"
@@ -931,30 +947,23 @@ func copyRelayResponse(w http.ResponseWriter, resp *http.Response) (sseCost floa
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
-	var meter *sseMeter
+
 	if strings.Contains(ct, "text/event-stream") {
-		meter = &sseMeter{}
+		return streamRelayBody(w, resp.Body, reasoningFallbackOn)
 	}
-	flusher, _ := w.(http.Flusher)
-	buf := make([]byte, 4096)
-	for {
-		n, err := resp.Body.Read(buf)
-		if n > 0 {
-			w.Write(buf[:n])
-			if meter != nil {
-				meter.scan(buf[:n])
-			}
-			if flusher != nil {
-				flusher.Flush()
-			}
-		}
-		if err != nil {
-			break
-		}
+
+	// Non-streaming JSON: buffer (bounded), transform if enabled, forward. Billing is in the
+	// headers already written above; the body transform never touches it.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxTransformBody+1))
+	if len(body) > maxTransformBody { // oversized: forward raw, untransformed
+		w.Write(body)
+		io.Copy(w, resp.Body)
+		return 0
 	}
-	if meter != nil {
-		return meter.cost
+	if reasoningFallbackOn {
+		body = applyReasoningFallback(body)
 	}
+	w.Write(body)
 	return 0
 }
 
@@ -993,6 +1002,264 @@ func (m *sseMeter) scan(p []byte) {
 			m.overflow = true
 		}
 	}
+}
+
+// reasoningFallback decides whether an assistant turn's EMPTY content should be surfaced from
+// its reasoning channel, and with what text. It returns (text, true) ONLY when content is
+// blank/whitespace AND a non-blank reasoning channel exists; reasoning_content is preferred
+// over reasoning (providers emit one or the other). It NEVER replaces real content - the guard
+// against overwriting or double-emitting a genuine answer.
+func reasoningFallback(content, reasoning, reasoningContent string) (string, bool) {
+	if strings.TrimSpace(content) != "" {
+		return "", false // a real answer: leave it exactly as sent
+	}
+	if strings.TrimSpace(reasoningContent) != "" {
+		return reasoningContent, true
+	}
+	if strings.TrimSpace(reasoning) != "" {
+		return reasoning, true
+	}
+	return "", false // nothing to surface: content stays empty
+}
+
+// applyReasoningFallback rewrites a NON-streaming chat/completions JSON body so a choice whose
+// message.content is empty/whitespace has that content filled from its reasoning channel
+// (message.reasoning or reasoning_content). It returns the ORIGINAL bytes unchanged when
+// nothing applies or the body is not the expected shape (fail-safe: never corrupt a response
+// we don't fully understand), so real-content / nothing-to-do / error bodies are byte-identical
+// passthrough. Only message.content is touched; every other field - including reasoning itself
+// (the accepted double-mirror) and usage token counts - is preserved (json.Number keeps
+// numbers bit-for-bit). Billing lives in headers, not the body, so it is never affected here.
+func applyReasoningFallback(body []byte) []byte {
+	// Cheap typed probe: does any choice actually need the fallback? If not, skip re-encoding
+	// entirely and hand back the original bytes untouched.
+	var probe struct {
+		Choices []struct {
+			Message struct {
+				Content          string `json:"content"`
+				Reasoning        string `json:"reasoning"`
+				ReasoningContent string `json:"reasoning_content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil || len(probe.Choices) == 0 {
+		return body
+	}
+	need := false
+	for _, c := range probe.Choices {
+		if _, ok := reasoningFallback(c.Message.Content, c.Message.Reasoning, c.Message.ReasoningContent); ok {
+			need = true
+			break
+		}
+	}
+	if !need {
+		return body
+	}
+	// At least one choice needs surfacing: re-parse generically (UseNumber preserves token
+	// counts) and mutate only the affected message.content values.
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	var root map[string]any
+	if err := dec.Decode(&root); err != nil {
+		return body
+	}
+	choices, ok := root["choices"].([]any)
+	if !ok {
+		return body
+	}
+	for _, ci := range choices {
+		cm, ok := ci.(map[string]any)
+		if !ok {
+			continue
+		}
+		msg, ok := cm["message"].(map[string]any)
+		if !ok {
+			continue
+		}
+		content, _ := msg["content"].(string)
+		reasoning, _ := msg["reasoning"].(string)
+		reasoningContent, _ := msg["reasoning_content"].(string)
+		if text, ok := reasoningFallback(content, reasoning, reasoningContent); ok {
+			msg["content"] = text
+		}
+	}
+	out, err := json.Marshal(root)
+	if err != nil {
+		return body // never emit a half-built body
+	}
+	return out
+}
+
+// maxSSELine bounds the per-line buffer of the streaming injector. A data: line longer than
+// this is flushed in pieces and treated as opaque passthrough (it can never be the tiny
+// [DONE] sentinel or meter comment), so a huge chunk can neither grow memory nor be misparsed.
+const maxSSELine = 1 << 20
+
+// streamRelayBody copies an SSE relay stream to the client, flushing per event so streaming
+// works end-to-end, and scanning for the broker's `: rogerai-cost=` meter comment (returned as
+// the stream's only cost signal). When reasoningFallbackOn and the whole stream emitted
+// reasoning deltas but ZERO visible content, it injects ONE synthesized content delta carrying
+// the accumulated reasoning immediately BEFORE the terminal [DONE] (or at EOF if the provider
+// sent none) - the fix for strict clients (hermes -z) that see empty content and fail. v1
+// limitation: the reasoning is delivered as a single consolidated delta at stream end, not
+// re-chunked live as it arrives. Everything else - the original reasoning deltas (the accepted
+// double-mirror), the finish chunk, [DONE], and the meter comment - passes through byte-for-byte.
+func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn bool) (sseCost float64) {
+	flusher, _ := w.(http.Flusher)
+	meter := &sseMeter{}
+	write := func(p []byte) {
+		w.Write(p)
+		meter.scan(p)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+
+	// Raw byte-for-byte passthrough when the fallback is disabled (a caller that wants the
+	// untouched provider stream) - identical to the legacy relay behavior.
+	if !reasoningFallbackOn {
+		buf := make([]byte, 4096)
+		for {
+			n, err := body.Read(buf)
+			if n > 0 {
+				write(buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+		return meter.cost
+	}
+
+	// Per-choice accumulation across the whole stream (index -> builders).
+	contentBuf := map[int]*strings.Builder{}
+	reasoningBuf := map[int]*strings.Builder{}
+	buf := func(m map[int]*strings.Builder, idx int) *strings.Builder {
+		b := m[idx]
+		if b == nil {
+			b = &strings.Builder{}
+			m[idx] = b
+		}
+		return b
+	}
+	injected := false
+
+	// synthesize writes one content delta per choice that emitted reasoning but no visible
+	// content, in ascending index order (deterministic). It is the whole fix, in one place.
+	synthesize := func() {
+		if injected {
+			return
+		}
+		injected = true
+		idxs := make([]int, 0, len(reasoningBuf))
+		for idx := range reasoningBuf {
+			idxs = append(idxs, idx)
+		}
+		sort.Ints(idxs)
+		for _, idx := range idxs {
+			r := reasoningBuf[idx].String()
+			content := ""
+			if cb := contentBuf[idx]; cb != nil {
+				content = cb.String()
+			}
+			if text, ok := reasoningFallback(content, r, ""); ok {
+				payload, _ := json.Marshal(map[string]any{
+					"choices": []any{map[string]any{
+						"index": idx,
+						"delta": map[string]any{"content": text},
+					}},
+				})
+				write([]byte("data: " + string(payload) + "\n\n"))
+			}
+		}
+	}
+
+	// observe parses a data: JSON line to track content/reasoning deltas per choice.
+	observe := func(payload string) {
+		var d struct {
+			Choices []struct {
+				Index int `json:"index"`
+				Delta struct {
+					Content          string `json:"content"`
+					Reasoning        string `json:"reasoning"`
+					ReasoningContent string `json:"reasoning_content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if json.Unmarshal([]byte(payload), &d) != nil {
+			return
+		}
+		for _, c := range d.Choices {
+			if c.Delta.Content != "" {
+				buf(contentBuf, c.Index).WriteString(c.Delta.Content)
+			}
+			if c.Delta.ReasoningContent != "" {
+				buf(reasoningBuf, c.Index).WriteString(c.Delta.ReasoningContent)
+			}
+			if c.Delta.Reasoning != "" {
+				buf(reasoningBuf, c.Index).WriteString(c.Delta.Reasoning)
+			}
+		}
+	}
+
+	// Line-buffered forwarding: hold each line so the synthesized delta can be injected BEFORE
+	// [DONE]. A line over maxSSELine is flushed in pieces (truncated) and forwarded opaquely.
+	var line []byte
+	truncated := false
+	rd := make([]byte, 4096)
+	for {
+		n, err := body.Read(rd)
+		for i := 0; i < n; i++ {
+			ch := rd[i]
+			line = append(line, ch)
+			if ch != '\n' {
+				if len(line) > maxSSELine { // opaque overflow: flush and keep going
+					write(line)
+					line = line[:0]
+					truncated = true
+				}
+				continue
+			}
+			// Complete raw line (includes its trailing newline).
+			if truncated { // tail of a line whose head already went out: forward as-is
+				write(line)
+				line = line[:0]
+				truncated = false
+				continue
+			}
+			text := strings.TrimSpace(strings.TrimRight(string(line), "\r\n"))
+			if strings.HasPrefix(text, "data:") {
+				payload := strings.TrimSpace(strings.TrimPrefix(text, "data:"))
+				if payload == "[DONE]" {
+					synthesize() // inject before the terminal sentinel
+					write(line)
+					line = line[:0]
+					continue
+				}
+				observe(payload)
+			}
+			write(line)
+			line = line[:0]
+		}
+		if err != nil {
+			break
+		}
+	}
+	if len(line) > 0 { // trailing bytes with no final newline
+		if !truncated {
+			// A final data: line that lacked its terminating blank line still counts toward the
+			// reasoning-only detection (observe ignores non-JSON / partial lines).
+			text := strings.TrimSpace(strings.TrimRight(string(line), "\r\n"))
+			if payload, ok := strings.CutPrefix(text, "data:"); ok {
+				if p := strings.TrimSpace(payload); p != "" && p != "[DONE]" {
+					observe(p)
+				}
+			}
+		}
+		write(line)
+	}
+	synthesize() // no [DONE] seen (or already injected -> no-op): best-effort at EOF
+	return meter.cost
 }
 
 // joinSet renders a set as a comma-separated header value.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1168,13 +1168,19 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 	// as raw JSON so a nonstandard type (a numeric id, a string created) is re-emitted as-is and
 	// can NEVER fail the chunk parse and silently drop tracking (audit finding).
 	var lastID, lastObject, lastCreated, lastModel json.RawMessage
+	// blankRaw treats absent / null / "" as no value, so an explicit empty envelope field can't
+	// clobber a real one already seen (nor be re-emitted).
+	blankRaw := func(v json.RawMessage) bool {
+		s := string(v)
+		return len(v) == 0 || s == "null" || s == `""`
+	}
 	keep := func(dst *json.RawMessage, v json.RawMessage) {
-		if len(v) > 0 && string(v) != "null" {
+		if !blankRaw(v) {
 			*dst = v
 		}
 	}
 	putRaw := func(m map[string]any, k string, v json.RawMessage) {
-		if len(v) > 0 && string(v) != "null" {
+		if !blankRaw(v) {
 			m[k] = v // json.RawMessage marshals verbatim (string, number, whatever it was)
 		}
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1115,12 +1115,14 @@ const maxSSELine = 1 << 20
 // streamRelayBody copies an SSE relay stream to the client, flushing per event so streaming
 // works end-to-end, and scanning for the broker's `: rogerai-cost=` meter comment (returned as
 // the stream's only cost signal). When reasoningFallbackOn and the whole stream emitted
-// reasoning deltas but ZERO visible content, it injects ONE synthesized content delta carrying
-// the accumulated reasoning immediately BEFORE the terminal [DONE] (or at EOF if the provider
-// sent none) - the fix for strict clients (hermes -z) that see empty content and fail. v1
-// limitation: the reasoning is delivered as a single consolidated delta at stream end, not
-// re-chunked live as it arrives. Everything else - the original reasoning deltas (the accepted
-// double-mirror), the finish chunk, [DONE], and the meter comment - passes through byte-for-byte.
+// reasoning deltas but ZERO visible content, it injects ONE synthesized content delta (per
+// choice) carrying the accumulated reasoning immediately BEFORE that choice's finish_reason
+// chunk (or before [DONE]/at EOF if none) - so a strict client (hermes -z) that finalizes on
+// finish_reason still sees the content. The synthesized chunk copies id/object/created/model
+// from the last observed chunk so it is a well-formed sibling. v1 limitation: the reasoning is
+// delivered as a single consolidated delta at stream end, not re-chunked live as it arrives.
+// Everything else - the original reasoning deltas (the accepted double-mirror), the finish
+// chunk, [DONE], and the meter comment - passes through byte-for-byte.
 func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn bool) (sseCost float64) {
 	flusher, _ := w.(http.Flusher)
 	meter := &sseMeter{}
@@ -1160,47 +1162,77 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 		}
 		return b
 	}
-	injected := false
+	injected := map[int]bool{} // per-choice latch: which choices we've already resolved
+	// Envelope metadata copied from the last observed chunk so a synthesized chunk is a
+	// well-formed sibling (some strict SDK parsers require id/object/model on every chunk).
+	var lastID, lastObject, lastModel string
+	var lastCreated json.Number
 
-	// synthesize writes one content delta per choice that emitted reasoning but no visible
-	// content (and no tool_calls - a tool turn's empty content is intentional), in ascending
-	// index order (deterministic). It is the whole fix, in one place.
-	synthesize := func() {
-		if injected {
+	// synthesizeChoice writes the reasoning->content delta for ONE choice, once. It is a no-op
+	// when the choice has real content, a tool_calls turn (empty content is intentional), or no
+	// reasoning to surface. Per-choice (not a global latch) so an n>1 stream can't get a
+	// premature or duplicated delta on another choice's finish.
+	synthesizeChoice := func(idx int) {
+		if injected[idx] {
 			return
 		}
-		injected = true
+		injected[idx] = true
+		if toolCalls[idx] {
+			return
+		}
+		r := ""
+		if rb := reasoningBuf[idx]; rb != nil {
+			r = rb.String()
+		}
+		content := ""
+		if cb := contentBuf[idx]; cb != nil {
+			content = cb.String()
+		}
+		text, ok := reasoningFallback(content, r, "")
+		if !ok {
+			return
+		}
+		chunk := map[string]any{
+			"choices": []any{map[string]any{"index": idx, "delta": map[string]any{"content": text}}},
+		}
+		if lastID != "" {
+			chunk["id"] = lastID
+		}
+		if lastObject != "" {
+			chunk["object"] = lastObject
+		}
+		if lastCreated != "" {
+			chunk["created"] = lastCreated
+		}
+		if lastModel != "" {
+			chunk["model"] = lastModel
+		}
+		payload, _ := json.Marshal(chunk)
+		write([]byte("data: " + string(payload) + "\n\n"))
+	}
+
+	// synthesizeAll resolves every choice that emitted reasoning (ascending index, deterministic)
+	// - the terminal catch-all for choices that never carried an explicit finish_reason.
+	synthesizeAll := func() {
 		idxs := make([]int, 0, len(reasoningBuf))
 		for idx := range reasoningBuf {
 			idxs = append(idxs, idx)
 		}
 		sort.Ints(idxs)
 		for _, idx := range idxs {
-			if toolCalls[idx] {
-				continue // don't overwrite a tool-call turn's (legitimately empty) content
-			}
-			r := reasoningBuf[idx].String()
-			content := ""
-			if cb := contentBuf[idx]; cb != nil {
-				content = cb.String()
-			}
-			if text, ok := reasoningFallback(content, r, ""); ok {
-				payload, _ := json.Marshal(map[string]any{
-					"choices": []any{map[string]any{
-						"index": idx,
-						"delta": map[string]any{"content": text},
-					}},
-				})
-				write([]byte("data: " + string(payload) + "\n\n"))
-			}
+			synthesizeChoice(idx)
 		}
 	}
 
-	// observe parses a data: JSON line to track content/reasoning/tool_calls deltas per choice,
-	// returning true when the chunk carries a finish_reason (the point to inject BEFORE, so the
-	// synthesized content lands ahead of the turn being marked finished - the strict-client fix).
-	observe := func(payload string) (finished bool) {
+	// observe parses a data: JSON line to track content/reasoning/tool_calls deltas and envelope
+	// metadata per choice, returning the choice indices whose chunk carried a finish_reason (the
+	// point to inject BEFORE, so the synthesized content lands ahead of THAT choice finishing).
+	observe := func(payload string) (finishedIdx []int) {
 		var d struct {
+			ID      string      `json:"id"`
+			Object  string      `json:"object"`
+			Created json.Number `json:"created"`
+			Model   string      `json:"model"`
 			Choices []struct {
 				Index        int             `json:"index"`
 				FinishReason json.RawMessage `json:"finish_reason"`
@@ -1213,7 +1245,19 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 			} `json:"choices"`
 		}
 		if json.Unmarshal([]byte(payload), &d) != nil {
-			return false
+			return nil
+		}
+		if d.ID != "" {
+			lastID = d.ID
+		}
+		if d.Object != "" {
+			lastObject = d.Object
+		}
+		if d.Created != "" {
+			lastCreated = d.Created
+		}
+		if d.Model != "" {
+			lastModel = d.Model
 		}
 		for _, c := range d.Choices {
 			if c.Delta.Content != "" {
@@ -1233,10 +1277,10 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 				toolCalls[c.Index] = true
 			}
 			if fr := strings.TrimSpace(string(c.FinishReason)); fr != "" && fr != "null" {
-				finished = true
+				finishedIdx = append(finishedIdx, c.Index)
 			}
 		}
-		return finished
+		return finishedIdx
 	}
 
 	// Line-buffered forwarding: hold each line so the synthesized delta can be injected BEFORE
@@ -1268,13 +1312,13 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 			if strings.HasPrefix(text, "data:") {
 				payload := strings.TrimSpace(strings.TrimPrefix(text, "data:"))
 				if payload == "[DONE]" {
-					synthesize() // inject before the terminal sentinel (fallback if no finish chunk)
+					synthesizeAll() // resolve any remaining choices before the terminal sentinel
 					write(line)
 					line = line[:0]
 					continue
 				}
-				if observe(payload) {
-					synthesize() // inject BEFORE the finish chunk so content precedes finish_reason
+				for _, idx := range observe(payload) {
+					synthesizeChoice(idx) // inject BEFORE this choice's finish chunk
 				}
 			}
 			write(line)
@@ -1297,7 +1341,7 @@ func streamRelayBody(w http.ResponseWriter, body io.Reader, reasoningFallbackOn 
 		}
 		write(line)
 	}
-	synthesize() // no [DONE]/finish seen (or already injected -> no-op): best-effort at EOF
+	synthesizeAll() // no [DONE]/finish seen (or already resolved -> no-op): best-effort at EOF
 	return meter.cost
 }
 

--- a/internal/client/proxy_bdd_test.go
+++ b/internal/client/proxy_bdd_test.go
@@ -1791,6 +1791,36 @@ func (s *proxyState) noContentDeltaSynthesized() error {
 	return nil
 }
 
+func (s *proxyState) brokerReturnsToolCallReply(reasoning string) error {
+	s.respBody = fmt.Sprintf(`{"choices":[{"message":{"role":"assistant","content":"","reasoning":%s,`+
+		`"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{}"}}]}}]}`,
+		jsonStr(unescapeGherkin(reasoning)))
+	return nil
+}
+
+func (s *proxyState) brokerStreamsReasoningThenToolCall(reasoning string) error {
+	s.streaming = true
+	s.brokerContentDeltas = 0
+	s.streamLines = []string{
+		fmt.Sprintf("data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":%s}}]}\n\n", jsonStr(reasoning)),
+		"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{}\"}}]}}]}\n\n",
+		"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+	}
+	return nil
+}
+
+func (s *proxyState) synthesizedContentPrecedesFinish() error {
+	out := s.rec.Body.String()
+	ci, fi := strings.Index(out, `"content":`), strings.Index(out, "finish_reason")
+	if ci < 0 {
+		return fmt.Errorf("no synthesized content delta in stream: %q", out)
+	}
+	if fi < 0 || ci > fi {
+		return fmt.Errorf("synthesized content not before finish_reason: content@%d finish@%d body=%q", ci, fi, out)
+	}
+	return nil
+}
+
 func (s *proxyState) sseCostCommentPresent(amount string) error {
 	want := ": rogerai-cost=" + strings.TrimPrefix(amount, "$")
 	if !strings.Contains(s.rec.Body.String(), want) {
@@ -1847,6 +1877,9 @@ func TestProxyBDD(t *testing.T) {
 			sc.Step(`^the streamed reasoning is still "(.*)"$`, st.streamedReasoningStill)
 			sc.Step(`^no content delta was synthesized$`, st.noContentDeltaSynthesized)
 			sc.Step(`^the SSE cost-meter comment for "([^"]*)" is present$`, st.sseCostCommentPresent)
+			sc.Step(`^the broker returns a tool-call reply with empty content and reasoning "(.*)"$`, st.brokerReturnsToolCallReply)
+			sc.Step(`^the broker streams a reasoning delta "(.*)" then a tool_call and no content$`, st.brokerStreamsReasoningThenToolCall)
+			sc.Step(`^the synthesized content precedes the finish_reason chunk$`, st.synthesizedContentPrecedesFinish)
 
 			// models.feature ("GET <path> with the session key" is served by the generic
 			// errors.feature step getPath, which handles /v1/models and unknown routes alike).

--- a/internal/client/proxy_bdd_test.go
+++ b/internal/client/proxy_bdd_test.go
@@ -40,6 +40,8 @@ type proxyState struct {
 	respBody          string
 	extraHeaders      map[string]string
 	streaming         bool
+	streamLines       []string // when set, the streaming stub emits these SSE events verbatim (no trickle)
+	brokerContentDeltas int    // how many content-bearing deltas the stub emits (to detect a synthesized one)
 	trickleN          int
 	trickleGap        time.Duration
 	chatSleep         time.Duration // >0: never sends a response header (triggers the header timeout)
@@ -168,11 +170,23 @@ func (s *proxyState) startBroker() {
 			if fl != nil {
 				fl.Flush()
 			}
-			for i := 0; i < s.trickleN; i++ {
-				time.Sleep(s.trickleGap)
-				_, _ = w.Write([]byte("data: chunk\n\n"))
-				if fl != nil {
-					fl.Flush()
+			if len(s.streamLines) > 0 {
+				// Emit the caller-configured SSE events verbatim (reasoning/content deltas), then
+				// the terminal [DONE] and (below) the meter comment - the real relayStream shape.
+				for _, ln := range s.streamLines {
+					time.Sleep(s.trickleGap)
+					_, _ = w.Write([]byte(ln))
+					if fl != nil {
+						fl.Flush()
+					}
+				}
+			} else {
+				for i := 0; i < s.trickleN; i++ {
+					time.Sleep(s.trickleGap)
+					_, _ = w.Write([]byte("data: chunk\n\n"))
+					if fl != nil {
+						fl.Flush()
+					}
 				}
 			}
 			_, _ = w.Write([]byte("data: [DONE]\n\n"))
@@ -1569,6 +1583,222 @@ func (s *proxyState) noHalfUpdatedMix() error { return nil }
 
 // ===================== registration =====================
 
+// --- reasoning_fallback.feature ---
+
+// jsonStr renders a Go string as a JSON string literal (proper escaping) for building
+// broker response bodies in the reasoning-fallback steps.
+func jsonStr(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// unescapeGherkin turns the literal "\n"/"\t" a Gherkin cell carries into real whitespace
+// (godog passes the backslash-n through verbatim); used so the whitespace-content scenario
+// actually exercises whitespace.
+func unescapeGherkin(s string) string {
+	s = strings.ReplaceAll(s, `\n`, "\n")
+	s = strings.ReplaceAll(s, `\t`, "\t")
+	return s
+}
+
+func (s *proxyState) reasoningFallbackDisabled() error {
+	s.band.ReasoningFallbackOff = true
+	return nil
+}
+
+func (s *proxyState) brokerReturnsContentReasoning(content, reasoning string) error {
+	s.respBody = fmt.Sprintf(`{"choices":[{"message":{"role":"assistant","content":%s,"reasoning":%s}}]}`,
+		jsonStr(unescapeGherkin(content)), jsonStr(unescapeGherkin(reasoning)))
+	return nil
+}
+
+func (s *proxyState) brokerReturnsContentReasoningContent(content, reasoningContent string) error {
+	s.respBody = fmt.Sprintf(`{"choices":[{"message":{"role":"assistant","content":%s,"reasoning_content":%s}}]}`,
+		jsonStr(unescapeGherkin(content)), jsonStr(unescapeGherkin(reasoningContent)))
+	return nil
+}
+
+func (s *proxyState) brokerBillsNextNonStreaming(amount string) error {
+	s.cost = strings.TrimPrefix(amount, "$")
+	return nil
+}
+
+// replyMessage decodes the single non-streaming choice's message the client received.
+func (s *proxyState) replyMessage() (content, reasoning, reasoningContent string) {
+	var d struct {
+		Choices []struct {
+			Message struct {
+				Content          string `json:"content"`
+				Reasoning        string `json:"reasoning"`
+				ReasoningContent string `json:"reasoning_content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	_ = json.Unmarshal(s.rec.Body.Bytes(), &d)
+	if len(d.Choices) == 0 {
+		return "", "", ""
+	}
+	m := d.Choices[0].Message
+	return m.Content, m.Reasoning, m.ReasoningContent
+}
+
+func (s *proxyState) replyContentIs(want string) error {
+	got, _, _ := s.replyMessage()
+	if got != want {
+		return fmt.Errorf("reply content = %q, want %q (body=%q)", got, want, s.rec.Body.String())
+	}
+	return nil
+}
+
+func (s *proxyState) replyContentIsEmpty() error {
+	got, _, _ := s.replyMessage()
+	if got != "" {
+		return fmt.Errorf("reply content = %q, want empty", got)
+	}
+	return nil
+}
+
+func (s *proxyState) replyReasoningStill(want string) error {
+	_, r, rc := s.replyMessage()
+	if r != want && rc != want {
+		return fmt.Errorf("reply reasoning = %q / reasoning_content = %q, want %q preserved", r, rc, want)
+	}
+	return nil
+}
+
+func (s *proxyState) responseBodyByteForByte() error {
+	if got := s.rec.Body.String(); got != s.respBody {
+		return fmt.Errorf("response body was reshaped:\n got = %q\nwant = %q", got, s.respBody)
+	}
+	return nil
+}
+
+func (s *proxyState) responseCarriesCostHeader(want string) error {
+	if got := s.rec.Header().Get("X-RogerAI-Cost"); got != want {
+		return fmt.Errorf("X-RogerAI-Cost = %q, want %q", got, want)
+	}
+	return nil
+}
+
+// gherkinQuoted extracts the quoted tokens from a step tail like: "a" "b" "c".
+func gherkinQuoted(tail string) []string {
+	var out []string
+	rest := tail
+	for {
+		i := strings.IndexByte(rest, '"')
+		if i < 0 {
+			break
+		}
+		rest = rest[i+1:]
+		j := strings.IndexByte(rest, '"')
+		if j < 0 {
+			break
+		}
+		out = append(out, rest[:j])
+		rest = rest[j+1:]
+	}
+	return out
+}
+
+func (s *proxyState) brokerStreamsReasoningDeltas(tail string) error {
+	s.streaming = true
+	s.brokerContentDeltas = 0
+	for _, d := range gherkinQuoted(tail) {
+		s.streamLines = append(s.streamLines,
+			fmt.Sprintf("data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":%s}}]}\n\n", jsonStr(d)))
+	}
+	// A realistic terminal finish chunk with empty content (the shape hermes chokes on).
+	s.streamLines = append(s.streamLines, "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+	return nil
+}
+
+func (s *proxyState) brokerStreamsContentDeltas(tail string) error {
+	s.streaming = true
+	deltas := gherkinQuoted(tail)
+	s.brokerContentDeltas = len(deltas)
+	for _, d := range deltas {
+		s.streamLines = append(s.streamLines,
+			fmt.Sprintf("data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":%s}}]}\n\n", jsonStr(d)))
+	}
+	s.streamLines = append(s.streamLines, "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+	return nil
+}
+
+func (s *proxyState) streamWillBill(amount string) error {
+	s.streaming = true
+	s.cost = strings.TrimPrefix(amount, "$")
+	return nil
+}
+
+// streamDeltas parses the SSE the CLIENT received into content+reasoning concatenations and
+// a count of content-bearing delta events (to detect a synthesized delta).
+func (s *proxyState) streamDeltas() (content, reasoning string, contentEvents int) {
+	var cb, rb strings.Builder
+	for _, raw := range strings.Split(s.rec.Body.String(), "\n") {
+		line := strings.TrimSpace(raw)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "[DONE]" || payload == "" {
+			continue
+		}
+		var d struct {
+			Choices []struct {
+				Delta struct {
+					Content          string `json:"content"`
+					Reasoning        string `json:"reasoning"`
+					ReasoningContent string `json:"reasoning_content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if json.Unmarshal([]byte(payload), &d) != nil {
+			continue
+		}
+		for _, c := range d.Choices {
+			if c.Delta.Content != "" {
+				cb.WriteString(c.Delta.Content)
+				contentEvents++
+			}
+			rb.WriteString(c.Delta.ReasoningContent)
+			rb.WriteString(c.Delta.Reasoning)
+		}
+	}
+	return cb.String(), rb.String(), contentEvents
+}
+
+func (s *proxyState) streamedContentIs(want string) error {
+	got, _, _ := s.streamDeltas()
+	if got != want {
+		return fmt.Errorf("streamed content = %q, want %q (body=%q)", got, want, s.rec.Body.String())
+	}
+	return nil
+}
+
+func (s *proxyState) streamedReasoningStill(want string) error {
+	_, got, _ := s.streamDeltas()
+	if got != want {
+		return fmt.Errorf("streamed reasoning = %q, want %q preserved", got, want)
+	}
+	return nil
+}
+
+func (s *proxyState) noContentDeltaSynthesized() error {
+	_, _, events := s.streamDeltas()
+	if events != s.brokerContentDeltas {
+		return fmt.Errorf("content-delta events = %d, want %d (a delta was synthesized)", events, s.brokerContentDeltas)
+	}
+	return nil
+}
+
+func (s *proxyState) sseCostCommentPresent(amount string) error {
+	want := ": rogerai-cost=" + strings.TrimPrefix(amount, "$")
+	if !strings.Contains(s.rec.Body.String(), want) {
+		return fmt.Errorf("SSE meter comment %q missing from stream; body=%q", want, s.rec.Body.String())
+	}
+	return nil
+}
+
 func TestProxyBDD(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -1599,6 +1829,24 @@ func TestProxyBDD(t *testing.T) {
 			sc.Step(`^the broker was never called$`, st.brokerNeverCalled)
 			sc.Step(`^the request is relayed to the broker$`, st.requestRelayed)
 			sc.Step(`^a chat request is made$`, st.chatRequestMade)
+
+			// reasoning_fallback.feature
+			sc.Step(`^the reasoning fallback is disabled$`, st.reasoningFallbackDisabled)
+			sc.Step(`^the broker returns message content "(.*)" and reasoning "(.*)"$`, st.brokerReturnsContentReasoning)
+			sc.Step(`^the broker returns message content "(.*)" and reasoning_content "(.*)"$`, st.brokerReturnsContentReasoningContent)
+			sc.Step(`^the broker bills "([^"]*)" for the next non-streaming reply$`, st.brokerBillsNextNonStreaming)
+			sc.Step(`^the reply content is "(.*)"$`, st.replyContentIs)
+			sc.Step(`^the reply content is empty$`, st.replyContentIsEmpty)
+			sc.Step(`^the reply reasoning is still "(.*)"$`, st.replyReasoningStill)
+			sc.Step(`^the response body is byte-for-byte the broker's body$`, st.responseBodyByteForByte)
+			sc.Step(`^the response carries cost header "([^"]*)"$`, st.responseCarriesCostHeader)
+			sc.Step(`^the broker streams reasoning deltas (.+) and no content$`, st.brokerStreamsReasoningDeltas)
+			sc.Step(`^the broker streams content deltas (.+)$`, st.brokerStreamsContentDeltas)
+			sc.Step(`^the stream will bill "([^"]*)"$`, st.streamWillBill)
+			sc.Step(`^the streamed content is "(.*)"$`, st.streamedContentIs)
+			sc.Step(`^the streamed reasoning is still "(.*)"$`, st.streamedReasoningStill)
+			sc.Step(`^no content delta was synthesized$`, st.noContentDeltaSynthesized)
+			sc.Step(`^the SSE cost-meter comment for "([^"]*)" is present$`, st.sseCostCommentPresent)
 
 			// models.feature ("GET <path> with the session key" is served by the generic
 			// errors.feature step getPath, which handles /v1/models and unknown routes alike).

--- a/internal/client/proxy_bdd_test.go
+++ b/internal/client/proxy_bdd_test.go
@@ -32,23 +32,23 @@ type proxyState struct {
 	broker string
 
 	// broker behavior (set by Given steps)
-	status            int
-	cost              string
-	retryAfter        string
-	provider          string
-	contentType       string
-	respBody          string
-	extraHeaders      map[string]string
-	streaming         bool
-	streamLines       []string // when set, the streaming stub emits these SSE events verbatim (no trickle)
-	brokerContentDeltas int    // how many content-bearing deltas the stub emits (to detect a synthesized one)
-	trickleN          int
-	trickleGap        time.Duration
-	chatSleep         time.Duration // >0: never sends a response header (triggers the header timeout)
-	always503         bool
-	failFirstUnpinned bool
-	discoverBody      string
-	unreachable       bool
+	status              int
+	cost                string
+	retryAfter          string
+	provider            string
+	contentType         string
+	respBody            string
+	extraHeaders        map[string]string
+	streaming           bool
+	streamLines         []string // when set, the streaming stub emits these SSE events verbatim (no trickle)
+	brokerContentDeltas int      // how many content-bearing deltas the stub emits (to detect a synthesized one)
+	trickleN            int
+	trickleGap          time.Duration
+	chatSleep           time.Duration // >0: never sends a response header (triggers the header timeout)
+	always503           bool
+	failFirstUnpinned   bool
+	discoverBody        string
+	unreachable         bool
 
 	// recorded from the broker (last chat request)
 	mu              sync.Mutex
@@ -68,8 +68,8 @@ type proxyState struct {
 	sessionKey string
 
 	// request outcome
-	rec         *httptest.ResponseRecorder
-	sentFields  map[string]json.RawMessage
+	rec             *httptest.ResponseRecorder
+	sentFields      map[string]json.RawMessage
 	served          int32
 	refused         int32
 	callsSnapshot   int32

--- a/internal/client/reasoning_fallback_test.go
+++ b/internal/client/reasoning_fallback_test.go
@@ -289,6 +289,21 @@ func TestStreamRelayBodyDirect(t *testing.T) {
 		}
 	})
 
+	t.Run("nonstandard envelope types do NOT disable tracking (numeric id, string created)", func(t *testing.T) {
+		// A provider that sends id as a number and created as a string must still get the
+		// fallback: the envelope is re-emitted verbatim and can't poison choice tracking.
+		body := `data: {"id":42,"created":"1700000000","model":"m","choices":[{"index":0,"delta":{"reasoning":"ans"}}]}` + "\n\ndata: [DONE]\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		out := rec.Body.String()
+		if !strings.Contains(out, `"content":"ans"`) {
+			t.Fatalf("fallback dropped on nonstandard envelope: %q", out)
+		}
+		if !strings.Contains(out, `"id":42`) || !strings.Contains(out, `"created":"1700000000"`) {
+			t.Fatalf("envelope not re-emitted verbatim: %q", out)
+		}
+	})
+
 	t.Run("n>1: only the reasoning-only choice is synthesized, no duplicate on the content choice", func(t *testing.T) {
 		body := `data: {"choices":[{"index":0,"delta":{"content":"hi"}}]}` + "\n\n" +
 			`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n" +

--- a/internal/client/reasoning_fallback_test.go
+++ b/internal/client/reasoning_fallback_test.go
@@ -254,6 +254,63 @@ func TestStreamRelayBodyDirect(t *testing.T) {
 		}
 	})
 
+	t.Run("synthesized chunk copies id/object/created/model from the last chunk", func(t *testing.T) {
+		body := `data: {"id":"chatcmpl-9","object":"chat.completion.chunk","created":1700000000,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"reasoning":"ans"}}]}` + "\n\ndata: [DONE]\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		// Find the synthesized chunk (the one carrying content) and check its envelope.
+		var synth map[string]any
+		for _, raw := range strings.Split(rec.Body.String(), "\n") {
+			line := strings.TrimSpace(raw)
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			p := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if p == "[DONE]" {
+				continue
+			}
+			var m map[string]any
+			if json.Unmarshal([]byte(p), &m) == nil {
+				if ch, _ := m["choices"].([]any); len(ch) > 0 {
+					if d, _ := ch[0].(map[string]any)["delta"].(map[string]any); d["content"] != nil {
+						synth = m
+					}
+				}
+			}
+		}
+		if synth == nil {
+			t.Fatalf("no synthesized chunk found: %q", rec.Body.String())
+		}
+		if synth["id"] != "chatcmpl-9" || synth["object"] != "chat.completion.chunk" || synth["model"] != "gpt-oss-120b" {
+			t.Fatalf("synthesized envelope missing id/object/model: %+v", synth)
+		}
+		if synth["created"] == nil {
+			t.Fatalf("synthesized envelope missing created: %+v", synth)
+		}
+	})
+
+	t.Run("n>1: only the reasoning-only choice is synthesized, no duplicate on the content choice", func(t *testing.T) {
+		body := `data: {"choices":[{"index":0,"delta":{"content":"hi"}}]}` + "\n\n" +
+			`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n" +
+			`data: {"choices":[{"index":1,"delta":{"reasoning":"think"}}]}` + "\n\n" +
+			`data: {"choices":[{"index":1,"delta":{},"finish_reason":"stop"}]}` + "\n\ndata: [DONE]\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		out := rec.Body.String()
+		if strings.Count(out, `"content":"hi"`) != 1 {
+			t.Fatalf("choice 0 content duplicated/altered: %q", out)
+		}
+		if strings.Count(out, `"content":"think"`) != 1 {
+			t.Fatalf("choice 1 should get exactly one synthesized content delta: %q", out)
+		}
+		// The synthesized content for choice 1 must reference index 1, and precede choice 1's finish.
+		ci := strings.Index(out, `"content":"think"`)
+		fi := strings.LastIndex(out, "finish_reason")
+		if ci < 0 || ci > fi {
+			t.Fatalf("choice-1 synthesized content not before its finish: %q", out)
+		}
+	})
+
 	t.Run("CRLF line endings pass through byte-for-byte", func(t *testing.T) {
 		body := "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\r\n\r\ndata: [DONE]\r\n\r\n"
 		rec := httptest.NewRecorder()

--- a/internal/client/reasoning_fallback_test.go
+++ b/internal/client/reasoning_fallback_test.go
@@ -1,0 +1,247 @@
+package client
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestReasoningFallbackDecision is the pure transform decision: fill EMPTY content from a
+// reasoning channel, never overwrite real content, prefer reasoning_content, ignore
+// whitespace-only reasoning.
+func TestReasoningFallbackDecision(t *testing.T) {
+	cases := []struct {
+		name             string
+		content          string
+		reasoning        string
+		reasoningContent string
+		wantText         string
+		wantApply        bool
+	}{
+		{"empty content, reasoning present", "", "the answer", "", "the answer", true},
+		{"whitespace content, reasoning present", "  \n\t ", "the answer", "", "the answer", true},
+		{"reasoning_content preferred over reasoning", "", "second", "first", "first", true},
+		{"reasoning_content only", "", "", "rc text", "rc text", true},
+		{"real content is never overwritten", "real", "hidden", "", "", false},
+		{"single-space content is filled", " ", "r", "", "r", true},
+		{"empty content and empty reasoning", "", "", "", "", false},
+		{"whitespace-only reasoning is ignored", "", "   ", "\n\t", "", false},
+		{"content present, reasoning present -> no change", "hi", "thinking", "rc", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			text, apply := reasoningFallback(c.content, c.reasoning, c.reasoningContent)
+			if apply != c.wantApply || text != c.wantText {
+				t.Fatalf("reasoningFallback(%q,%q,%q) = (%q,%v), want (%q,%v)",
+					c.content, c.reasoning, c.reasoningContent, text, apply, c.wantText, c.wantApply)
+			}
+		})
+	}
+}
+
+func msgContent(t *testing.T, body []byte) string {
+	t.Helper()
+	var d struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &d); err != nil {
+		t.Fatalf("unmarshal %q: %v", body, err)
+	}
+	if len(d.Choices) == 0 {
+		t.Fatalf("no choices in %q", body)
+	}
+	return d.Choices[0].Message.Content
+}
+
+// TestApplyReasoningFallbackNonStreaming exercises the whole-body transform.
+func TestApplyReasoningFallbackNonStreaming(t *testing.T) {
+	t.Run("empty content + reasoning -> content filled", func(t *testing.T) {
+		in := []byte(`{"choices":[{"message":{"role":"assistant","content":"","reasoning":"42"}}]}`)
+		if got := msgContent(t, applyReasoningFallback(in)); got != "42" {
+			t.Fatalf("content = %q, want 42", got)
+		}
+	})
+
+	t.Run("reasoning_content field name honored", func(t *testing.T) {
+		in := []byte(`{"choices":[{"message":{"content":"","reasoning_content":"rc"}}]}`)
+		if got := msgContent(t, applyReasoningFallback(in)); got != "rc" {
+			t.Fatalf("content = %q, want rc", got)
+		}
+	})
+
+	t.Run("null content + reasoning -> filled", func(t *testing.T) {
+		in := []byte(`{"choices":[{"message":{"content":null,"reasoning":"nn"}}]}`)
+		if got := msgContent(t, applyReasoningFallback(in)); got != "nn" {
+			t.Fatalf("content = %q, want nn", got)
+		}
+	})
+
+	t.Run("missing content field + reasoning -> filled", func(t *testing.T) {
+		in := []byte(`{"choices":[{"message":{"reasoning":"mm"}}]}`)
+		if got := msgContent(t, applyReasoningFallback(in)); got != "mm" {
+			t.Fatalf("content = %q, want mm", got)
+		}
+	})
+
+	t.Run("non-empty content -> byte-identical passthrough", func(t *testing.T) {
+		in := []byte(`{"choices":[{"message":{"content":"real","reasoning":"hidden"}}]}`)
+		if got := string(applyReasoningFallback(in)); got != string(in) {
+			t.Fatalf("mutated a non-empty-content body:\n got %q\nwant %q", got, in)
+		}
+	})
+
+	t.Run("empty content + empty reasoning -> byte-identical passthrough", func(t *testing.T) {
+		in := []byte(`{"choices":[{"message":{"content":"","reasoning":""}}]}`)
+		if got := string(applyReasoningFallback(in)); got != string(in) {
+			t.Fatalf("mutated a nothing-to-do body:\n got %q\nwant %q", got, in)
+		}
+	})
+
+	t.Run("malformed JSON -> returned unchanged", func(t *testing.T) {
+		in := []byte(`not json at all`)
+		if got := string(applyReasoningFallback(in)); got != string(in) {
+			t.Fatalf("mutated malformed body: %q", got)
+		}
+	})
+
+	t.Run("no choices -> unchanged", func(t *testing.T) {
+		in := []byte(`{"error":{"message":"nope"}}`)
+		if got := string(applyReasoningFallback(in)); got != string(in) {
+			t.Fatalf("mutated an error body: %q", got)
+		}
+	})
+
+	t.Run("usage token numbers preserved exactly", func(t *testing.T) {
+		in := []byte(`{"choices":[{"message":{"content":"","reasoning":"x"}}],"usage":{"total_tokens":1234567,"prompt_tokens":10}}`)
+		out := applyReasoningFallback(in)
+		if got := msgContent(t, out); got != "x" {
+			t.Fatalf("content = %q, want x", got)
+		}
+		var d struct {
+			Usage struct {
+				Total  json.Number `json:"total_tokens"`
+				Prompt json.Number `json:"prompt_tokens"`
+			} `json:"usage"`
+		}
+		dec := json.NewDecoder(strings.NewReader(string(out)))
+		dec.UseNumber()
+		if err := dec.Decode(&d); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if d.Usage.Total.String() != "1234567" || d.Usage.Prompt.String() != "10" {
+			t.Fatalf("usage numbers altered: total=%s prompt=%s", d.Usage.Total, d.Usage.Prompt)
+		}
+	})
+
+	t.Run("multi-choice: only the empty one is filled, the other preserved", func(t *testing.T) {
+		in := []byte(`{"choices":[{"index":0,"message":{"content":"","reasoning":"a"}},{"index":1,"message":{"content":"b","reasoning":"c"}}]}`)
+		out := applyReasoningFallback(in)
+		var d struct {
+			Choices []struct {
+				Message struct {
+					Content string `json:"content"`
+				} `json:"message"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal(out, &d); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if d.Choices[0].Message.Content != "a" || d.Choices[1].Message.Content != "b" {
+			t.Fatalf("choices = %q / %q, want a / b", d.Choices[0].Message.Content, d.Choices[1].Message.Content)
+		}
+	})
+}
+
+// TestStreamRelayBodyDirect covers the streaming injector's edge branches (overflow line,
+// no-[DONE] stream, meter ordering) that the BDD happy paths don't reach.
+func TestStreamRelayBodyDirect(t *testing.T) {
+	t.Run("reasoning-only, no DONE sentinel -> synthesized at EOF", func(t *testing.T) {
+		body := `data: {"choices":[{"index":0,"delta":{"reasoning":"hello"}}]}` + "\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		if !strings.Contains(rec.Body.String(), `"content":"hello"`) {
+			t.Fatalf("no synthesized content at EOF: %q", rec.Body.String())
+		}
+	})
+
+	t.Run("disabled -> byte-identical passthrough", func(t *testing.T) {
+		body := `data: {"choices":[{"index":0,"delta":{"reasoning":"hello"}}]}` + "\n\ndata: [DONE]\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), false)
+		if rec.Body.String() != body {
+			t.Fatalf("disabled path altered the stream:\n got %q\nwant %q", rec.Body.String(), body)
+		}
+	})
+
+	t.Run("very long non-terminal data line passes through intact", func(t *testing.T) {
+		huge := strings.Repeat("x", 300000)
+		body := `data: {"choices":[{"index":0,"delta":{"reasoning":"` + huge + `"}}]}` + "\n\ndata: [DONE]\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		out := rec.Body.String()
+		if !strings.Contains(out, huge) || !strings.Contains(out, "data: [DONE]") {
+			t.Fatalf("giant line or terminal lost (len=%d)", len(out))
+		}
+	})
+
+	t.Run("meter comment after DONE survives, synthesized delta lands before DONE", func(t *testing.T) {
+		body := `data: {"choices":[{"index":0,"delta":{"reasoning":"r"}}]}` + "\n\ndata: [DONE]\n\n: rogerai-cost=0.5\n\n"
+		rec := httptest.NewRecorder()
+		cost := streamRelayBody(rec, strings.NewReader(body), true)
+		if cost != 0.5 {
+			t.Fatalf("cost = %v, want 0.5", cost)
+		}
+		out := rec.Body.String()
+		if !strings.Contains(out, ": rogerai-cost=0.5") {
+			t.Fatalf("meter comment lost: %q", out)
+		}
+		if ci, di := strings.Index(out, `"content":"r"`), strings.Index(out, "[DONE]"); ci < 0 || ci > di {
+			t.Fatalf("synthesized content not before [DONE]: content@%d done@%d", ci, di)
+		}
+	})
+
+	t.Run("reasoning-only stream ending without a trailing newline still synthesizes", func(t *testing.T) {
+		body := `data: {"choices":[{"index":0,"delta":{"reasoning":"tail"}}]}` // no final \n
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		out := rec.Body.String()
+		if !strings.Contains(out, "tail") || !strings.Contains(out, `"content":"tail"`) {
+			t.Fatalf("trailing-line reasoning not preserved+synthesized: %q", out)
+		}
+	})
+
+	t.Run("multi-choice reasoning-only -> one synthesized delta per choice", func(t *testing.T) {
+		body := `data: {"choices":[{"index":0,"delta":{"reasoning":"zero"}}]}` + "\n\n" +
+			`data: {"choices":[{"index":1,"delta":{"reasoning":"one"}}]}` + "\n\ndata: [DONE]\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		out := rec.Body.String()
+		if !strings.Contains(out, `"index":0`) || !strings.Contains(out, `"content":"zero"`) ||
+			!strings.Contains(out, `"index":1`) || !strings.Contains(out, `"content":"one"`) {
+			t.Fatalf("per-choice synthesized deltas missing: %q", out)
+		}
+	})
+}
+
+// TestCopyRelayResponseOversizedNonStreaming: a body over maxTransformBody is forwarded raw
+// (never buffered/transformed) - the defensive ceiling.
+func TestCopyRelayResponseOversizedNonStreaming(t *testing.T) {
+	big := `{"choices":[{"message":{"content":"","reasoning":"x"}}],"pad":"` + strings.Repeat("a", maxTransformBody) + `"}`
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(big)),
+	}
+	rec := httptest.NewRecorder()
+	copyRelayResponse(rec, resp, true)
+	if rec.Body.String() != big {
+		t.Fatalf("oversized body was not forwarded verbatim (len got=%d want=%d)", rec.Body.Len(), len(big))
+	}
+}

--- a/internal/client/reasoning_fallback_test.go
+++ b/internal/client/reasoning_fallback_test.go
@@ -173,6 +173,38 @@ func TestApplyReasoningFallbackNonStreaming(t *testing.T) {
 	})
 }
 
+// findSynthChunk returns the parsed SSE chunk the proxy SYNTHESIZED (the one whose
+// choices[0].delta carries content), or nil. Used to assert on the injected chunk specifically
+// rather than a whole-body substring that a passed-through provider chunk could satisfy.
+func findSynthChunk(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var synth map[string]any
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		p := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if p == "[DONE]" {
+			continue
+		}
+		var m map[string]any
+		if json.Unmarshal([]byte(p), &m) != nil {
+			continue
+		}
+		ch, _ := m["choices"].([]any)
+		if len(ch) == 0 {
+			continue
+		}
+		c0, _ := ch[0].(map[string]any)
+		d, _ := c0["delta"].(map[string]any)
+		if d != nil && d["content"] != nil {
+			synth = m // the injected chunk (last wins, though there is at most one per choice)
+		}
+	}
+	return synth
+}
+
 // TestStreamRelayBodyDirect covers the streaming injector's edge branches (overflow line,
 // no-[DONE] stream, meter ordering) that the BDD happy paths don't reach.
 func TestStreamRelayBodyDirect(t *testing.T) {
@@ -258,26 +290,7 @@ func TestStreamRelayBodyDirect(t *testing.T) {
 		body := `data: {"id":"chatcmpl-9","object":"chat.completion.chunk","created":1700000000,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"reasoning":"ans"}}]}` + "\n\ndata: [DONE]\n\n"
 		rec := httptest.NewRecorder()
 		streamRelayBody(rec, strings.NewReader(body), true)
-		// Find the synthesized chunk (the one carrying content) and check its envelope.
-		var synth map[string]any
-		for _, raw := range strings.Split(rec.Body.String(), "\n") {
-			line := strings.TrimSpace(raw)
-			if !strings.HasPrefix(line, "data:") {
-				continue
-			}
-			p := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-			if p == "[DONE]" {
-				continue
-			}
-			var m map[string]any
-			if json.Unmarshal([]byte(p), &m) == nil {
-				if ch, _ := m["choices"].([]any); len(ch) > 0 {
-					if d, _ := ch[0].(map[string]any)["delta"].(map[string]any); d["content"] != nil {
-						synth = m
-					}
-				}
-			}
-		}
+		synth := findSynthChunk(t, rec.Body.String())
 		if synth == nil {
 			t.Fatalf("no synthesized chunk found: %q", rec.Body.String())
 		}
@@ -301,6 +314,23 @@ func TestStreamRelayBodyDirect(t *testing.T) {
 		}
 		if !strings.Contains(out, `"id":42`) || !strings.Contains(out, `"created":"1700000000"`) {
 			t.Fatalf("envelope not re-emitted verbatim: %q", out)
+		}
+	})
+
+	t.Run("an explicit empty id does not clobber a previously seen real id", func(t *testing.T) {
+		// chunk 1 sets a real id; chunk 2 carries "id":"" (pathological) then the reasoning. The
+		// SYNTHESIZED chunk must keep "real-9" - asserting on the synthesized chunk specifically
+		// (not a whole-body substring, which chunk 1 would satisfy regardless of the guard).
+		body := `data: {"id":"real-9","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}]}` + "\n\n" +
+			`data: {"id":"","choices":[{"index":0,"delta":{"reasoning":"ans"}}]}` + "\n\ndata: [DONE]\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		synth := findSynthChunk(t, rec.Body.String())
+		if synth == nil {
+			t.Fatalf("no synthesized chunk found: %q", rec.Body.String())
+		}
+		if synth["id"] != "real-9" {
+			t.Fatalf("synthesized chunk id = %v, want real-9 (empty id clobbered the real one)", synth["id"])
 		}
 	})
 

--- a/internal/client/reasoning_fallback_test.go
+++ b/internal/client/reasoning_fallback_test.go
@@ -140,6 +140,20 @@ func TestApplyReasoningFallbackNonStreaming(t *testing.T) {
 		}
 	})
 
+	t.Run("empty content + reasoning + tool_calls -> NOT filled (byte-identical)", func(t *testing.T) {
+		in := []byte(`{"choices":[{"message":{"content":"","reasoning":"calling api","tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"{}"}}]}}]}`)
+		if got := string(applyReasoningFallback(in)); got != string(in) {
+			t.Fatalf("tool-call turn was filled:\n got %q\nwant %q", got, in)
+		}
+	})
+
+	t.Run("empty tool_calls array does NOT block the fallback", func(t *testing.T) {
+		in := []byte(`{"choices":[{"message":{"content":"","reasoning":"ans","tool_calls":[]}}]}`)
+		if got := msgContent(t, applyReasoningFallback(in)); got != "ans" {
+			t.Fatalf("content = %q, want ans (empty tool_calls should not guard)", got)
+		}
+	})
+
 	t.Run("multi-choice: only the empty one is filled, the other preserved", func(t *testing.T) {
 		in := []byte(`{"choices":[{"index":0,"message":{"content":"","reasoning":"a"}},{"index":1,"message":{"content":"b","reasoning":"c"}}]}`)
 		out := applyReasoningFallback(in)
@@ -214,6 +228,38 @@ func TestStreamRelayBodyDirect(t *testing.T) {
 		out := rec.Body.String()
 		if !strings.Contains(out, "tail") || !strings.Contains(out, `"content":"tail"`) {
 			t.Fatalf("trailing-line reasoning not preserved+synthesized: %q", out)
+		}
+	})
+
+	t.Run("synthesized content precedes the finish_reason chunk", func(t *testing.T) {
+		body := `data: {"choices":[{"index":0,"delta":{"reasoning":"ans"}}]}` + "\n\n" +
+			`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\ndata: [DONE]\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		out := rec.Body.String()
+		ci, fi := strings.Index(out, `"content":"ans"`), strings.Index(out, "finish_reason")
+		if ci < 0 || fi < 0 || ci > fi {
+			t.Fatalf("content not before finish_reason: content@%d finish@%d body=%q", ci, fi, out)
+		}
+	})
+
+	t.Run("reasoning + tool_call stream -> no synthesized content", func(t *testing.T) {
+		body := `data: {"choices":[{"index":0,"delta":{"reasoning":"thinking"}}]}` + "\n\n" +
+			`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"f","arguments":"{}"}}]}}]}` + "\n\n" +
+			`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\ndata: [DONE]\n\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		if strings.Contains(rec.Body.String(), `"content":`) {
+			t.Fatalf("tool-call stream got a synthesized content delta: %q", rec.Body.String())
+		}
+	})
+
+	t.Run("CRLF line endings pass through byte-for-byte", func(t *testing.T) {
+		body := "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\r\n\r\ndata: [DONE]\r\n\r\n"
+		rec := httptest.NewRecorder()
+		streamRelayBody(rec, strings.NewReader(body), true)
+		if rec.Body.String() != body {
+			t.Fatalf("CRLF stream altered:\n got %q\nwant %q", rec.Body.String(), body)
 		}
 	})
 


### PR DESCRIPTION
## reasoning->content fallback on the relay proxy (option A, default ON)

**BUILD-AND-HOLD** - this is RELAY-PATH code (`internal/client` proxy: the path `roger use`, the DJ agent, and all guest operators flow through). Please review before merge.

### Problem
Some reasoning models (gpt-oss, deepseek) emit their final answer in `choices[].message.reasoning` / `reasoning_content` and leave `content` **empty**. Strict OpenAI clients (hermes `-z`) read only `content`, see it blank, and report *"no final response - failed"* on reasoning-heavy bands. Founder approved **option A** (2026-07-08): the proxy surfaces the reasoning **as** content when, and only when, content is genuinely empty.

### What changed (`internal/client/client.go`)
- **Non-streaming** (`applyReasoningFallback`): when a choice's `message.content` is empty/whitespace and it carries reasoning, fill `content` from the reasoning channel (`reasoning_content` preferred, else `reasoning`). Every other field and all token/usage numbers are preserved bit-for-bit (`json.Number`). A body with real content, nothing-to-surface, an error, or unparseable JSON is returned **byte-identical** (fail-safe passthrough).
- **Streaming** (`streamRelayBody`): all chunks pass through **byte-for-byte**. If the whole stream emitted reasoning deltas but **zero** visible content, one synthesized `delta.content` carrying the accumulated reasoning is injected **immediately before `[DONE]`** (or at EOF if the provider sent none).
  - **v1 limitation (honest):** the reasoning is delivered as **one consolidated content delta at stream end**, not re-chunked live as it arrives. Faithful live re-chunking is deferred; this is the safe first cut the founder pre-approved.
- **Toggle:** `ProxyOptions.ReasoningFallbackOff` (zero-value = **fallback ON**). Set true for raw passthrough (a client that wants the untouched provider body). Chosen inverted so the feature is on everywhere by default without touching any existing constructor.

### Guards / tradeoffs
- **No overwrite, no double-emit:** real content is never touched; if content is non-empty at any point, nothing is synthesized.
- **Accepted double-mirror** (option A, understood): because we fill only EMPTY content, a client that reads reasoning separately still gets `reasoning` intact **and** now a content mirror.
- **Money/relay path untouched:** only response **body text** is reshaped. Status, headers (incl. billed `X-RogerAI-Cost`), model, routing, and the `: rogerai-cost=` SSE meter comment all pass through unchanged; the returned stream cost still comes from that meter.

### Spec-first (RED -> GREEN)
- Spec: `features/proxy/reasoning_fallback.feature` (godog) - non-streaming fill / untouched-non-empty / empty+empty-unchanged / `reasoning_content` field / whitespace-empty / billed-cost-passthrough / streaming synth / streaming-with-content-untouched / SSE-meter-survives / toggle-off raw passthrough (non-streaming and streaming).
- Units: `internal/client/reasoning_fallback_test.go` - table tests on the pure transform + `applyReasoningFallback` edge cases (null/missing content, usage-number fidelity, multi-choice, malformed) + `streamRelayBody` direct tests (no-DONE, meter ordering, overflow line, multi-choice, oversized non-streaming body).
- **RED** captured: a hermes-style empty-content reply yielded empty content and the reasoning-only stream synthesized nothing. **GREEN**: all scenarios pass.
- The BDD drives the **real** `ProxyHandler` over real HTTP against an httptest broker emitting the exact hermes-failing wire shape (no business-logic mocks).

### Review addressed (2nd commit)
A fresh-context reviewer caught two real issues, both fixed:
- **Streaming inject point:** the synthesized delta was before `[DONE]` but **after** the `finish_reason` chunk; a strict client that finalizes on `finish_reason` could ignore it. Now injected **before the finish chunk** (`[DONE]`/EOF remain fallback points).
- **Tool-call guard:** an empty-content turn carrying `tool_calls` has intentionally empty content; both paths now skip it (mirrors `internal/harness.parseCompletion`). An empty `tool_calls` array does not block the fallback.
- Plus: a memory cap on streaming reasoning accumulation, and CRLF/finish-order/tool-call scenarios + unit tests.

### Verification
- `go build ./...`, `go vet ./...`: clean.
- `go test ./internal/client` (godog strict) and `-race`: pass.
- `make cover-gate`: **PASS** - `internal/client` 95.2% (>=90), module total 92.3% (>=90).
- Live hermes `-z` E2E against the free `gpt-oss-120b` band: **deferred to founder manual QA** (needs a live broker/band + credentials the CI sandbox lacks). The BDD reproduces the failing wire shape end-to-end through the real proxy as the automated stand-in.
