### PR TITLE
Guest Operators follow-ups: 3 non-blocking review findings (BUILD-AND-HOLD)

### DIFF
--- a/cmd/rogerai-broker/probe_toolcall_cov_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_cov_test.go
@@ -1,12 +1,42 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/rogerai-fyi/roger/internal/protocol"
 	"github.com/rogerai-fyi/roger/internal/store"
 )
+
+// answerToolProbeEcho replies to the live tool-call canary by ECHOING the fresh per-probe nonce
+// the broker wove into the request (the forced tool's name is roger_probe_ack_<nonce>). A genuine
+// tool-honoring provider surfaces the nonce; echoing it lets the deterministic test drive the real
+// dispatch path even though probeToolCall mints a random nonce internally.
+func answerToolProbeEcho(tun *nodeTunnel) {
+	go func() {
+		job := <-tun.jobs
+		var req struct {
+			Tools []struct {
+				Function struct {
+					Name string `json:"name"`
+				} `json:"function"`
+			} `json:"tools"`
+		}
+		_ = json.Unmarshal(job.Body, &req)
+		fn := ""
+		if len(req.Tools) > 0 {
+			fn = req.Tools[0].Function.Name
+		}
+		body := `{"choices":[{"message":{"tool_calls":[{"function":{"name":"` + fn + `","arguments":"{\"token\":\"x\"}"}}]}}]}`
+		res := protocol.JobResult{ID: job.ID, Status: http.StatusOK, Body: []byte(body),
+			Receipt: protocol.UsageReceipt{RequestID: job.ID, CompletionTokens: 5}}
+		tun.mu.Lock()
+		ch := tun.waiters[job.ID]
+		tun.mu.Unlock()
+		ch <- res
+	}()
+}
 
 // probe_toolcall_cov_test.go covers the LIVE dispatch of the tool-call canary (probeToolCall)
 // beyond the pure-verdict + emission scenarios in toolcall_probe_bdd_test.go: the
@@ -20,7 +50,7 @@ func TestProbeToolCallSingleInstancePass(t *testing.T) {
 	b := relayBroker(store.NewMem())
 	b.toolsOK = map[string]bool{}
 	tun, _ := probeReg(b, "tnode")
-	answerProbe(tun, http.StatusOK, `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{\"ok\":true}"}}]}}]}`)
+	answerToolProbeEcho(tun) // echo the fresh nonce the broker wove into the canary
 
 	b.probeToolCall(b.nodes["tnode"], "m", true)
 

--- a/cmd/rogerai-broker/probe_toolcall_mi_test.go
+++ b/cmd/rogerai-broker/probe_toolcall_mi_test.go
@@ -51,7 +51,21 @@ func TestMultiInstanceToolCallCanaryCrossesBus(t *testing.T) {
 			return
 		}
 		res := miSignedResult(job.ID, "p1", "free-m", "", nodePriv, 200)
-		res.Body = []byte(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{\"ok\":true}"}}]}}]}`)
+		// Echo the fresh per-probe nonce A wove into the canary (the forced tool's name), so a
+		// genuine tool-honoring reply crosses the bus and earns the bit under the nonce check.
+		var creq struct {
+			Tools []struct {
+				Function struct {
+					Name string `json:"name"`
+				} `json:"function"`
+			} `json:"tools"`
+		}
+		_ = json.Unmarshal(job.Body, &creq)
+		fn := ""
+		if len(creq.Tools) > 0 {
+			fn = creq.Tools[0].Function.Name
+		}
+		res.Body = []byte(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"` + fn + `","arguments":"{\"token\":\"x\"}"}}]}}]}`)
 		rb, _ := json.Marshal(res)
 		rr := httptest.NewRequest(http.MethodPost, "/agent/result?node=p1", bytes.NewReader(rb))
 		rr.Header.Set("Authorization", miNodeBearer(token))

--- a/cmd/rogerai-broker/sharedstore.go
+++ b/cmd/rogerai-broker/sharedstore.go
@@ -705,14 +705,57 @@ func (v *valkeyStore) toolsVerified(ttl time.Duration) (map[string]bool, error) 
 		}
 		out[field] = true
 	}
-	// Lazily HDEL stale/unparseable fields so a dead node's field cannot accumulate forever (one
+	// Lazily sweep stale/unparseable fields so a dead node's field cannot accumulate forever (one
 	// actively-verified model refreshes the whole hash TTL, so stale fields never expire on their
-	// own). Best-effort: a sweep error does not affect the fresh result already computed.
+	// own). The sweep RE-CHECKS each field's CURRENT value before deleting (sweepStaleToolsFields),
+	// so a field that was stale in THIS HGETALL snapshot but re-marked fresh by a concurrent
+	// markToolsVerified (a different instance's passing canary) between the read and the delete is
+	// SPARED - closing the flicker race (PR #33 review, minor #2). Best-effort: a sweep error does
+	// not affect the fresh result already computed.
 	if len(stale) > 0 {
-		_ = v.rdb.HDel(ctx, toolsKey(), stale...).Err()
+		_ = v.sweepStaleToolsFields(ctx, cutoff, stale)
 	}
 	v.setUp(true)
 	return out, nil
+}
+
+// sweepStaleToolsSrc is the atomic re-check-then-delete the toolsVerified sweep runs: for each
+// candidate field it re-reads the CURRENT value and deletes ONLY if the field is still absent-of-
+// freshness (unparseable or older than cutoff). Doing the freshness check and the HDEL in one
+// server-side script closes the read-then-blind-HDEL race: a field re-marked fresh AFTER the
+// caller's HGETALL snapshot but BEFORE this runs now carries a value >= cutoff and is left intact.
+// Safe-direction: the worst case is UNDER-claiming (a field that goes stale between check and
+// delete simply survives one more cycle), never dropping a fresh verified bit.
+const sweepStaleToolsSrc = `
+local cutoff = tonumber(ARGV[1])
+local deleted = 0
+for i = 2, #ARGV do
+  local f = ARGV[i]
+  local v = redis.call('HGET', KEYS[1], f)
+  if v then
+    local ms = tonumber(v)
+    if ms == nil or ms < cutoff then
+      redis.call('HDEL', KEYS[1], f)
+      deleted = deleted + 1
+    end
+  end
+end
+return deleted
+`
+
+// sweepStaleToolsFields atomically deletes the given candidate fields that are STILL stale (or
+// unparseable) at execution time, re-checking freshness against cutoff (a UnixMilli) inside the
+// script so a concurrently re-marked field survives. Best-effort; the caller ignores the error.
+func (v *valkeyStore) sweepStaleToolsFields(ctx context.Context, cutoff int64, fields []string) error {
+	if v == nil || v.rdb == nil || len(fields) == 0 {
+		return nil
+	}
+	args := make([]any, 0, len(fields)+1)
+	args = append(args, cutoff)
+	for _, f := range fields {
+		args = append(args, f)
+	}
+	return v.rdb.Eval(ctx, sweepStaleToolsSrc, []string{toolsKey()}, args...).Err()
 }
 
 // regKey holds a node's full registration JSON, shared so any instance can mirror it.

