### PR TITLE
operator: AGENT view UX refinements - first-time DESK focus, DJ art on landing, /operator in footer

### DIFF
--- a/features/operator/desk_entry.feature
+++ b/features/operator/desk_entry.feature
@@ -36,11 +36,63 @@ Feature: THE DESK takes focus on the AGENT [0] landing
     Then THE DESK does not have focus
     And the ask box has focus
 
-  Scenario: A tuned-in session (a live holder) never steals focus to the desk
+  # A live proxy holder with NO resolved model (a disconnected / oddly-seeded re-entry) is
+  # NOT a fresh landing and NOT a tuned band: keep the ask box focused, never steal to the
+  # desk. Only a genuinely-resolved model surfaces the desk (the once-per-model path below).
+  Scenario: A live holder with no resolved model keeps the ask box focused
     Given an AGENT session at the ask prompt
     When the desk scan lands guest "opencode"
     Then THE DESK does not have focus
     And the ask box has focus
+
+  # ── first-time-per-model desk focus: a tuned band surfaces the desk ONCE ──────
+  #
+  # Founder ruling: when a band IS tuned (resolveAgentModel non-empty), the FIRST AGENT
+  # entry for that model this session surfaces the focused desk (cursor on the DJ row) once
+  # a guest is detected; a SECOND entry for the same model stays ask-focused. Switching to a
+  # DIFFERENT model re-surfaces the desk once for it (operatorSeenModels, per session).
+
+  Scenario: A first entry for a tuned model surfaces the focused desk and marks it seen
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    When the desk scan lands guest "opencode"
+    Then THE DESK has focus
+    And the ask box is not focused
+    And the desk cursor is on the DJ row
+    And the model "gpt-oss-20b" is marked surfaced this session
+
+  Scenario: A second entry for the same model stays ask-focused (surfaced once per model)
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    And the model "gpt-oss-20b" has already surfaced the desk this session
+    When the desk scan lands guest "opencode"
+    Then THE DESK does not have focus
+    And the ask box has focus
+
+  Scenario: A different model re-surfaces the desk once, even after another model was seen
+    Given an AGENT session whose last band "llama-3.3-70b-instruct" is still on air
+    And the model "gpt-oss-20b" has already surfaced the desk this session
+    When the desk scan lands guest "opencode"
+    Then THE DESK has focus
+    And the desk cursor is on the DJ row
+
+  Scenario: Type-through de-focuses a tuned-model focused desk and lands the char in ask
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    And the desk scan lands guest "opencode"
+    When the user types "h"
+    Then THE DESK does not have focus
+    And the ask box has focus
+    And the ask box echoes "h"
+
+  Scenario: A tuned first-entry with NO guests keeps the ask box focused (zero-guest invariant)
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    When the desk scan lands no guests
+    Then THE DESK does not have focus
+    And the ask box has focus
+
+  Scenario: The focused desk shows the choose-an-operator hint
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    When the desk scan lands guest "opencode"
+    Then THE DESK has focus
+    And the AGENT view shows "type to just ask"
 
   # ── arrows move the desk cursor ──────────────────────────────────────────────
 

--- a/features/operator/desk_view.feature
+++ b/features/operator/desk_view.feature
@@ -111,6 +111,15 @@ Feature: THE DESK roster on the AGENT landing
     Then no roster row carries a carat
     And no roster row is rendered reverse-video
 
+  # Refinement 2 (amends §6 "static preview, no marquee"): the resident DJ's house plate
+  # (mono+red djBrandArt) anchors the roster even when the desk is NOT focused; the guest
+  # plates still render on focus/selection only (ONE HUE, ONE BEAT preserved).
+  Scenario: The static preview shows the resident DJ house plate (band tuned, desk not focused)
+    Given an AGENT session with a tuned band "qwen3-32b-fp8" and a live proxy holder
+    And detected guests "opencode"
+    Then the AGENT landing renders THE DESK roster
+    And the static preview shows the resident DJ house plate
+
   Scenario: Arrow keys at the prompt never move a roster cursor
     Given detected guests "opencode" and "aider"
     When the user presses "down"
