### PR TITLE
web/nav: fix the APP_STORE_URL placeholder flagged by the smoke link-crawler

### DIFF
--- a/web/src/_partials/nav.html
+++ b/web/src/_partials/nav.html
@@ -49,10 +49,9 @@
         <!-- RESERVED: App Store badge SLOT (cut, not live). Position is locked here -
              after Log in, before the theme toggle - so the utility cluster won't
              reflow when the CTA goes live. We do NOT fabricate an App Store link or
-             badge yet: no listing exists. When the RogerAI iOS app ships, replace
-             this comment with the real "Download on the App Store" badge <a>:
-             <a class="nav__link nav__util nav__appstore" href="APP_STORE_URL"
-                aria-label="Download RogerAI on the App Store"> ...badge... </a> -->
+             badge yet: no listing exists. When the RogerAI iOS app ships, add the
+             real "Download on the App Store" badge anchor here (classes
+             nav__link nav__util nav__appstore, pointing at the App Store listing). -->
 {{/if}}
         <button class="theme-toggle" id="themeToggle" type="button"
                 aria-label="Switch to dark theme" aria-pressed="false">


### PR DESCRIPTION
The reserved App Store slot comment (PR #40) contained a literal href="APP_STORE_URL" example; the smoke link-crawler scans raw HTML and flagged it as a broken internal link on all 13 marketing-nav pages (browsers ignore it since it is commented, so no user-facing breakage, but it fails the gate). Rewrote the reserved-slot comment to describe the future badge without a literal href. Verified: node web/build.mjs -> 0 APP_STORE_URL hrefs in dist; go test ./test/smoke passes.