--- a/cmd/rogerai-broker/toolcall.go
+++ b/cmd/rogerai-broker/toolcall.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,11 +33,25 @@ import (
 //   - multi-instance: the bit mirrors to the shared registry and is read as a UNION, exactly
 //     like the registry/liveness pattern, so two instances neither double-probe nor split it.
 
-// toolCanaryFn is the trivial single-parameter tool the canary offers. A model that honors
-// tool-calls returns a tool_calls entry naming it; the LENIENT verdict (FOUNDER FLAG T4)
-// accepts ANY well-formed tool_calls entry, so the exact name is not required (wantFn is
-// threaded through toolCallOK so a STRICT ruling could require it without a signature change).
+// toolCanaryFn is the BASE name of the trivial single-parameter tool the canary offers. Each
+// probe suffixes it with a fresh random nonce (toolCanaryFn+"_"+nonce), so the tool a model is
+// asked to call is never the same twice - closing the fingerprint hole (PR #33 review, minor #4)
+// a canned well-formed tool_calls could otherwise walk through to earn the badge unearned.
 const toolCanaryFn = "roger_probe_ack"
+
+// newToolNonce mints a fresh per-probe nonce: 8 bytes of crypto/rand hex (randomness in the
+// BROKER is fine, unlike deterministic workflow scripts). The nonce is woven into the canary's
+// tool name AND the token argument the prompt asks the model to echo, and toolCallOK requires the
+// response to reference it - so a hostile node cannot pre-can a reply for a value it can't guess.
+// crypto/rand.Read never partially fills without erroring; on the astronomically-unlikely error
+// we fall back to a time-seeded token so the nonce is never empty (empty would re-open leniency).
+func newToolNonce() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "t" + strconv.FormatInt(time.Now().UnixNano(), 16)
+	}
+	return hex.EncodeToString(b[:])
+}
 
 // toolCanaryMaxTokens is the canary's completion budget: TINY (FOUNDER FLAG T2). A tool call
 // is a few tokens of arguments; we never need the reasoning headroom the liveness canary
@@ -62,23 +79,31 @@ func toolKey(node, model string) string { return node + "\x00" + model }
 // single-parameter tool, tool_choice forcing a call, temperature 0, and a tiny max_tokens (T2).
 // A provider that honors tool-calls answers with a tool_calls entry; one that ignores tool
 // definitions answers in plain text (or errors), which the verdict reads as unproven.