@@ -175,3 +184,17 @@ Feature: THE DESK roster on the AGENT landing
     And color is disabled
     Then the roster renders without ANSI color
     And the DJ row still carries the ◉ mark as a plain rune
+
+  # ── /operator discoverability: footer + in-body idle help ────────────────────
+  #
+  # Refinement 3: /operator is advertised in the AGENT footer (dropping /persona to hold
+  # the ~88-col width - /persona stays in /help + Tab-complete) and in the in-body idle
+  # help. Copy standardizes on "/operator hands the mic".
+
+  Scenario: The AGENT footer advertises /operator and drops /persona
+    Then the AGENT footer shows "/operator"
+    And the AGENT footer does not show "/persona"
+
+  Scenario: The in-body idle help names /operator hands the mic next to /model switches
+    Then the in-body idle help shows "/model switches"
+    And the in-body idle help shows "/operator hands the mic"

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -1437,7 +1437,7 @@ func (m model) agentView(w int) string {
 	if !m.compact {
 		// Busy-aware help: while a turn streams, the one thing the user needs is how to
 		// STOP it (esc), so lead with that instead of the idle command list.
-		help := "enter asks  ·  /model switches  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  read/list auto · write/run confirm"
+		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  read/list auto · write/run confirm"
 		switch {
 		case m.agentBusy && m.narrow():
 			help = "type queues · esc cancels (2× force)"

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -184,9 +184,23 @@ func (m model) onOperatorDetected(msg operatorDetectedMsg) (tea.Model, tea.Cmd) 
 		m.deskFocused = true
 		m.deskCursor = 0
 		m.agentIn.Blur()
+		// Surface the desk ONCE PER MODEL PER SESSION: mark the tuned model seen so a second
+		// AGENT entry for it stays ask-focused (a fresh landing has no model yet - nothing to
+		// mark; the auto-tune that follows keeps its focus without re-marking).
+		if mdl := m.resolveAgentModel(); mdl != "" {
+			if m.operatorSeenModels == nil {
+				m.operatorSeenModels = map[string]bool{}
+			}
+			m.operatorSeenModels[mdl] = true
+		}
+		m.status = stDim.Render(deskFocusHint)
 	}
 	return m, nil
 }
+
+// deskFocusHint is the one-line status shown while THE DESK holds focus: how to pick an
+// operator, keep the DJ, or just start asking. Mirrors the /operator picker footer voice.
+const deskFocusHint = "↑↓ choose an operator · ⏎ DJ keeps the mic · type to just ask · esc exits"
 
 // deskEntryEligible reports whether the AGENT is on the FRESH landing where THE DESK may
 // take focus: AGENT mode, no channel/model, the ask box empty (nothing typed), the
@@ -195,8 +209,17 @@ func (m model) deskEntryEligible() bool {
 	if m.mode != modeAgent || m.deskFocused {
 		return false
 	}
-	if m.proxyHolder != nil || m.connected != nil || m.resolveAgentModel() != "" {
-		return false // a channel is (or was) up - not a fresh landing
+	// A band that IS (or was) tuned surfaces THE DESK once per model per session: the first
+	// AGENT entry for a resolved model lands on the selectable desk; a second entry for the
+	// SAME model stays ask-focused (operatorSeenModels). A live holder with NO resolved model
+	// (a disconnected / oddly-seeded re-entry) is neither a fresh landing nor a tuned band -
+	// keep the ask focused. A genuinely-fresh landing (no holder, no model) stays eligible.
+	if mdl := m.resolveAgentModel(); mdl != "" {
+		if m.operatorSeenModels[mdl] {
+			return false // this model already surfaced the desk this session
+		}
+	} else if m.proxyHolder != nil {
+		return false // a holder with no resolved model - not a fresh landing
 	}
 	if strings.TrimSpace(m.agentIn.Value()) != "" || m.agentBusy || (m.agent != nil && m.agent.running.Load()) {
 		return false
@@ -1226,11 +1249,15 @@ func (m model) deskRosterView(w, cursor int, focused bool) string {
 	}
 	var b strings.Builder
 	b.WriteString("\n" + truncVisible("  "+stSelBar.Render("▌")+" "+stBrand.Render("THE DESK")+"    "+stDim.Render(sub), w) + "\n")
-	// R2: the selected operator's plate as a marquee, in its ONE canonical hue. Focused
-	// only - the static preview stays byte-identical (no marquee, no carat).
-	if focused {
-		b.WriteString(m.deskMarquee(w, cursor))
+	// The operator's plate as a marquee, in its ONE canonical hue. Focused: the cursor drives
+	// which operator's plate shows. NOT focused (refinement 2, amends R2 / §6): the static
+	// preview anchors on the resident DJ's house plate (cursor 0 = djBrandArt) - guest plates
+	// still surface on focus/selection ONLY (ONE HUE, ONE BEAT preserved).
+	cur := cursor
+	if !focused {
+		cur = 0
 	}
+	b.WriteString(m.deskMarquee(w, cur))
 	b.WriteString(truncVisible("    "+stDim.Render(pad("operator", 13)+pad("wire", 11)+"status"), w) + "\n")
 	// The resident DJ row is always first (index 0), with the red on-air mark.
 	b.WriteString(truncVisible(deskGutter(focused && cursor == 0)+stRed.Render(glyphOnAir)+" "+stKey.Render(pad("DJ", 12))+" "+stDim.Render(pad("in the TUI", 10)+" resident · dj.md persona · read/list auto, write/run confirm"), w) + "\n")

--- a/internal/tui/operator_steps_desk_entry_test.go
+++ b/internal/tui/operator_steps_desk_entry_test.go
@@ -375,8 +375,33 @@ func (s *opBDD) pickAutoBandPicksNothing(login string) error {
 	return nil
 }
 
+// deskSurfacedForModel marks a model as already having surfaced the focused desk this
+// session (operatorSeenModels), so a re-entry for it stays ask-focused - the once-per-model
+// ruling. Seeded directly to pin the state without an esc/re-enter round-trip.
+func (s *opBDD) deskSurfacedForModel(mdl string) error {
+	s.mutate(func(m *model) {
+		if m.operatorSeenModels == nil {
+			m.operatorSeenModels = map[string]bool{}
+		}
+		m.operatorSeenModels[mdl] = true
+	})
+	return nil
+}
+
+// modelMarkedSurfaced asserts the model is now recorded in operatorSeenModels - the FIRST
+// entry that surfaced the desk must mark it, so a second entry for it stays ask-focused.
+func (s *opBDD) modelMarkedSurfaced(mdl string) error {
+	if !s.model().operatorSeenModels[mdl] {
+		return fmt.Errorf("model %q is not marked surfaced this session (operatorSeenModels=%v)", mdl, s.model().operatorSeenModels)
+	}
+	return nil
+}
+
 // initializeDeskEntryScenarios registers the desk_entry + auto_tune step definitions.
 func initializeDeskEntryScenarios(st *opBDD, sc *godog.ScenarioContext) {
+	sc.Step(`^the model "([^"]*)" has already surfaced the desk this session$`, st.deskSurfacedForModel)
+	sc.Step(`^the model "([^"]*)" is marked surfaced this session$`, st.modelMarkedSurfaced)
+	sc.Step(`^the AGENT view shows "([^"]*)"$`, st.transcriptShows)
 	sc.Step(`^a fresh AGENT session with nothing tuned in$`, st.freshNothingTuned)
 	sc.Step(`^a fresh AGENT session with a free band "([^"]*)" on air$`, st.freshFreeBand)
 	sc.Step(`^a fresh AGENT session with only a paid band on air$`, st.freshPaidOnly)

--- a/internal/tui/operator_steps_phase3_test.go
+++ b/internal/tui/operator_steps_phase3_test.go
@@ -302,12 +302,21 @@ func (s *opBDD) landingRendersNoDeskChrome() error {
 
 func (s *opBDD) firstRosterRowIsDJ() error {
 	lines := s.rosterLines()
-	if len(lines) < 3 {
-		return fmt.Errorf("roster too short:\n%s", s.roster())
+	// The column header ("operator … wire … status") precedes the operator rows; the DJ
+	// row is the first row after it. Located by content (not a fixed index) so the resident
+	// DJ house plate now sitting above the header (refinement 2) does not throw the count.
+	hdr := -1
+	for i, ln := range lines {
+		if strings.Contains(ln, "operator") && strings.Contains(ln, "wire") && strings.Contains(ln, "status") {
+			hdr = i
+			break
+		}
 	}
-	// lines[0] heading, lines[1] column header, lines[2] the first row.
-	if !strings.Contains(lines[2], "DJ") || !strings.Contains(lines[2], "resident") {
-		return fmt.Errorf("the first roster row is not the DJ row: %q", lines[2])
+	if hdr < 0 || hdr+1 >= len(lines) {
+		return fmt.Errorf("no column header / first row in roster:\n%s", s.roster())
+	}
+	if !strings.Contains(lines[hdr+1], "DJ") || !strings.Contains(lines[hdr+1], "resident") {
+		return fmt.Errorf("the first roster row is not the DJ row: %q", lines[hdr+1])
 	}
 	return nil
 }
@@ -318,8 +327,10 @@ func (s *opBDD) djRowCarriesRedMark() error {
 		block = s.rosterRaw()
 		token = stRed.Render(glyphOnAir)
 	})
+	// Match the DJ ROW specifically ("dj.md persona" is row-only text); the DJ house plate
+	// above also carries the word "resident" but is a dim lockup, not the on-air row.
 	for _, ln := range strings.Split(block, "\n") {
-		if strings.Contains(stripANSI(ln), "resident") {
+		if strings.Contains(stripANSI(ln), "dj.md persona") {
 			if !strings.Contains(ln, token) {
 				return fmt.Errorf("the DJ row does not carry the red %s mark: %q", glyphOnAir, ln)
 			}
@@ -492,6 +503,44 @@ func (s *opBDD) djRowPlainMark() error {
 	}
 	if !strings.Contains(row, glyphOnAir) {
 		return fmt.Errorf("the DJ row lost the %s mark under NO_COLOR: %q", glyphOnAir, row)
+	}
+	return nil
+}
+
+// staticPreviewShowsDJPlate pins refinement 2: the resident DJ's house plate anchors the
+// roster on the UNFOCUSED static preview ("the house agent" is plate-only text - the DJ
+// ROW says "dj.md persona", the plate says "the house agent").
+func (s *opBDD) staticPreviewShowsDJPlate() error {
+	m := s.model()
+	if m.deskFocused {
+		return fmt.Errorf("the desk is focused - this scenario pins the STATIC (unfocused) preview")
+	}
+	if !strings.Contains(s.roster(), "the house agent") {
+		return fmt.Errorf("the static preview does not render the resident DJ house plate:\n%s", s.roster())
+	}
+	return nil
+}
+
+// agentFooterShows / agentFooterOmits pin refinement 3's footer copy. s.view() is the full
+// rendered screen including the modal footer / status line.
+func (s *opBDD) agentFooterShows(text string) error {
+	if !strings.Contains(s.view(), text) {
+		return fmt.Errorf("the AGENT footer lacks %q:\n%s", text, s.view())
+	}
+	return nil
+}
+func (s *opBDD) agentFooterOmits(text string) error {
+	if strings.Contains(s.view(), text) {
+		return fmt.Errorf("the AGENT footer unexpectedly shows %q:\n%s", text, s.view())
+	}
+	return nil
+}
+
+// agentIdleHelpShows pins the in-body idle help copy (the one-line command hint under the
+// ask prompt, in agentView).
+func (s *opBDD) agentIdleHelpShows(text string) error {
+	if !strings.Contains(s.agentViewText(), text) {
+		return fmt.Errorf("the in-body idle help lacks %q:\n%s", text, s.agentViewText())
 	}
 	return nil
 }
@@ -1193,6 +1242,10 @@ func initializePhase3Steps(st *opBDD, sc *godog.ScenarioContext) {
 	sc.Step(`^the ask prompt still has focus$`, st.askPromptHasFocus)
 	sc.Step(`^the ask prompt echoes "([^"]*)"$`, st.askPromptEchoes)
 	sc.Step(`^the AGENT landing renders THE DESK roster$`, st.landingRendersRoster)
+	sc.Step(`^the static preview shows the resident DJ house plate$`, st.staticPreviewShowsDJPlate)
+	sc.Step(`^the AGENT footer shows "([^"]*)"$`, st.agentFooterShows)
+	sc.Step(`^the AGENT footer does not show "([^"]*)"$`, st.agentFooterOmits)
+	sc.Step(`^the in-body idle help shows "([^"]*)"$`, st.agentIdleHelpShows)
 	sc.Step(`^the roster heading reads "([^"]*)"$`, st.rosterHeadingReads)
 	sc.Step(`^the roster heading subtitle reads "([^"]*)"$`, st.rosterSubtitleReads)
 	sc.Step(`^the roster heading subtitle does not name a model$`, st.rosterSubtitleNamesNoModel)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -694,6 +694,12 @@ type model struct {
 	// (cold) tune-in to a band; a band in this set drops straight into the open channel
 	// (warm reconnect). Cleared by nothing this session (a band stays "warm" once tuned).
 	recentBands map[string]bool
+	// operatorSeenModels records every model that has ALREADY surfaced the focused AGENT
+	// DESK this session (Guest Operators): the first AGENT entry for a tuned model lands on
+	// the selectable desk once a guest is detected; a second entry for the SAME model stays
+	// ask-focused. Switching to a different model re-surfaces the desk once for it. Lazily
+	// initialized; per-session (never cleared - an esc-exit keeps the record).
+	operatorSeenModels map[string]bool
 	// staged tune-in sequence (modeConnecting): connectStage is the step the
 	// animation has reached (0..connectStageDone); connectStartFrame anchors the
 	// per-step dwell to m.frame so the steps advance on the one carrier beat. Under
@@ -8319,7 +8325,7 @@ func (m model) footer(w int) string {
 				left = stDim.Render("y run · n/esc deny")
 			}
 		default:
-			left = stDim.Render("type to ask  ·  /model  ·  /clear  ·  /persona  ·  esc exits AGENT")
+			left = stDim.Render("type to ask  ·  /model  ·  /operator  ·  /clear  ·  esc exits AGENT")
 			if m.narrow() {
 				left = stDim.Render("ask · /model · esc exit")
 			}


### PR DESCRIPTION
Three founder-approved UX refinements to the AGENT [0] view (from live-test feedback), mostly reusing the existing focused-desk machinery.

1. FIRST-TIME-PER-MODEL DESK FOCUS - the first time you enter AGENT for a given model each session (and guests are detected), THE DESK takes focus with the cursor on the DJ row. Type anything to just chat the DJ (no char lost), Enter-on-DJ goes to ask, esc exits. Second entry for that model stays ask-focused; switching bands re-surfaces once. Never steals focus when no guests. (operatorSeenModels session map + deskEntryEligible generalization.)
2. DJ ART ON THE STATIC LANDING - the resident DJ's house plate (mono+red) now renders above the roster even when the desk is not focused; guest plates still appear on focus/selection (one-hue-one-beat preserved).
3. /operator IN THE FOOTER + IN-BODY HELP - added next to /model (dropped /persona from the footer to hold width; it stays in /help + Tab-complete). Copy standardized on "/operator hands the mic".

Rulings applied: once-per-model-per-session; cursor on DJ. Doc amendment pushed to rogerai-internal-docs (GUEST-OPERATOR-PLATES.md S6 + GUEST-OPERATORS.md S3: static preview shows the DJ house plate).

Verified: 312 operator scenarios green (godog strict), cover-gate PASS (>=90% every pkg, total 92.3%), -race ./internal/tui clean, push-gate PASS. (manual.html shows in the branch diff only because the branch is behind #42; the branch does not modify it - main's shortened changelog is preserved on merge.)