### PR TITLE
web: declutter the top nav + pre-cut the App slot (IA reorg)

### DIFF
--- a/web/build.mjs
+++ b/web/build.mjs
@@ -53,6 +53,7 @@ const CSS_BUNDLES = {
   "broadcasts-one-gpu-many-users.html": [...CSS_MARKETING, "broadcasts.css"], // broadcast 005 · SEO field guide (concurrency)
   "broadcasts-free-chatgpt-alternative.html": [...CSS_MARKETING, "broadcasts.css"], // broadcast 006 · SEO field guide (free ChatGPT alt)
   "bands.html":     [...CSS_MARKETING],                  // redirect shell: shared chrome only
+  "app.html":       [...CSS_MARKETING, "notfound.css"],  // "tuning up" placeholder: reuses the centered .lost plate
   "404.html":       [...CSS_MARKETING, "notfound.css"],
   // account (chrome) pages
   "account.html":   [...CSS_ACCOUNT, "account.css"],

--- a/web/src/_partials/footer.html
+++ b/web/src/_partials/footer.html
@@ -10,6 +10,7 @@
         <small class="footer__heading">Product</small>
         <a href="/models.html">Models</a>
         <a href="/voices.html">Voices</a>
+        <a href="/app.html">App</a>
         <a href="{{anchors}}#spec">Spec</a>
         <a href="{{anchors}}#how">Operating</a>
         <a href="{{anchors}}#monetize">Monetize</a>
@@ -19,6 +20,7 @@
         <a href="/login.html">Log in</a>
         <a href="/dashboard.html">Dashboard</a>
         <a href="/console.html">Console</a>
+        <a href="/keys.html">API keys</a>
         <a href="/account.html">Account</a>
       </div>
       <div class="footer__group">

--- a/web/src/_partials/nav.html
+++ b/web/src/_partials/nav.html
@@ -21,26 +21,38 @@
 {{/if}}
     <nav class="nav__menu" id="navMenu" aria-label="Primary">
 {{#if variant=marketing}}
-      <!-- section group: terse single-word manual labels, in document order -->
+      <!-- section group: terse single-word DESTINATION labels. Decluttered - the
+           same-page anchors (Spec #spec / Operating #how / Monetize #monetize) moved
+           OUT of the top bar; they still live in the footer Product group and are
+           reachable by scroll on the homepage, so nothing is lost. App -> the future
+           showcase page (a "tuning up" placeholder until the app ships). -->
       <div class="nav__sections">
         <a class="nav__link" href="/models.html">Models</a>
         <a class="nav__link" href="/voices.html">Voices</a>
-        <a class="nav__link" href="{{anchors}}#spec">Spec</a>
-        <a class="nav__link" href="{{anchors}}#how">Operating</a>
-        <a class="nav__link" href="{{anchors}}#monetize">Monetize</a>
+        <a class="nav__link" href="/app.html">App</a>
       </div>
 
       <span class="nav__divider" aria-hidden="true"></span>
 {{/if}}
-      <!-- utility cluster: manual, account, source, theme - on EVERY page -->
+      <!-- utility cluster: manual, source, account, theme - on EVERY page.
+           Decluttered - "API keys" (a signed-in action) moved OUT of the top bar to
+           the footer Account group; it stays reachable from Log in / the dashboard. -->
       <div class="nav__utils">
         {{#unless variant=marketing}}<a class="nav__link nav__util" href="/models.html">Models</a>{{/unless}}
         {{#unless variant=marketing}}<a class="nav__link nav__util" href="/voices.html">Voices</a>{{/unless}}
         <a class="nav__link nav__util" href="/manual.html">Manual</a>
-        <a class="nav__link nav__util" href="/keys.html">API keys</a>
-        <a class="nav__link nav__util" href="/login.html" data-session-login>Log in</a>
 {{#if variant=marketing}}
         <a class="nav__link nav__util nav__link--ghost" href="https://github.com/rogerai-fyi/roger">Source</a>
+{{/if}}
+        <a class="nav__link nav__util" href="/login.html" data-session-login>Log in</a>
+{{#if variant=marketing}}
+        <!-- RESERVED: App Store badge SLOT (cut, not live). Position is locked here -
+             after Log in, before the theme toggle - so the utility cluster won't
+             reflow when the CTA goes live. We do NOT fabricate an App Store link or
+             badge yet: no listing exists. When the RogerAI iOS app ships, replace
+             this comment with the real "Download on the App Store" badge <a>:
+             <a class="nav__link nav__util nav__appstore" href="APP_STORE_URL"
+                aria-label="Download RogerAI on the App Store"> ...badge... </a> -->
 {{/if}}
         <button class="theme-toggle" id="themeToggle" type="button"
                 aria-label="Switch to dark theme" aria-pressed="false">

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- include: head.html title="App - RogerAI" desc="The band, in your pocket. The RogerAI app is tuning up - tune in, share, and earn from your phone soon. For now, ride the band on the CLI." theme=external css=site robots=noindex -->
+</head>
+<body>
+
+  <!-- running head: this page is one bound document -->
+  <div class="rail" aria-hidden="true">
+    <span class="rail__head">RogerAI · The App</span>
+    <span class="rail__rev"><!-- include: orange3d.html id=rail --> Rev. 2026.06 · ((•))</span>
+  </div>
+
+  <!-- ============================ NAV ============================ -->
+  <!-- include: nav.html variant=marketing home=/ anchors=/ scrolled=1 -->
+
+  <!-- ============================ TUNING UP ============================ -->
+  <!-- reuses the notfound.css .lost plate: a centered, ham-radio-manual message.
+       Not a dropped signal though - Ping is LIVE (base .ping, on-air red eye),
+       because the app is coming, not gone. -->
+  <main id="top">
+  <section class="lost">
+    <div class="wrap lost__inner">
+      <span class="fig" aria-hidden="true">FIG. APP - ON THE AIR SOON</span>
+
+      <!-- Ping in the LIVE pose: on-air red eye, waves standing by (base.css) -->
+      <span class="lost__ping" aria-hidden="true">
+        <svg class="ping" viewBox="0 0 64 72" fill="currentColor" focusable="false"
+             role="img" aria-label="Ping, tuning up">
+          <g class="ping__waves" fill="none" stroke="var(--live)" stroke-linecap="round" stroke-width="2">
+            <path class="ping__wave ping__wave--a" d="M22 12 A11 11 0 0 1 42 12" opacity="0"/>
+            <path class="ping__wave ping__wave--b" d="M16 11 A16 16 0 0 1 48 11" opacity="0"/>
+          </g>
+          <g class="ping__body">
+            <path d="M10 8 h9 v4.5 H14.5 v9 H19 V26 H10 Z"/>
+            <path d="M54 8 h-9 v4.5 H49.5 v9 H45 V26 h9 Z"/>
+            <path d="M22 30 h20 v18 a4 4 0 0 1 -4 4 h-12 a4 4 0 0 1 -4 -4 Z"/>
+            <rect x="25" y="64" width="5" height="5" rx="1"/>
+            <rect x="34" y="64" width="5" height="5" rx="1"/>
+          </g>
+          <circle class="ping__glow" cx="32" cy="18" r="9" fill="var(--live)" opacity="0.3"/>
+          <circle class="ping__eye" cx="32" cy="18" r="5" fill="var(--live)"/>
+        </svg>
+      </span>
+
+      <h1 class="lost__title">
+        <span class="onair" aria-hidden="true">((<span class="onair__dot">•</span>))</span>
+        the band, in your pocket.
+      </h1>
+      <p class="lost__sub">
+        The RogerAI app is <b>tuning up</b>. Tune in, share your rig, and read your
+        receipts from your phone - same band, no desk required. We are warming the
+        transmitter now; this channel goes live when the app ships.
+      </p>
+
+      <p class="lost__path mono" aria-label="Status">
+        <span class="lost__path-label" aria-hidden="true">status</span>
+        <span class="lost__path-code">warming the transmitter · standing by</span>
+      </p>
+
+      <div class="lost__actions">
+        <a class="lost__home" href="/">
+          <span class="onair" aria-hidden="true">((<span class="onair__dot">•</span>))</span>
+          back to the band
+        </a>
+        <a class="lost__alt" href="/manual.html">ride the band on the CLI →</a>
+      </div>
+    </div>
+  </section>
+  </main>
+
+  <!-- ============================ FOOTER ============================ -->
+  <!-- include: footer.html anchors=/ -->
+
+  <script src="js/site.js" defer></script>
+  <script src="js/session.js" defer></script>
+  <script src="js/promo.js" defer></script>
+</body>
+</html>

--- a/web/test/nav.test.mjs
+++ b/web/test/nav.test.mjs
@@ -1,0 +1,120 @@
+// Regression lock for the DECLUTTERED top nav + the pre-cut "App" slot (the IA reorg).
+//
+// The ONE shared nav (_partials/nav.html) renders TWO variants: "marketing" (section
+// links + burger) and "lean" (account pages: brand + theme + account only). The reorg:
+//   - top-bar sections: Models · Voices · App   (the same-page anchors Spec/Operating/
+//     Monetize were REMOVED from the bar; they still live in the footer + scroll)
+//   - utility cluster: "API keys" REMOVED from the bar (it's a signed-in action; it
+//     moved to the footer Account group)
+//   - an App Store CTA SLOT is RESERVED (a comment, cut but not live) after Log in,
+//     before the theme toggle - no listing exists yet, so no badge/link is fabricated
+//   - App -> /app.html, a real "tuning up" placeholder page (so the link 200s, not dead)
+//   - the footer keeps the FULL map: everything pulled from the bar stays reachable there
+//
+// We build the site once (node:fs only, no install) and assert over the RENDERED dist
+// so the gating ({{#if variant}}) is exercised for real, plus a few source-partial facts.
+// Run: node --test test/nav.test.mjs   (picked up by `npm test`).
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const WEB = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SRC = path.join(WEB, "src");
+const DIST = path.join(WEB, "dist");
+const readDist = (p) => readFileSync(path.join(DIST, p), "utf8");
+const readSrc = (p) => readFileSync(path.join(SRC, p), "utf8");
+
+// Build once so the assertions run against the real rendered chrome (both nav variants).
+before(() => execFileSync("node", ["build.mjs"], { cwd: WEB }));
+
+// Slice out just the <header class="nav"> ... </header> block (the top bar) of a page.
+const topbar = (html) => {
+  const m = html.match(/<header class="nav[\s\S]*?<\/header>/);
+  assert.ok(m, "page has a <header class=\"nav\"> block");
+  return m[0];
+};
+// Only LIVE anchors - strip HTML comments first (the reorg leaves explanatory comments
+// that legitimately mention "API keys" / "#spec" as prose, not as live links).
+const liveHrefs = (block) =>
+  [...block.replace(/<!--[\s\S]*?-->/g, "").matchAll(/<a\b[^>]*href="([^"]*)"/g)].map((m) => m[1]);
+
+test("marketing top bar: Models · Voices · App and NOTHING else in the sections group", () => {
+  const bar = topbar(readDist("index.html"));
+  const sections = bar.match(/<div class="nav__sections">[\s\S]*?<\/div>/)[0];
+  const hrefs = liveHrefs(sections);
+  assert.deepEqual(hrefs, ["/models.html", "/voices.html", "/app.html"],
+    "sections are exactly Models, Voices, App - the #spec/#how/#monetize anchors are gone");
+});
+
+test("marketing top bar: the removed items are NOT live links anywhere in the bar", () => {
+  const links = liveHrefs(topbar(readDist("index.html")));
+  for (const gone of ["#spec", "#how", "#monetize", "/keys.html"]) {
+    assert.ok(!links.some((h) => h.includes(gone)), `${gone} is not a live top-bar link`);
+  }
+});
+
+test("marketing top bar: order is Models·Voices·App | Manual·Source·Log in (then the reserved slot + toggle)", () => {
+  const links = liveHrefs(topbar(readDist("index.html")));
+  assert.deepEqual(links, [
+    "#top",                                   // brand
+    "/models.html", "/voices.html", "/app.html",
+    "/manual.html",
+    "https://github.com/rogerai-fyi/roger",   // Source (ghost)
+    "/login.html",
+  ], "the decluttered marketing bar renders the exact target link set, in order");
+});
+
+test("App Store CTA slot is RESERVED (a comment), not a fabricated live link/badge", () => {
+  const bar = topbar(readDist("index.html"));
+  assert.match(bar, /RESERVED: App Store badge SLOT/, "the reserved-slot comment marks the position");
+  // no live App Store anchor yet (no listing exists) - the slot lives only inside a comment.
+  const links = liveHrefs(bar);
+  assert.ok(!links.some((h) => /app.?store|apps\.apple\.com|itunes\.apple\.com/i.test(h)),
+    "no App Store link is fabricated");
+  assert.doesNotMatch(bar.replace(/<!--[\s\S]*?-->/g, ""), /nav__appstore/,
+    "no live nav__appstore element outside the comment");
+});
+
+test("lean nav (account pages): brand + Models/Voices/Manual/Log in + toggle, no marketing extras", () => {
+  const bar = topbar(readDist("dashboard.html"));
+  const links = liveHrefs(bar);
+  assert.deepEqual(links, [
+    "/",                                      // brand -> home
+    "/models.html", "/voices.html", "/manual.html", "/login.html",
+  ], "the lean variant stays minimal - no App/Source/anchors/API-keys in the bar");
+});
+
+test("footer keeps the FULL map: everything pulled from the bar is still reachable there", () => {
+  const links = liveHrefs(readDist("index.html").match(/<footer[\s\S]*?<\/nav>/)[0]);
+  for (const must of [
+    "/app.html",        // the new destination
+    "#spec", "#how", "#monetize",  // the anchors removed from the bar (same-page on the homepage)
+    "/keys.html",       // API keys, removed from the bar -> Account group
+  ]) {
+    assert.ok(links.includes(must), `footer carries ${must} so the decluttered bar loses nothing`);
+  }
+});
+
+test("the App link resolves: /app.html is a real placeholder page, not a dead link", () => {
+  assert.ok(existsSync(path.join(DIST, "app.html")), "app.html builds to dist (the link 200s)");
+  const app = readDist("app.html");
+  assert.match(app, /the band, in your pocket/, "on-theme radio 'tuning up' copy");
+  assert.match(app, /name="robots" content="noindex"/, "the placeholder is noindex (not in sitemap yet)");
+  assert.doesNotMatch(app, /<!--\s*include:|<!--\s*css-bundle\s*-->/, "all partial/css includes resolved");
+});
+
+test("homepage anchors survive: the sections the bar used to jump to still exist", () => {
+  const home = readDist("index.html");
+  for (const id of ["spec", "how", "monetize"]) {
+    assert.match(home, new RegExp(`id="${id}"`), `#${id} section still on the homepage (reachable by footer/scroll)`);
+  }
+});
+
+test("source partial: no stray {{APP_STORE_URL}} marker (would ship literally)", () => {
+  // build.mjs resolves unknown {{name}} to "" - the reserved-slot example URL must be a
+  // plain token, not a {{...}} marker that would silently blank inside the shipped comment.
+  assert.doesNotMatch(readSrc("_partials/nav.html"), /\{\{\s*APP_STORE_URL\s*\}\}/);
+});


### PR DESCRIPTION
**BUILD-AND-HOLD** - do not merge. Web-only, no backend. Per the approved website IA plan.

## What & why
Lighten the marketing top bar (it carried ~9 links) and reserve the App Store CTA position, without fabricating a link for a listing that does not exist yet.

## Top bar: before -> after
**Before (marketing):** Models · Voices · Spec (#spec) · Operating (#how) · Monetize (#monetize) | Manual · API keys · Log in · Source · toggle

**After (marketing):** Models · Voices · **App** | Manual · Source · Log in · **[App Store slot reserved]** · toggle

Removed from the bar (all still reachable):
- `Spec` (#spec), `Operating` (#how), `Monetize` (#monetize) - same-page anchors; still in the footer Product group and reachable by scroll on the homepage.
- `API keys` (/keys.html) - a signed-in action; moved to the footer Account group, still reachable from Log in / the dashboard.

Added:
- `App` -> `/app.html` (a real placeholder, not a dead link).

## Reserved App Store slot
A comment in the utility cluster, locked **after Log in, before the theme toggle**, so the cluster will not reflow when the badge goes live. No App Store link/badge is fabricated (no listing exists). A test asserts the slot is present as a comment and that no live App Store anchor ships.

## Placeholder page: `web/src/app.html`
Tiny, on-theme "tuning up" plate - reuses `notfound.css`'s centered `.lost` layout + the live Ping, house radio voice ("the band, in your pocket... the RogerAI app is tuning up"). `robots=noindex` (kept out of the sitemap). Registered in `build.mjs` CSS_BUNDLES.

## Footer (full map kept)
Added `App` to Product and `API keys` to Account, so nothing pulled from the bar is lost. The footer ships on every page (marketing + lean/account).

## Verification
- `node build.mjs` OK - 28 pages incl. app.html, no unresolved includes, app.html correctly absent from the 11-url sitemap (noindex).
- Nav renders right on a marketing page (index) and a lean/account page (dashboard).
- No dead links: App -> /app.html 200s; the 3 anchors + API keys are gone from the top-bar marketing variant but present in the footer (grep-confirmed).
- Homepage anchor sections `#spec/#how/#monetize` still exist (reachable by footer/scroll).
- New `web/test/nav.test.mjs` (9 cases) locks both nav variants, the reserved slot, the footer full-map reachability, and the live App placeholder. Full web suite: **74/74 pass**.
- Pre-push gate (fast path + claude-audit): **PASS** (high confidence). One non-blocking minor: the noindex placeholder also emits a self-canonical - pre-existing behavior shared with 404.html, harmless for a placeholder.