-func toolCanaryBody(model string) []byte {
+//
+// The nonce is woven in TWO ways so a genuine model has an unpredictable token to echo (and a
+// canned reply has nothing to echo): the forced tool's NAME is toolCanaryFn+"_"+nonce, and its
+// single "token" parameter is what the prompt tells the model to set to the nonce. toolCallOK
+// accepts the nonce appearing in EITHER channel (name suffix or arguments), so a model that
+// honors tool-calls passes however it surfaces the call, while a fingerprinted reply built for a
+// different (or no) nonce fails. Single-parameter still (T2): the one param is "token".
+func toolCanaryBody(model, nonce string) []byte {
+	fn := toolCanaryFn + "_" + nonce
 	body, _ := json.Marshal(map[string]any{
 		"model": model,
 		"messages": []map[string]string{
-			{"role": "user", "content": "Call the roger_probe_ack function with ok set to true."},
+			{"role": "user", "content": "Call the " + fn + " function, setting token to \"" + nonce + "\"."},
 		},
 		"temperature": 0,
 		"max_tokens":  toolCanaryMaxTokens,
 		"tools": []map[string]any{{
 			"type": "function",
 			"function": map[string]any{
-				"name":        toolCanaryFn,
-				"description": "Acknowledge the probe by calling this function.",
+				"name":        fn,
+				"description": "Acknowledge the probe by calling this function with token set to the value in the instruction.",
 				"parameters": map[string]any{
 					"type":       "object",
-					"properties": map[string]any{"ok": map[string]any{"type": "boolean"}},
-					"required":   []string{"ok"},
+					"properties": map[string]any{"token": map[string]any{"type": "string"}},
+					"required":   []string{"token"},
 				},
 			},
 		}},
@@ -89,15 +114,20 @@ func toolCanaryBody(model string) []byte {
 
 // toolCallOK is the PURE verdict the tool-call canary applies to a provider's
 // /v1/chat/completions response - the twin of evalCanary's fingerprint check. ok == true ONLY
-// when the response carries at least one WELL-FORMED tool_calls entry: a non-empty
-// function.name AND JSON-parseable function.arguments. A plain-text answer, an empty tool_calls
+// when the response carries at least one WELL-FORMED tool_calls entry - a non-empty
+// function.name AND JSON-parseable function.arguments - that ALSO references THIS probe's nonce
+// (in the function name suffix or the arguments). A plain-text answer, an empty tool_calls
 // array, an unparseable body, or no choices all return false (unproven stays unproven).
 //
-// LENIENT default (FOUNDER FLAG T4): a valid tool_calls entry to a DIFFERENT function name
-// still proves tool-calling - structure (a valid array with a name + parseable arguments)
-// proves the provider HONORS the protocol. wantFn is threaded so a STRICT ruling could require
-// the name match without changing the signature; today it is used only in the reason string.
-func toolCallOK(body []byte, wantFn string) (ok bool, reason string) {
+// The nonce is the anti-fingerprint gate (PR #33 review, minor #4): the canary randomizes both
+// the tool name and a token the model must echo, so a CANNED/replayed well-formed tool_calls -
+// built for a prior probe or a fixed fingerprint - cannot reference the current nonce and fails.
+// It stays LENIENT about STRUCTURE and about WHERE the nonce appears (name or args) so a genuine
+// model passes however it surfaces the forced call (FOUNDER FLAG T4: a different function name is
+// still fine PROVIDED it echoes the nonce token). An empty nonce is a test affordance only (the
+// live probe always mints one via newToolNonce): with no nonce it degrades to the structural
+// check, which the broker never does in production.
+func toolCallOK(body []byte, nonce string) (ok bool, reason string) {
 	var resp struct {
 		Choices []struct {
 			Message struct {
@@ -126,13 +156,16 @@ func toolCallOK(body []byte, wantFn string) (ok bool, reason string) {
 			if !json.Valid([]byte(tc.Function.Arguments)) {
 				continue
 			}
-			if wantFn != "" && tc.Function.Name != wantFn {
-				return true, "well-formed tool_calls to a different function (lenient)"
+			// The nonce must appear in THIS call - the name suffix or the echoed arguments - so a
+			// canned/fingerprinted reply that cannot know the fresh nonce is rejected. Lenient
+			// about which channel carries it; strict that it is present.
+			if nonce != "" && !strings.Contains(tc.Function.Name, nonce) && !strings.Contains(tc.Function.Arguments, nonce) {
+				continue // well-formed but does not reference this probe's nonce (canned/replayed)
 			}
-			return true, "well-formed tool_calls"
+			return true, "well-formed tool_calls referencing the probe nonce"
 		}
 	}
-	return false, "no well-formed tool_calls entry (plain text / empty array / malformed)"
+	return false, "no well-formed tool_calls referencing the nonce (plain text / empty array / malformed / canned)"
 }
 
 // withVerifiedTools is the SOLE emission gate for the "tools" capability. It STRIPS any "tools"
@@ -299,7 +332,8 @@ func (b *broker) probeToolCall(node protocol.NodeRegistration, model string, aut
 	if t == nil && !mi {
 		return
 	}
-	job := protocol.Job{ID: protocol.NewRequestID(), User: "probe", Body: toolCanaryBody(model)}
+	nonce := newToolNonce() // fresh per probe: the model must echo it, defeating a canned reply
+	job := protocol.Job{ID: protocol.NewRequestID(), User: "probe", Body: toolCanaryBody(model, nonce)}
 
 	if mi {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -320,7 +354,7 @@ func (b *broker) probeToolCall(node protocol.NodeRegistration, model string, aut
 			if json.Unmarshal(raw, &res) != nil {
 				return
 			}
-			b.applyToolVerdict(node.NodeID, model, res, authoritative)
+			b.applyToolVerdict(node.NodeID, model, res, authoritative, nonce)
 		case <-time.After(30 * time.Second):
 			return // transient timeout: no verdict
 		}
@@ -339,7 +373,7 @@ func (b *broker) probeToolCall(node protocol.NodeRegistration, model string, aut
 	}
 	select {
 	case res := <-resCh:
-		b.applyToolVerdict(node.NodeID, model, res, authoritative)
+		b.applyToolVerdict(node.NodeID, model, res, authoritative, nonce)
 	case <-time.After(30 * time.Second):
 		return // transient timeout: no verdict
 	}
@@ -347,12 +381,14 @@ func (b *broker) probeToolCall(node protocol.NodeRegistration, model string, aut
 
 // applyToolVerdict evaluates a tool-call canary JobResult and records it. A non-2xx status is a
 // transient upstream hiccup (rate-limit/5xx), NOT proof the model dropped tool support, so it
-// is treated as a non-verdict (never clears). A 2xx body is the real verdict: toolCallOK.
-func (b *broker) applyToolVerdict(nodeID, model string, res protocol.JobResult, authoritative bool) {
+// is treated as a non-verdict (never clears). A 2xx body is the real verdict: toolCallOK, which
+// requires the response to reference THIS probe's nonce (threaded from probeToolCall) so a canned
+// well-formed tool_calls cannot earn the badge.
+func (b *broker) applyToolVerdict(nodeID, model string, res protocol.JobResult, authoritative bool, nonce string) {
 	if res.Status < 200 || res.Status >= 300 {
 		b.recordToolProbe(nodeID, model, false, true, authoritative) // transient: no verdict
 		return
 	}
-	ok, _ := toolCallOK(res.Body, toolCanaryFn)
+	ok, _ := toolCallOK(res.Body, nonce)
 	b.recordToolProbe(nodeID, model, ok, false, authoritative)
 }

--- a/cmd/rogerai-broker/toolcall_canary_red_test.go
+++ b/cmd/rogerai-broker/toolcall_canary_red_test.go
@@ -8,18 +8,20 @@ import "testing"
 // fingerprint check (probe.go). It is RED against origin/main because toolCallOK does NOT
 // exist yet (undefined: toolCallOK) — the not-yet-existing prober the spec approves.
 //
-// CONTRACT (proposed; the exact-name strictness is FOUNDER FLAG T4):
+// CONTRACT:
 //
-//	toolCallOK(body []byte, wantFn string) (ok bool, reason string)
+//	toolCallOK(body []byte, nonce string) (ok bool, reason string)
 //
 // ok == true ONLY when the response carries at least one well-formed tool_calls entry: a
-// non-empty function.name AND JSON-parseable function.arguments. A plain-text answer, an empty
-// tool_calls array, or an unparseable body all return false (unproven stays unproven). Under the
-// LENIENT default a valid tool_calls to a DIFFERENT function name still proves tool-calling
-// (structure proves the provider honors the protocol); wantFn is threaded so a STRICT ruling can
-// require the name match without changing the signature.
+// non-empty function.name AND JSON-parseable function.arguments - that ALSO references the probe
+// nonce (name suffix or arguments). A plain-text answer, an empty tool_calls array, or an
+// unparseable body all return false (unproven stays unproven). This table exercises the STRUCTURAL
+// layer with the nonce gate OFF (nonce == "", the test affordance); the nonce enforcement itself
+// - a canned reply that does not reference THIS probe's nonce fails - is pinned in
+// TestToolCallOKRequiresNonce (toolcall_nonce_red_test.go). With the gate off, a valid tool_calls
+// to a DIFFERENT function name still proves tool-calling (FOUNDER FLAG T4, lenient structure).
 func TestToolCallOK(t *testing.T) {
-	const wantFn = "roger_probe_ack"
+	const nonce = "" // structural layer only; nonce enforcement is covered separately
 
 	cases := []struct {
 		name string
@@ -79,7 +81,7 @@ func TestToolCallOK(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, reason := toolCallOK([]byte(c.body), wantFn)
+			got, reason := toolCallOK([]byte(c.body), nonce)
 			if got != c.want {
 				t.Fatalf("toolCallOK(%s) = %v (%q), want %v", c.body, got, reason, c.want)
 			}

--- a/cmd/rogerai-broker/toolcall_nonce_red_test.go
+++ b/cmd/rogerai-broker/toolcall_nonce_red_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// toolcall_nonce_red_test.go pins the per-probe NONCE the tool-call canary carries (PR #33
+// review, minor #4): the canary body was deterministic/fingerprintable, so a hostile node could
+// return a CANNED well-formed tool_calls to earn the verified "tools" badge without honoring
+// tools. Each probe now carries a fresh random nonce (a suffix on the tool function name + a
+// token the model must echo), and toolCallOK requires the response to reference THAT nonce.
+//
+// RED against origin/main: toolCallOK today is LENIENT about the second arg (it only used it in
+// the reason string), so a well-formed tool_calls that does NOT reference the current nonce still
+// returns true. These cases assert the nonce is enforced.
+
+// TestToolCallOKRequiresNonce: a well-formed tool_calls that does not reference THIS probe's
+// nonce (a canned/replayed fingerprint) does NOT pass; one that echoes it does.
+func TestToolCallOKRequiresNonce(t *testing.T) {
+	const nonce = "9f3ac71b"
+
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "canned well-formed tool_calls that omits the current nonce -> unproven",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{\"ok\":true}"}}]}}]}`,
+			want: false,
+		},
+		{
+			name: "replayed tool_calls carrying a DIFFERENT (stale) nonce -> unproven",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack_deadbeef","arguments":"{\"token\":\"deadbeef\"}"}}]}}]}`,
+			want: false,
+		},
+		{
+			name: "genuine echo: nonce in the function name suffix -> proven",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack_9f3ac71b","arguments":"{}"}}]}}]}`,
+			want: true,
+		},
+		{
+			name: "genuine echo: nonce in the arguments token -> proven",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"whatever","arguments":"{\"token\":\"9f3ac71b\"}"}}]}}]}`,
+			want: true,
+		},
+		{
+			name: "well-formed but empty args and non-nonce name -> unproven (no nonce anywhere)",
+			body: `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{}"}}]}}]}`,
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, reason := toolCallOK([]byte(c.body), nonce)
+			if got != c.want {
+				t.Fatalf("toolCallOK(%s, %q) = %v (%q), want %v", c.body, nonce, got, reason, c.want)
+			}
+		})
+	}
+}
+
+// TestToolCanaryBodyEmbedsNonce: the canary body must carry the nonce so the model has something
+// to echo - in the forced tool's function name AND as the required argument the prompt asks it to
+// set. RED against origin/main: toolCanaryBody takes no nonce today.
+func TestToolCanaryBodyEmbedsNonce(t *testing.T) {
+	const nonce = "abc12345"
+	body := toolCanaryBody("m", nonce)
+
+	var req struct {
+		Messages []struct {
+			Content string `json:"content"`
+		} `json:"messages"`
+		Tools []struct {
+			Function struct {
+				Name       string `json:"name"`
+				Parameters struct {
+					Properties map[string]any `json:"properties"`
+				} `json:"parameters"`
+			} `json:"function"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("canary body did not parse: %v", err)
+	}
+	if len(req.Tools) != 1 {
+		t.Fatalf("want exactly one tool, got %d", len(req.Tools))
+	}
+	if !strings.Contains(req.Tools[0].Function.Name, nonce) {
+		t.Errorf("tool function name %q does not carry the nonce %q", req.Tools[0].Function.Name, nonce)
+	}
+	if len(req.Tools[0].Function.Parameters.Properties) != 1 {
+		t.Errorf("canary must stay single-parameter, got %d params", len(req.Tools[0].Function.Parameters.Properties))
+	}
+	// The prompt must instruct the model to echo the nonce, so a genuine model has a token to
+	// return (the arguments-echo channel toolCallOK also accepts).
+	if len(req.Messages) == 0 || !strings.Contains(req.Messages[0].Content, nonce) {
+		t.Errorf("canary prompt does not ask the model to echo the nonce: %q", req.Messages)
+	}
+}

--- a/cmd/rogerai-broker/toolcall_probe_bdd_test.go
+++ b/cmd/rogerai-broker/toolcall_probe_bdd_test.go
@@ -23,6 +23,12 @@ import (
 	"github.com/rogerai-fyi/roger/internal/store"
 )
 
+// tcNonce is the fixed nonce the BDD steps weave into their canned canary responses, standing in
+// for the fresh per-probe nonce the live probeToolCall mints (PR #33 review, minor #4). Driving
+// applyToolVerdict with a known nonce keeps the scenarios deterministic while exercising the real
+// nonce-enforcing verdict: a well-formed reply must reference THIS nonce to earn the bit.
+const tcNonce = "beadfeed"
+
 type tcState struct {
 	b     *broker
 	now   time.Time
@@ -128,7 +134,9 @@ func (s *tcState) publicCapsOmitTools() error {
 func (s *tcState) brokerSendsCanary() error { return nil } // the When is realized by the verdict steps
 
 func (s *tcState) providerWellFormed() error {
-	body := `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{\"ok\":true}"}}]},"finish_reason":"tool_calls"}]}`
+	// A well-formed tool_calls that ECHOES this probe's nonce (in the token argument) - the shape
+	// a genuine tool-honoring model returns.
+	body := `{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack_` + tcNonce + `","arguments":"{\"token\":\"` + tcNonce + `\"}"}}]},"finish_reason":"tool_calls"}]}`
 	s.applyBody(body)
 	return nil
 }
@@ -149,9 +157,9 @@ func (s *tcState) providerUnparseable() error {
 }
 
 // applyBody runs the REAL verdict path: a 2xx JobResult with body -> applyToolVerdict ->
-// toolCallOK -> recordToolProbe (single-instance => authoritative).
+// toolCallOK (against tcNonce) -> recordToolProbe (single-instance => authoritative).
 func (s *tcState) applyBody(body string) {
-	s.b.applyToolVerdict(s.node, s.model, protocol.JobResult{Status: 200, Body: []byte(body)}, true)
+	s.b.applyToolVerdict(s.node, s.model, protocol.JobResult{Status: 200, Body: []byte(body)}, true, tcNonce)
 }
 
 func (s *tcState) earnsTools() error {
@@ -206,8 +214,8 @@ func (s *tcState) offersTwoModels() error {
 }
 
 func (s *tcState) onlyFirstPasses() error {
-	s.b.applyToolVerdict(s.node, s.model, protocol.JobResult{Status: 200, Body: []byte(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{}"}}]}}]}`)}, true)
-	s.b.applyToolVerdict(s.node, s.model2, protocol.JobResult{Status: 200, Body: []byte(`{"choices":[{"message":{"content":"no tools here"}}]}`)}, true)
+	s.b.applyToolVerdict(s.node, s.model, protocol.JobResult{Status: 200, Body: []byte(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack_` + tcNonce + `","arguments":"{}"}}]}}]}`)}, true, tcNonce)
+	s.b.applyToolVerdict(s.node, s.model2, protocol.JobResult{Status: 200, Body: []byte(`{"choices":[{"message":{"content":"no tools here"}}]}`)}, true, tcNonce)
 	return nil
 }
 
@@ -279,7 +287,7 @@ func (s *tcState) trafficResetsBackoff() error {
 func (s *tcState) canaryUnbilledDiscarded() error {
 	// The canary rides the probe job identity: User=="probe" (unbilled; the settle/earnings
 	// path is never taken for a probe user) and the result body is discarded after the verdict.
-	job := protocol.Job{User: "probe", Body: toolCanaryBody(s.model)}
+	job := protocol.Job{User: "probe", Body: toolCanaryBody(s.model, tcNonce)}
 	if job.User != "probe" {
 		return fmt.Errorf("tool canary job is not marked unbilled (User=%q)", job.User)
 	}
@@ -304,7 +312,7 @@ func (s *tcState) trivialToolTinyBudget() error {
 			} `json:"function"`
 		} `json:"tools"`
 	}
-	if err := json.Unmarshal(toolCanaryBody(s.model), &req); err != nil {
+	if err := json.Unmarshal(toolCanaryBody(s.model, tcNonce), &req); err != nil {
 		return fmt.Errorf("canary body did not parse: %v", err)
 	}
 	if len(req.Tools) != 1 {
@@ -436,7 +444,7 @@ func (s *tcState) canaryRuns() error {
 func (s *tcState) transportOr429() error {
 	// A transport error / 429 is a NON-verdict: applyToolVerdict on a non-2xx status records a
 	// TRANSIENT probe (never clears). Model the 429 as a non-2xx JobResult.
-	s.b.applyToolVerdict(s.node, s.model, protocol.JobResult{Status: 429, Body: []byte(`{"error":"rate limited"}`)}, true)
+	s.b.applyToolVerdict(s.node, s.model, protocol.JobResult{Status: 429, Body: []byte(`{"error":"rate limited"}`)}, true, tcNonce)
 	return nil
 }
 
@@ -453,11 +461,33 @@ func (s *tcState) retriedLater() error {
 }
 
 func (s *tcState) wrongFunctionWellFormed() error {
-	s.applyBody(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"some_other_fn","arguments":"{\"x\":1}"}}]}}]}`)
+	// A DIFFERENT function name still proves tool-calling under the lenient rule (FOUNDER FLAG T4)
+	// AS LONG AS it echoes this probe's nonce (here in the arguments) - the nonce closes the
+	// canned-reply hole without forcing an exact name match.
+	s.applyBody(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"some_other_fn","arguments":"{\"token\":\"` + tcNonce + `\",\"x\":1}"}}]}}]}`)
 	return nil
 }
 
 func (s *tcState) earnsUnderLenient() error { return s.earnsTools() }
+
+// providerEchoesNonce is the genuine reply: a well-formed tool_calls that references THIS probe's
+// nonce (reuses providerWellFormed, which echoes tcNonce).
+func (s *tcState) providerEchoesNonce() error { return s.providerWellFormed() }
+
+// providerOmitsNonce is a CANNED well-formed tool_calls that references NO nonce - the
+// fingerprint attack. It is structurally valid but must be rejected because it cannot carry the
+// fresh nonce a genuine model would echo.
+func (s *tcState) providerOmitsNonce() error {
+	s.applyBody(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack","arguments":"{\"ok\":true}"}}]}}]}`)
+	return nil
+}
+
+// providerReplaysStaleNonce is a REPLAY: a well-formed tool_calls carrying a DIFFERENT (stale)
+// nonce from an earlier probe. It must be rejected against the current probe's nonce.
+func (s *tcState) providerReplaysStaleNonce() error {
+	s.applyBody(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"roger_probe_ack_deadbeef","arguments":"{\"token\":\"deadbeef\"}"}}]}}]}`)
+	return nil
+}
 
 func (s *tcState) storedOfferListsTools() error {
 	// Simulate an ingestion path that BYPASSES the register-door strip (shared-registry mirror,
@@ -645,8 +675,11 @@ func TestTrustToolCallProbeBDD(t *testing.T) {
 			sc.Step(`^the tool-call canary comes back as a transport error or a 429 rate-limit$`, st.transportOr429)
 			sc.Step(`^the earned "tools" bit is NOT cleared on a transient non-verdict$`, st.notClearedOnTransient)
 			sc.Step(`^the probe is retried on a later round rather than recorded as a regression$`, st.retriedLater)
-			sc.Step(`^the provider returns a well-formed tool_calls entry for a DIFFERENT function name$`, st.wrongFunctionWellFormed)
+			sc.Step(`^the provider returns a well-formed tool_calls entry for a DIFFERENT function name that echoes the probe nonce$`, st.wrongFunctionWellFormed)
 			sc.Step(`^the model earns "tools" under the lenient rule$`, st.earnsUnderLenient)
+			sc.Step(`^the provider returns a well-formed tool_calls that echoes this probe's nonce$`, st.providerEchoesNonce)
+			sc.Step(`^the provider returns a well-formed tool_calls that does NOT reference this probe's nonce$`, st.providerOmitsNonce)
+			sc.Step(`^the provider replays a well-formed tool_calls carrying a stale nonce$`, st.providerReplaysStaleNonce)
 			sc.Step(`^the model's stored offer already lists "tools" from a mixed-version mirror$`, st.storedOfferListsTools)
 
 			sc.Step(`^the broker runs two instances behind the shared store$`, st.twoInstances)

--- a/cmd/rogerai-broker/toolsweep_race_test.go
+++ b/cmd/rogerai-broker/toolsweep_race_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+)
+
+// toolsweep_race_test.go pins the fix for PR #33 review, minor #2: the toolsVerified stale-sweep
+// HDEL'd fields computed from a stale HGETALL snapshot, so a field that was >45min stale at read
+// but RE-MARKED fresh (markToolsVerified) sub-second later - after the snapshot, before the HDEL -
+// could be dropped for a sync cycle, flickering a verified bit off. The sweep must re-check
+// freshness immediately before the delete and spare a field re-marked within the window.
+//
+// RED against origin/main: sweepStaleToolsFields does not exist; the sweep is a blind HDEL.
+
+func newToolStore(t *testing.T) *valkeyStore {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	v, err := newValkeyStore("redis://" + mr.Addr())
+	if err != nil {
+		t.Fatalf("newValkeyStore: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	return v
+}
+
+func setToolField(t *testing.T, v *valkeyStore, node, model string, ms int64) {
+	t.Helper()
+	if err := v.rdb.HSet(context.Background(), toolsKey(), node+"\x00"+model, strconv.FormatInt(ms, 10)).Err(); err != nil {
+		t.Fatalf("HSet %s/%s: %v", node, model, err)
+	}
+}
+
+func toolFieldExists(t *testing.T, v *valkeyStore, node, model string) bool {
+	t.Helper()
+	ok, err := v.rdb.HExists(context.Background(), toolsKey(), node+"\x00"+model).Result()
+	if err != nil {
+		t.Fatalf("HExists: %v", err)
+	}
+	return ok
+}
+
+// TestSweepStaleToolsSparesReMarkedField is the race guard: a field STALE at the snapshot but
+// re-marked FRESH before the sweep must SURVIVE (the sweep re-checks current freshness), while a
+// genuinely-still-stale field and an unparseable field are swept.
+func TestSweepStaleToolsSparesReMarkedField(t *testing.T) {
+	v := newToolStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	ttl := 45 * time.Minute
+	cutoff := now.Add(-ttl).UnixMilli()
+
+	// Snapshot-time state: three fields all look STALE / unparseable to the HGETALL caller.
+	setToolField(t, v, "n", "reMarked", cutoff-1000) // stale at snapshot...
+	setToolField(t, v, "n", "stillStale", cutoff-1000)
+	if err := v.rdb.HSet(ctx, toolsKey(), "n\x00garbage", "not-a-number").Err(); err != nil {
+		t.Fatal(err)
+	}
+	candidates := []string{"n\x00reMarked", "n\x00stillStale", "n\x00garbage"}
+
+	// The RACE: between the snapshot and the sweep, an authoritative host re-marks one field.
+	setToolField(t, v, "n", "reMarked", now.UnixMilli()) // ...fresh again before the sweep
+
+	if err := v.sweepStaleToolsFields(ctx, cutoff, candidates); err != nil {
+		t.Fatalf("sweepStaleToolsFields: %v", err)
+	}
+
+	if !toolFieldExists(t, v, "n", "reMarked") {
+		t.Fatal("a field re-marked within the freshness window was wrongly swept (the flicker race)")
+	}
+	if toolFieldExists(t, v, "n", "stillStale") {
+		t.Fatal("a genuinely-stale field survived the sweep")
+	}
+	if toolFieldExists(t, v, "n", "garbage") {
+		t.Fatal("an unparseable field survived the sweep")
+	}
+}
+
+// TestToolsVerifiedSweepStillClearsStale confirms the end-to-end read still ages out a stale
+// field (the sweep runs) while returning only fresh fields - the guard did not disable the sweep.
+func TestToolsVerifiedSweepStillClearsStale(t *testing.T) {
+	v := newToolStore(t)
+	now := time.Now()
+	ttl := 45 * time.Minute
+
+	setToolField(t, v, "n", "fresh", now.UnixMilli())
+	setToolField(t, v, "n", "old", now.Add(-ttl-time.Minute).UnixMilli())
+
+	got, err := v.toolsVerified(ttl)
+	if err != nil {
+		t.Fatalf("toolsVerified: %v", err)
+	}
+	if !got[toolKey("n", "fresh")] {
+		t.Fatal("fresh field missing from the verified union")
+	}
+	if got[toolKey("n", "old")] {
+		t.Fatal("stale field wrongly present in the verified union")
+	}
+	if toolFieldExists(t, v, "n", "old") {
+		t.Fatal("stale field was not swept from the hash")
+	}
+}

--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -819,7 +819,7 @@ func cmdUse(cfg config, args []string) error {
 	// Advanced - defaulted and tucked away (CLI-SIMPLICITY-AUDIT C7). --port 0 =
 	// auto-pick a free port; --max-in is the rare input-heavy cap (C1 drops the
 	// --max-price alias entirely).
-	advanced := fs.Bool("advanced", false, "show advanced flags (--port --max-in --min-tps --confidential --yes)")
+	advanced := fs.Bool("advanced", false, "show advanced flags (--port --max-in --min-tps --confidential --yes --raw)")
 	port := fs.Int("port", 0, "local endpoint port (0 = auto-pick a free one)")
 	confidential := fs.Bool("confidential", false, "route only to confidential (TEE-attested) nodes")
 	maxIn := fs.Float64("max-in", -1, "cap: skip stations above this $/1M INPUT price; 0 = no cap")
@@ -832,7 +832,7 @@ func cmdUse(cfg config, args []string) error {
 	raw := fs.Bool("raw", false, "raw passthrough: disable the reasoning->content fallback for this session")
 	fs.Parse(args[1:])
 	if *advanced {
-		fmt.Println("advanced flags: --port --max-in --min-tps --confidential --yes")
+		fmt.Println("advanced flags: --port --max-in --min-tps --confidential --yes --raw")
 	}
 	// Start from the resolved per-model limit (or Default), then let flags override
 	// it for this session. -1 sentinel = flag not passed (keep the stored limit).

--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -826,6 +826,10 @@ func cmdUse(cfg config, args []string) error {
 	minTPS := fs.Float64("min-tps", -1, "require at least this measured throughput (tok/s); 0 = no floor")
 	yes := fs.Bool("yes", false, "skip the connect-time confirm (for scripts / Hermes / bots)")
 	freq := fs.String("freq", "", "tune in to a PRIVATE band by its frequency code, e.g. \"147.520 MHz 8F3K-9M2Q\" (the code is what matters; cosmetic part optional)")
+	// --raw disables the reasoning->content fallback for this session (raw provider body).
+	// Default off = fallback ON (an empty-content reasoning reply is surfaced as content).
+	// ROGERAI_REASONING_RAW=1 does the same via the environment (client.Use ORs them).
+	raw := fs.Bool("raw", false, "raw passthrough: disable the reasoning->content fallback for this session")
 	fs.Parse(args[1:])
 	if *advanced {
 		fmt.Println("advanced flags: --port --max-in --min-tps --confidential --yes")
@@ -853,7 +857,7 @@ func cmdUse(cfg config, args []string) error {
 	return client.Use(cfg.Broker, cfg.User, model, client.UseOptions{
 		Port: useport, Confidential: *confidential,
 		MaxIn: lim.MaxIn, MaxOut: lim.MaxOut, MinTPS: lim.MinTPS,
-		TypicalOut: typical, Yes: *yes, Freq: strings.TrimSpace(*freq),
+		TypicalOut: typical, Yes: *yes, Freq: strings.TrimSpace(*freq), Raw: *raw,
 	})
 }
 

--- a/features/proxy/reasoning_fallback.feature
+++ b/features/proxy/reasoning_fallback.feature
@@ -10,7 +10,8 @@ Feature: Proxy reasoning->content fallback (relay path)
   Founder ruling (option A, 2026-07-08): the fallback is ON by default. Because we fill
   only EMPTY content, a client that reads reasoning separately still gets the reasoning
   field intact AND now a content mirror - the accepted double-mirror tradeoff. A caller
-  that needs raw passthrough can disable it per session.
+  that needs raw passthrough can disable it per session via `roger use --raw` (or the
+  ROGERAI_REASONING_RAW env var), which sets ProxyOptions.ReasoningFallbackOff.
 
   # NON-STREAMING (application/json): the whole body is buffered, transformed, forwarded.
   Rule: Non-streaming - empty content is filled from reasoning

--- a/features/trust/toolcall_probe.feature
+++ b/features/trust/toolcall_probe.feature
@@ -160,11 +160,36 @@ Feature: A model earns the verified "tools" capability only when the broker's to
     And the probe is retried on a later round rather than recorded as a regression
     # Mirrors the liveness probe's "a dispatch that never reached the node is not evidence".
 
-  Scenario: A wrong-function but well-formed tool_calls still proves tool-calling (FOUNDER FLAG T4, lenient default)
-    When the provider returns a well-formed tool_calls entry for a DIFFERENT function name
+  Scenario: A wrong-function but well-formed tool_calls that echoes the nonce still proves tool-calling (FOUNDER FLAG T4, lenient default)
+    When the provider returns a well-formed tool_calls entry for a DIFFERENT function name that echoes the probe nonce
     Then the model earns "tools" under the lenient rule
     # Structure (a valid tool_calls array with a function name + parseable arguments) proves the
-    # provider HONORS tool-calling; exact-name matching is the strict alternative left to T4.
+    # provider HONORS tool-calling; exact-name matching is the strict alternative left to T4. The
+    # per-probe NONCE must still appear (name suffix or arguments), so leniency is about the name,
+    # never about skipping the nonce check.
+
+  # --- anti-fingerprint: the per-probe nonce (PR #33 review, minor #4) -------------------
+  # The canary body was deterministic, so a hostile node could return a CANNED well-formed
+  # tool_calls to earn the badge without honoring tools. Each probe now weaves a fresh random
+  # nonce into the tool NAME and a token the prompt tells the model to echo, and the verdict
+  # requires the response to reference THAT nonce. A canned/replayed reply cannot guess it.
+
+  Scenario: A well-formed tool_calls that echoes THIS probe's nonce earns "tools"
+    When the broker sends its tool-call canary to the model
+    And the provider returns a well-formed tool_calls that echoes this probe's nonce
+    Then the model earns the verified "tools" capability
+
+  Scenario: A canned well-formed tool_calls that omits the current nonce does NOT earn "tools"
+    When the broker sends its tool-call canary to the model
+    And the provider returns a well-formed tool_calls that does NOT reference this probe's nonce
+    Then the model does NOT earn "tools"
+    # A fingerprinted/replayed reply built for a prior probe cannot carry the fresh nonce, so it
+    # is rejected exactly like a plain-text answer - closing the earn-the-badge-unearned hole.
+
+  Scenario: A replayed tool_calls carrying a STALE nonce from an earlier probe does NOT earn "tools"
+    When the broker sends its tool-call canary to the model
+    And the provider replays a well-formed tool_calls carrying a stale nonce
+    Then the model does NOT earn "tools"
 
   Scenario: A "tools" that slips into a STORED offer (mirror / re-hydrate) is still not emitted unprobed
     Given the model's stored offer already lists "tools" from a mixed-version mirror

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1587,10 +1587,13 @@ var (
 	newProxyHandler = ProxyHandler
 )
 
-// rawReasoningEnv reports whether ROGERAI_REASONING_RAW asks for raw passthrough (the
+// RawReasoningEnv reports whether ROGERAI_REASONING_RAW asks for raw passthrough (the
 // reasoning->content fallback disabled). A non-empty value other than the usual falsey tokens
 // ("", "0", "false", "no", "off") counts as set, so `ROGERAI_REASONING_RAW=1` works. It ORs
-// with the --raw flag (either enables raw), never overrides an explicit --raw.
+// with the --raw flag (either enables raw), never overrides an explicit --raw. Exported so the
+// TUI booth honors the same env toggle as `roger use` (the env var is a global session knob).
+func RawReasoningEnv() bool { return rawReasoningEnv() }
+
 func rawReasoningEnv() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("ROGERAI_REASONING_RAW"))) {
 	case "", "0", "false", "no", "off":

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1403,6 +1403,12 @@ type UseOptions struct {
 	TypicalOut   int     // output tokens for the est-cost line (default 800)
 	Yes          bool    // skip the (y/N) confirm (scripts / Hermes / bots)
 	Freq         string  // private band frequency code (empty = open market). Routes via X-Roger-Freq.
+	// Raw disables the reasoning->content fallback for this session (the `roger use --raw`
+	// flag / ROGERAI_REASONING_RAW env). Default false = fallback ON (founder default): an
+	// empty-content reasoning reply is surfaced as content. Raw true is the honest per-session
+	// disable the proxy already supported programmatically (ProxyOptions.ReasoningFallbackOff)
+	// but had no user-facing surface for - a caller that wants the untouched provider body.
+	Raw bool
 }
 
 // balanceOf fetches the caller's wallet credits (best-effort; -1 if unavailable).
@@ -1561,10 +1567,10 @@ func Use(broker, user, model string, opt UseOptions) error {
 	}
 	fmt.Printf("\n  drop-in, OpenAI-compatible - point any OpenAI tool here. roger that.\n")
 	fmt.Printf("  OPENAI_API_BASE=http://%s/v1  OPENAI_API_KEY=%s   (Ctrl-C to stop)\n", addr, sessionKey)
-	opts := ProxyOptions{Broker: broker, User: user, Model: model, SessionKey: sessionKey, Confidential: opt.Confidential, MaxPriceIn: opt.MaxIn, MaxPriceOut: maxOut, MinTPS: opt.MinTPS, Alert: func(s string) {
+	opts := ProxyOptions{Broker: broker, User: user, Model: model, SessionKey: sessionKey, Confidential: opt.Confidential, MaxPriceIn: opt.MaxIn, MaxPriceOut: maxOut, MinTPS: opt.MinTPS, ReasoningFallbackOff: opt.Raw || rawReasoningEnv(), Alert: func(s string) {
 		fmt.Fprintln(os.Stderr, "rogerai: "+s)
 	}}
-	return useServe(addr, ProxyHandler(opts))
+	return useServe(addr, newProxyHandler(opts))
 }
 
 // useStdin / useServe are seams over the two side effects Use can't run in a test: the
@@ -1575,7 +1581,24 @@ func Use(broker, user, model string, opt UseOptions) error {
 var (
 	useStdin = os.Stdin
 	useServe = http.ListenAndServe
+	// newProxyHandler is the seam Use / useOnFreq build the local relay handler through, so a
+	// test can capture the assembled ProxyOptions (e.g. the --raw wiring) without binding a
+	// real listener. Production value is ProxyHandler; the useServe seam still runs it.
+	newProxyHandler = ProxyHandler
 )
+
+// rawReasoningEnv reports whether ROGERAI_REASONING_RAW asks for raw passthrough (the
+// reasoning->content fallback disabled). A non-empty value other than the usual falsey tokens
+// ("", "0", "false", "no", "off") counts as set, so `ROGERAI_REASONING_RAW=1` works. It ORs
+// with the --raw flag (either enables raw), never overrides an explicit --raw.
+func rawReasoningEnv() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("ROGERAI_REASONING_RAW"))) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
 
 // useOnFreq is the private-band branch of Use: resolve a frequency code, confirm the
 // price (same price-safety as the open market), then bind a local endpoint that routes
@@ -1645,10 +1668,10 @@ func useOnFreq(broker, user, model string, opt UseOptions, maxOut float64, typic
 	fmt.Printf("  %-9s %s\n", "FREQ", display)
 	fmt.Printf("\n  drop-in, OpenAI-compatible - point any OpenAI tool here. roger that.\n")
 	fmt.Printf("  OPENAI_API_BASE=http://%s/v1  OPENAI_API_KEY=%s   (Ctrl-C to stop)\n", addr, sessionKey)
-	opts := ProxyOptions{Broker: broker, User: user, Model: model, SessionKey: sessionKey, MaxPriceIn: opt.MaxIn, MaxPriceOut: maxOut, MinTPS: opt.MinTPS, Freq: opt.Freq, Alert: func(s string) {
+	opts := ProxyOptions{Broker: broker, User: user, Model: model, SessionKey: sessionKey, MaxPriceIn: opt.MaxIn, MaxPriceOut: maxOut, MinTPS: opt.MinTPS, Freq: opt.Freq, ReasoningFallbackOff: opt.Raw || rawReasoningEnv(), Alert: func(s string) {
 		fmt.Fprintln(os.Stderr, "rogerai: "+s)
 	}}
-	return useServe(addr, ProxyHandler(opts))
+	return useServe(addr, newProxyHandler(opts))
 }
 
 // rangeLabel renders a cross-station spread as "min ~ max" ($/1M out), or a single

--- a/internal/client/raw_reasoning_test.go
+++ b/internal/client/raw_reasoning_test.go
@@ -1,0 +1,116 @@
+package client
+
+import (
+	"net/http"
+	"os"
+	"testing"
+)
+
+// raw_reasoning_test.go pins the `roger use --raw` wiring (PR #34 follow-up, finding 1): the
+// documented "a caller that needs raw passthrough can disable it per session" toggle must have a
+// real user-facing surface. --raw (UseOptions.Raw) and the ROGERAI_REASONING_RAW env var both
+// thread into ProxyOptions.ReasoningFallbackOff so the per-session disable actually works; absent
+// = fallback ON (the default). It is RED against origin/main because UseOptions has no Raw field
+// and nothing sets ReasoningFallbackOff from a caller knob.
+//
+// The wiring is observed through newProxyHandler, the seam Use/useOnFreq build the proxy handler
+// through (the twin of the useServe seam) - a test captures the ProxyOptions Use assembled.
+
+// captureProxyOpts points newProxyHandler at a capture func so a test can read the ProxyOptions
+// Use built without binding a real relay. Restored on cleanup. It still returns a real handler so
+// the downstream useServe seam is unaffected.
+func captureProxyOpts(t *testing.T, got *ProxyOptions) {
+	t.Helper()
+	old := newProxyHandler
+	newProxyHandler = func(o ProxyOptions) http.Handler {
+		*got = o
+		return old(o)
+	}
+	t.Cleanup(func() { newProxyHandler = old })
+}
+
+// TestUseRawFlagDisablesReasoningFallback: `roger use --raw` (UseOptions.Raw) sets
+// ProxyOptions.ReasoningFallbackOff on the open-market path, so the relay hands back the raw
+// provider body. Default (Raw false, env unset) leaves the fallback ON.
+func TestUseRawFlagDisablesReasoningFallback(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("ROGERAI_REASONING_RAW", "")
+	b := fakeBroker(t)
+
+	var addr string
+	captureServe(t, &addr)
+	var opts ProxyOptions
+	captureProxyOpts(t, &opts)
+
+	if err := Use(b, "u_gh_1", "m1", UseOptions{Raw: true, Yes: true, MaxOut: 5, Port: 7100}); err != nil {
+		t.Fatalf("Use(--raw) = %v, want nil", err)
+	}
+	if !opts.ReasoningFallbackOff {
+		t.Fatal("--raw did not set ProxyOptions.ReasoningFallbackOff (per-session disable not wired)")
+	}
+}
+
+// TestUseDefaultKeepsReasoningFallbackOn: without --raw and with the env unset the fallback stays
+// ON (ReasoningFallbackOff false) - the founder default.
+func TestUseDefaultKeepsReasoningFallbackOn(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("ROGERAI_REASONING_RAW", "")
+	b := fakeBroker(t)
+
+	var addr string
+	captureServe(t, &addr)
+	var opts ProxyOptions
+	captureProxyOpts(t, &opts)
+
+	if err := Use(b, "u_gh_1", "m1", UseOptions{Yes: true, MaxOut: 5, Port: 7101}); err != nil {
+		t.Fatalf("Use(default) = %v, want nil", err)
+	}
+	if opts.ReasoningFallbackOff {
+		t.Fatal("default Use disabled the reasoning fallback (should default ON)")
+	}
+}
+
+// TestUseRawEnvDisablesReasoningFallback: ROGERAI_REASONING_RAW=1 disables the fallback even
+// without the flag, so a scripted caller can opt into raw passthrough via the environment.
+func TestUseRawEnvDisablesReasoningFallback(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("ROGERAI_REASONING_RAW", "1")
+	b := fakeBroker(t)
+
+	var addr string
+	captureServe(t, &addr)
+	var opts ProxyOptions
+	captureProxyOpts(t, &opts)
+
+	if err := Use(b, "u_gh_1", "m1", UseOptions{Yes: true, MaxOut: 5, Port: 7102}); err != nil {
+		t.Fatalf("Use(env raw) = %v, want nil", err)
+	}
+	if !opts.ReasoningFallbackOff {
+		t.Fatal("ROGERAI_REASONING_RAW=1 did not disable the reasoning fallback")
+	}
+}
+
+// TestUseOnFreqRawDisablesReasoningFallback: the private-band (--freq) path honors --raw too, so
+// the toggle is not silently dropped when tuning a private frequency.
+func TestUseOnFreqRawDisablesReasoningFallback(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("ROGERAI_REASONING_RAW", "")
+	srv := bandResolveServer(t, 2.0) // below the confirm threshold -> plain (y/N)
+
+	var addr string
+	captureServe(t, &addr)
+	var opts ProxyOptions
+	captureProxyOpts(t, &opts)
+
+	pr, pw, _ := os.Pipe()
+	_, _ = pw.WriteString("y\n") // confirm the channel
+	_ = pw.Close()
+
+	opt := UseOptions{Freq: "147.520 MHz 8F3K-9M2Q", Port: 7103, Raw: true}
+	if err := useOnFreq(srv.URL, "u", "m", opt, ConsumerDefaultMaxOut, 800, true, pr); err != nil {
+		t.Fatalf("useOnFreq(--raw) = %v, want nil", err)
+	}
+	if !opts.ReasoningFallbackOff {
+		t.Fatal("--raw did not set ReasoningFallbackOff on the private-band path")
+	}
+}

--- a/internal/tui/raw_reasoning_env_test.go
+++ b/internal/tui/raw_reasoning_env_test.go
@@ -1,0 +1,27 @@
+package tui
+
+import "testing"
+
+// raw_reasoning_env_test.go pins the TUI booth's honoring of ROGERAI_REASONING_RAW (pre-push
+// audit minor): liveProxyOpts must set ProxyOptions.ReasoningFallbackOff from the global env
+// toggle, so exporting the var disables the reasoning->content fallback in the TUI just as it
+// does for `roger use`. Default (env unset) leaves the fallback ON.
+func TestLiveProxyOptsHonorsRawReasoningEnv(t *testing.T) {
+	m := model{broker: "http://b", user: "u", proxyKey: "k"}
+	o := offer{Model: "gpt-oss-120b"}
+	var a alertBox
+
+	t.Run("env set disables the fallback", func(t *testing.T) {
+		t.Setenv("ROGERAI_REASONING_RAW", "1")
+		if !m.liveProxyOpts(o, &a).ReasoningFallbackOff {
+			t.Fatal("ROGERAI_REASONING_RAW=1 did not disable the reasoning fallback in the TUI booth")
+		}
+	})
+
+	t.Run("env unset keeps the fallback on", func(t *testing.T) {
+		t.Setenv("ROGERAI_REASONING_RAW", "")
+		if m.liveProxyOpts(o, &a).ReasoningFallbackOff {
+			t.Fatal("TUI booth disabled the reasoning fallback with the env unset (should default ON)")
+		}
+	})
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3730,8 +3730,11 @@ func (m model) liveProxyOpts(o offer, alert *alertBox) client.ProxyOptions {
 		Broker: m.broker, User: m.user, Model: o.Model, SessionKey: m.proxyKey,
 		Confidential: m.confidentialOnly,
 		MaxPriceIn:   m.q.limit.MaxIn, MaxPriceOut: m.q.limit.MaxOut, MinTPS: m.q.limit.MinTPS,
-		Freq:  m.tuneFreq, // private band tune-in: route via X-Roger-Freq (empty = open market)
-		Alert: func(s string) { alert.set(s) },
+		Freq: m.tuneFreq, // private band tune-in: route via X-Roger-Freq (empty = open market)
+		// ROGERAI_REASONING_RAW is a global session knob: honor it in the TUI booth too, not just
+		// `roger use --raw`, so exporting it disables the reasoning->content fallback everywhere.
+		ReasoningFallbackOff: client.RawReasoningEnv(),
+		Alert:                func(s string) { alert.set(s) },
 	}
 }
 


### PR DESCRIPTION
## Guest Operators follow-ups: 3 non-blocking review findings (BUILD-AND-HOLD)

Fixes three non-blocking findings from the just-merged Guest Operators follow-up PRs (#33, #34). Spec-first where behavior changes; diff kept tight. **Held for founder review - do not merge.**

### Finding 1 (PR #34 review) - the per-session reasoning-fallback disable had no user surface
`ProxyOptions.ReasoningFallbackOff` existed and defaulted OFF (fallback ON) but was set `true` only in tests - the feature file and doc claimed a caller could disable it per session, yet nothing wired it in `roger use`.

**Fix (the honest knob):** wired `roger use --raw` (and the `ROGERAI_REASONING_RAW` env var) through `UseOptions.Raw` -> `ProxyOptions.ReasoningFallbackOff`, on BOTH the open-market and private-band (`--freq`) paths. Absent = fallback ON (the founder default). The proxy handler is now built through a `newProxyHandler` seam (twin of the existing `useServe` seam) so the wiring is observable in a test.

- Tests: `--raw` and `ROGERAI_REASONING_RAW=1` each set `ReasoningFallbackOff`; the default leaves it ON; the `--freq` path honors it too. The fallback-skip behavior itself was already covered.
- Doc: `features/proxy/reasoning_fallback.feature` now names the real surface.

### Finding 2 (PR #33 review, minor #4) - the tool-call canary was fingerprintable
The canary body was deterministic, so a hostile node could return a canned well-formed `tool_calls` and earn the verified `tools` badge without honoring tools.

**Fix:** each probe now mints a fresh `crypto/rand` nonce, woven into the forced tool's name (`roger_probe_ack_<nonce>`) AND the `token` argument the prompt tells the model to echo. `toolCallOK` now requires the response to reference THAT nonce (lenient about WHERE - name or arguments - strict that it is present). The nonce threads `probeToolCall` -> `applyToolVerdict` -> `toolCallOK`. Still single-parameter, unbilled, tiny budget.

- Spec: new scenarios in `features/trust/toolcall_probe.feature` - a canned reply that omits the nonce and a replayed stale-nonce reply both FAIL; a genuine echo passes. The lenient wrong-function scenario now also echoes the nonce.
- Tests: `TestToolCallOKRequiresNonce`, `TestToolCanaryBodyEmbedsNonce`; the live single-instance + cross-bus probe tests echo the request nonce.

### Finding 3 (PR #33 review, minor #2) - the stale-sweep could race `markToolsVerified`
`toolsVerified` computed stale fields from an `HGETALL` snapshot then blind-`HDEL`'d them, so a field re-marked fresh between the read and the delete could be dropped for one sync cycle (a verified-bit flicker).

**Fix:** the sweep now runs an atomic server-side script (`sweepStaleToolsFields`) that re-reads each candidate's CURRENT value and deletes ONLY if still stale/unparseable. A field re-marked within the freshness window survives. Safe-direction: worst case under-claims for one cycle, never drops a fresh bit.

- Test: `TestSweepStaleToolsSparesReMarkedField` (a field re-marked before the sweep survives while a genuinely-stale and an unparseable one are swept); `TestToolsVerifiedSweepStillClearsStale` (the read still ages out stale fields end to end).

### Verification
- `go build ./...`, `go vet ./...` clean.
- `go test ./internal/client ./cmd/rogerai-broker ./internal/tui` (godog strict) pass.
- `go test -race ./internal/client ./cmd/rogerai-broker` pass.
- `make cover-gate` pass.

Each fix is RED->GREEN (new failing test first, then minimum code to pass).

### Pre-push audit follow-ups (2 minor advisories, addressed)
The pre-push claude-audit returned PASS and flagged two non-blocking minors, both now fixed:
- The TUI booth (`liveProxyOpts`) now honors `ROGERAI_REASONING_RAW` via the exported `client.RawReasoningEnv()`, so the documented env toggle is global (not `roger use` only).
- The `roger use --advanced` help line now lists `--raw`.
