### PR TITLE
agent[0]: 3 desk UX refinements (first-time-per-model focus, static DJ plate, /operator discoverability)

### DIFF
--- a/features/operator/desk_entry.feature
+++ b/features/operator/desk_entry.feature
@@ -36,11 +36,72 @@ Feature: THE DESK takes focus on the AGENT [0] landing
     Then THE DESK does not have focus
     And the ask box has focus
 
-  Scenario: A tuned-in session (a live holder) never steals focus to the desk
+  # A live proxy holder with NO resolved model (a disconnected / oddly-seeded re-entry) is
+  # NOT a fresh landing and NOT a tuned band: keep the ask box focused, never steal to the
+  # desk. Only a genuinely-resolved model surfaces the desk (the once-per-model path below).
+  Scenario: A live holder with no resolved model keeps the ask box focused
     Given an AGENT session at the ask prompt
     When the desk scan lands guest "opencode"
     Then THE DESK does not have focus
     And the ask box has focus
+
+  # ── first-time-per-model desk focus: a tuned band surfaces the desk ONCE ──────
+  #
+  # Founder ruling: when a band IS tuned (resolveAgentModel non-empty), the FIRST AGENT
+  # entry for that model this session surfaces the focused desk (cursor on the DJ row) once
+  # a guest is detected; a SECOND entry for the same model stays ask-focused. Switching to a
+  # DIFFERENT model re-surfaces the desk once for it (operatorSeenModels, per session).
+
+  Scenario: A first entry for a tuned model surfaces the focused desk and marks it seen
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    When the desk scan lands guest "opencode"
+    Then THE DESK has focus
+    And the ask box is not focused
+    And the desk cursor is on the DJ row
+    And the model "gpt-oss-20b" is marked surfaced this session
+
+  Scenario: A second entry for the same model stays ask-focused (surfaced once per model)
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    And the model "gpt-oss-20b" has already surfaced the desk this session
+    When the desk scan lands guest "opencode"
+    Then THE DESK does not have focus
+    And the ask box has focus
+
+  Scenario: A different model re-surfaces the desk once, even after another model was seen
+    Given an AGENT session whose last band "llama-3.3-70b-instruct" is still on air
+    And the model "gpt-oss-20b" has already surfaced the desk this session
+    When the desk scan lands guest "opencode"
+    Then THE DESK has focus
+    And the desk cursor is on the DJ row
+
+  Scenario: Type-through de-focuses a tuned-model focused desk and lands the char in ask
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    And the desk scan lands guest "opencode"
+    When the user types "h"
+    Then THE DESK does not have focus
+    And the ask box has focus
+    And the ask box echoes "h"
+
+  # Regression (audit 2026-07-08): the focused-desk hint used to linger on the status line
+  # after a type-through defocus, advertising arrow-selection that no longer applied.
+  Scenario: Typing through clears the focused-desk hint (no stale arrow-selection advice)
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    And the desk scan lands guest "opencode"
+    When the user types "h"
+    Then the AGENT view shows "the DJ has the mic"
+    And the AGENT view does not show "choose an operator"
+
+  Scenario: A tuned first-entry with NO guests keeps the ask box focused (zero-guest invariant)
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    When the desk scan lands no guests
+    Then THE DESK does not have focus
+    And the ask box has focus
+
+  Scenario: The focused desk shows the choose-an-operator hint
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    When the desk scan lands guest "opencode"
+    Then THE DESK has focus
+    And the AGENT view shows "type to just ask"
 
   # ── arrows move the desk cursor ──────────────────────────────────────────────
 

--- a/features/operator/desk_view.feature
+++ b/features/operator/desk_view.feature
@@ -111,6 +111,15 @@ Feature: THE DESK roster on the AGENT landing
     Then no roster row carries a carat
     And no roster row is rendered reverse-video
 
+  # Refinement 2 (amends §6 "static preview, no marquee"): the resident DJ's house plate
+  # (mono+red djBrandArt) anchors the roster even when the desk is NOT focused; the guest
+  # plates still render on focus/selection only (ONE HUE, ONE BEAT preserved).
+  Scenario: The static preview shows the resident DJ house plate (band tuned, desk not focused)
+    Given an AGENT session with a tuned band "qwen3-32b-fp8" and a live proxy holder
+    And detected guests "opencode"
+    Then the AGENT landing renders THE DESK roster
+    And the static preview shows the resident DJ house plate
+
   Scenario: Arrow keys at the prompt never move a roster cursor
     Given detected guests "opencode" and "aider"
     When the user presses "down"
@@ -175,3 +184,17 @@ Feature: THE DESK roster on the AGENT landing
     And color is disabled
     Then the roster renders without ANSI color
     And the DJ row still carries the ◉ mark as a plain rune
+
+  # ── /operator discoverability: footer + in-body idle help ────────────────────
+  #
+  # Refinement 3: /operator is advertised in the AGENT footer (dropping /persona to hold
+  # the ~88-col width - /persona stays in /help + Tab-complete) and in the in-body idle
+  # help. Copy standardizes on "/operator hands the mic".
+
+  Scenario: The AGENT footer advertises /operator and drops /persona
+    Then the AGENT footer shows "/operator"
+    And the AGENT footer does not show "/persona"
+
+  Scenario: The in-body idle help names /operator hands the mic next to /model switches
+    Then the in-body idle help shows "/model switches"
+    And the in-body idle help shows "/operator hands the mic"

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -480,7 +480,7 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 				// The resident DJ: hand focus to the ask box.
 				m.deskFocused = false
 				m.agentIn.Focus()
-				m.status = stDim.Render("the DJ has the mic · type to ask · esc exits")
+				m.status = stDim.Render(djHasMicStatus)
 				return m, textinput.Blink
 			}
 			ds := deskGuests(m.operatorDetections)
@@ -492,9 +492,11 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if isPrintableKey(k) {
 			// Type-through: the DJ is implied. De-focus the desk and let the rune land in
-			// the ask box via the text-entry Update below.
+			// the ask box via the text-entry Update below. Clear the focused-desk hint so the
+			// status line stops advertising arrow-selection (mirrors the enter-on-DJ path).
 			m.deskFocused = false
 			m.agentIn.Focus()
+			m.status = stDim.Render(djHasMicStatus)
 		}
 	}
 	// Text-entry mode: enter submits (or QUEUES while a turn runs - see the enter case),
@@ -1437,7 +1439,11 @@ func (m model) agentView(w int) string {
 	if !m.compact {
 		// Busy-aware help: while a turn streams, the one thing the user needs is how to
 		// STOP it (esc), so lead with that instead of the idle command list.
-		help := "enter asks  ·  /model switches  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  read/list auto · write/run confirm"
+		// Width-budgeted like the footer (refinement 3): keep the line under the canonical
+		// ~120 cols so truncVisible never clips the read/list·write/run safety posture. /clear
+		// and esc live in the footer, so the idle line drops them to make room for /operator
+		// while keeping ⌃y copy (founder: copy stays discoverable here) and the posture tail.
+		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  ⌃y copy  ·  read/list auto · write/run confirm"
 		switch {
 		case m.agentBusy && m.narrow():
 			help = "type queues · esc cancels (2× force)"

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -160,6 +160,7 @@ func (m model) onOperatorDetected(msg operatorDetectedMsg) (tea.Model, tea.Cmd) 
 			m.deskFocused = false
 			m.deskCursor = 0
 			m.agentIn.Focus()
+			m.status = stDim.Render(djHasMicStatus) // drop the now-stale focused-desk hint
 		} else {
 			if max := m.deskRowCount() - 1; m.deskCursor > max {
 				m.deskCursor = max
@@ -184,9 +185,28 @@ func (m model) onOperatorDetected(msg operatorDetectedMsg) (tea.Model, tea.Cmd) 
 		m.deskFocused = true
 		m.deskCursor = 0
 		m.agentIn.Blur()
+		// Surface the desk ONCE PER MODEL PER SESSION: mark the tuned model seen so a second
+		// AGENT entry for it stays ask-focused (a fresh landing has no model yet - nothing to
+		// mark; the auto-tune that follows keeps its focus without re-marking).
+		if mdl := m.resolveAgentModel(); mdl != "" {
+			if m.operatorSeenModels == nil {
+				m.operatorSeenModels = map[string]bool{}
+			}
+			m.operatorSeenModels[mdl] = true
+		}
+		m.status = stDim.Render(deskFocusHint)
 	}
 	return m, nil
 }
+
+// deskFocusHint is the one-line status shown while THE DESK holds focus: how to pick an
+// operator, keep the DJ, or just start asking. Mirrors the /operator picker footer voice.
+const deskFocusHint = "↑↓ choose an operator · ⏎ DJ keeps the mic · type to just ask · esc exits"
+
+// djHasMicStatus replaces deskFocusHint the moment the desk hands focus back to the ask box
+// (enter-on-DJ, type-through, or a guest set that empties under focus) so the status line
+// never keeps advertising arrow-selection that no longer applies.
+const djHasMicStatus = "the DJ has the mic · type to ask · esc exits"
 
 // deskEntryEligible reports whether the AGENT is on the FRESH landing where THE DESK may
 // take focus: AGENT mode, no channel/model, the ask box empty (nothing typed), the
@@ -195,8 +215,17 @@ func (m model) deskEntryEligible() bool {
 	if m.mode != modeAgent || m.deskFocused {
 		return false
 	}
-	if m.proxyHolder != nil || m.connected != nil || m.resolveAgentModel() != "" {
-		return false // a channel is (or was) up - not a fresh landing
+	// A band that IS (or was) tuned surfaces THE DESK once per model per session: the first
+	// AGENT entry for a resolved model lands on the selectable desk; a second entry for the
+	// SAME model stays ask-focused (operatorSeenModels). A live holder with NO resolved model
+	// (a disconnected / oddly-seeded re-entry) is neither a fresh landing nor a tuned band -
+	// keep the ask focused. A genuinely-fresh landing (no holder, no model) stays eligible.
+	if mdl := m.resolveAgentModel(); mdl != "" {
+		if m.operatorSeenModels[mdl] {
+			return false // this model already surfaced the desk this session
+		}
+	} else if m.proxyHolder != nil {
+		return false // a holder with no resolved model - not a fresh landing
 	}
 	if strings.TrimSpace(m.agentIn.Value()) != "" || m.agentBusy || (m.agent != nil && m.agent.running.Load()) {
 		return false
@@ -1226,11 +1255,15 @@ func (m model) deskRosterView(w, cursor int, focused bool) string {
 	}
 	var b strings.Builder
 	b.WriteString("\n" + truncVisible("  "+stSelBar.Render("▌")+" "+stBrand.Render("THE DESK")+"    "+stDim.Render(sub), w) + "\n")
-	// R2: the selected operator's plate as a marquee, in its ONE canonical hue. Focused
-	// only - the static preview stays byte-identical (no marquee, no carat).
-	if focused {
-		b.WriteString(m.deskMarquee(w, cursor))
+	// The operator's plate as a marquee, in its ONE canonical hue. Focused: the cursor drives
+	// which operator's plate shows. NOT focused (refinement 2, amends R2 / §6): the static
+	// preview anchors on the resident DJ's house plate (cursor 0 = djBrandArt) - guest plates
+	// still surface on focus/selection ONLY (ONE HUE, ONE BEAT preserved).
+	cur := cursor
+	if !focused {
+		cur = 0
 	}
+	b.WriteString(m.deskMarquee(w, cur))
 	b.WriteString(truncVisible("    "+stDim.Render(pad("operator", 13)+pad("wire", 11)+"status"), w) + "\n")
 	// The resident DJ row is always first (index 0), with the red on-air mark.
 	b.WriteString(truncVisible(deskGutter(focused && cursor == 0)+stRed.Render(glyphOnAir)+" "+stKey.Render(pad("DJ", 12))+" "+stDim.Render(pad("in the TUI", 10)+" resident · dj.md persona · read/list auto, write/run confirm"), w) + "\n")

--- a/internal/tui/operator_steps_desk_entry_test.go
+++ b/internal/tui/operator_steps_desk_entry_test.go
@@ -375,8 +375,34 @@ func (s *opBDD) pickAutoBandPicksNothing(login string) error {
 	return nil
 }
 
+// deskSurfacedForModel marks a model as already having surfaced the focused desk this
+// session (operatorSeenModels), so a re-entry for it stays ask-focused - the once-per-model
+// ruling. Seeded directly to pin the state without an esc/re-enter round-trip.
+func (s *opBDD) deskSurfacedForModel(mdl string) error {
+	s.mutate(func(m *model) {
+		if m.operatorSeenModels == nil {
+			m.operatorSeenModels = map[string]bool{}
+		}
+		m.operatorSeenModels[mdl] = true
+	})
+	return nil
+}
+
+// modelMarkedSurfaced asserts the model is now recorded in operatorSeenModels - the FIRST
+// entry that surfaced the desk must mark it, so a second entry for it stays ask-focused.
+func (s *opBDD) modelMarkedSurfaced(mdl string) error {
+	if !s.model().operatorSeenModels[mdl] {
+		return fmt.Errorf("model %q is not marked surfaced this session (operatorSeenModels=%v)", mdl, s.model().operatorSeenModels)
+	}
+	return nil
+}
+
 // initializeDeskEntryScenarios registers the desk_entry + auto_tune step definitions.
 func initializeDeskEntryScenarios(st *opBDD, sc *godog.ScenarioContext) {
+	sc.Step(`^the model "([^"]*)" has already surfaced the desk this session$`, st.deskSurfacedForModel)
+	sc.Step(`^the model "([^"]*)" is marked surfaced this session$`, st.modelMarkedSurfaced)
+	sc.Step(`^the AGENT view shows "([^"]*)"$`, st.transcriptShows)
+	sc.Step(`^the AGENT view does not show "([^"]*)"$`, st.transcriptDoesNotShow)
 	sc.Step(`^a fresh AGENT session with nothing tuned in$`, st.freshNothingTuned)
 	sc.Step(`^a fresh AGENT session with a free band "([^"]*)" on air$`, st.freshFreeBand)
 	sc.Step(`^a fresh AGENT session with only a paid band on air$`, st.freshPaidOnly)

--- a/internal/tui/operator_steps_phase3_test.go
+++ b/internal/tui/operator_steps_phase3_test.go
@@ -302,12 +302,21 @@ func (s *opBDD) landingRendersNoDeskChrome() error {
 
 func (s *opBDD) firstRosterRowIsDJ() error {
 	lines := s.rosterLines()
-	if len(lines) < 3 {
-		return fmt.Errorf("roster too short:\n%s", s.roster())
+	// The column header ("operator … wire … status") precedes the operator rows; the DJ
+	// row is the first row after it. Located by content (not a fixed index) so the resident
+	// DJ house plate now sitting above the header (refinement 2) does not throw the count.
+	hdr := -1
+	for i, ln := range lines {
+		if strings.Contains(ln, "operator") && strings.Contains(ln, "wire") && strings.Contains(ln, "status") {
+			hdr = i
+			break
+		}
 	}
-	// lines[0] heading, lines[1] column header, lines[2] the first row.
-	if !strings.Contains(lines[2], "DJ") || !strings.Contains(lines[2], "resident") {
-		return fmt.Errorf("the first roster row is not the DJ row: %q", lines[2])
+	if hdr < 0 || hdr+1 >= len(lines) {
+		return fmt.Errorf("no column header / first row in roster:\n%s", s.roster())
+	}
+	if !strings.Contains(lines[hdr+1], "DJ") || !strings.Contains(lines[hdr+1], "resident") {
+		return fmt.Errorf("the first roster row is not the DJ row: %q", lines[hdr+1])
 	}
 	return nil
 }
@@ -318,8 +327,10 @@ func (s *opBDD) djRowCarriesRedMark() error {
 		block = s.rosterRaw()
 		token = stRed.Render(glyphOnAir)
 	})
+	// Match the DJ ROW specifically ("dj.md persona" is row-only text); the DJ house plate
+	// above also carries the word "resident" but is a dim lockup, not the on-air row.
 	for _, ln := range strings.Split(block, "\n") {
-		if strings.Contains(stripANSI(ln), "resident") {
+		if strings.Contains(stripANSI(ln), "dj.md persona") {
 			if !strings.Contains(ln, token) {
 				return fmt.Errorf("the DJ row does not carry the red %s mark: %q", glyphOnAir, ln)
 			}
@@ -492,6 +503,46 @@ func (s *opBDD) djRowPlainMark() error {
 	}
 	if !strings.Contains(row, glyphOnAir) {
 		return fmt.Errorf("the DJ row lost the %s mark under NO_COLOR: %q", glyphOnAir, row)
+	}
+	return nil
+}
+
+// staticPreviewShowsDJPlate pins refinement 2: the resident DJ's house plate anchors the
+// roster on the UNFOCUSED static preview ("the house agent" is plate-only text - the DJ
+// ROW says "dj.md persona", the plate says "the house agent").
+func (s *opBDD) staticPreviewShowsDJPlate() error {
+	m := s.model()
+	if m.deskFocused {
+		return fmt.Errorf("the desk is focused - this scenario pins the STATIC (unfocused) preview")
+	}
+	if !strings.Contains(s.roster(), "the house agent") {
+		return fmt.Errorf("the static preview does not render the resident DJ house plate:\n%s", s.roster())
+	}
+	return nil
+}
+
+// agentFooterShows / agentFooterOmits pin refinement 3's footer copy. They render the
+// footer LINE specifically (m.footer) - not the whole view - so "/operator" in the in-body
+// idle help can never satisfy them; the assertion truly pins the FOOTER.
+func (s *opBDD) agentFooter() string { return stripANSI(s.model().footer(s.tuiWidth())) }
+func (s *opBDD) agentFooterShows(text string) error {
+	if !strings.Contains(s.agentFooter(), text) {
+		return fmt.Errorf("the AGENT footer lacks %q:\n%s", text, s.agentFooter())
+	}
+	return nil
+}
+func (s *opBDD) agentFooterOmits(text string) error {
+	if strings.Contains(s.agentFooter(), text) {
+		return fmt.Errorf("the AGENT footer unexpectedly shows %q:\n%s", text, s.agentFooter())
+	}
+	return nil
+}
+
+// agentIdleHelpShows pins the in-body idle help copy (the one-line command hint under the
+// ask prompt, in agentView).
+func (s *opBDD) agentIdleHelpShows(text string) error {
+	if !strings.Contains(s.agentViewText(), text) {
+		return fmt.Errorf("the in-body idle help lacks %q:\n%s", text, s.agentViewText())
 	}
 	return nil
 }
@@ -1193,6 +1244,10 @@ func initializePhase3Steps(st *opBDD, sc *godog.ScenarioContext) {
 	sc.Step(`^the ask prompt still has focus$`, st.askPromptHasFocus)
 	sc.Step(`^the ask prompt echoes "([^"]*)"$`, st.askPromptEchoes)
 	sc.Step(`^the AGENT landing renders THE DESK roster$`, st.landingRendersRoster)
+	sc.Step(`^the static preview shows the resident DJ house plate$`, st.staticPreviewShowsDJPlate)
+	sc.Step(`^the AGENT footer shows "([^"]*)"$`, st.agentFooterShows)
+	sc.Step(`^the AGENT footer does not show "([^"]*)"$`, st.agentFooterOmits)
+	sc.Step(`^the in-body idle help shows "([^"]*)"$`, st.agentIdleHelpShows)
 	sc.Step(`^the roster heading reads "([^"]*)"$`, st.rosterHeadingReads)
 	sc.Step(`^the roster heading subtitle reads "([^"]*)"$`, st.rosterSubtitleReads)
 	sc.Step(`^the roster heading subtitle does not name a model$`, st.rosterSubtitleNamesNoModel)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -694,6 +694,12 @@ type model struct {
 	// (cold) tune-in to a band; a band in this set drops straight into the open channel
 	// (warm reconnect). Cleared by nothing this session (a band stays "warm" once tuned).
 	recentBands map[string]bool
+	// operatorSeenModels records every model that has ALREADY surfaced the focused AGENT
+	// DESK this session (Guest Operators): the first AGENT entry for a tuned model lands on
+	// the selectable desk once a guest is detected; a second entry for the SAME model stays
+	// ask-focused. Switching to a different model re-surfaces the desk once for it. Lazily
+	// initialized; per-session (never cleared - an esc-exit keeps the record).
+	operatorSeenModels map[string]bool
 	// staged tune-in sequence (modeConnecting): connectStage is the step the
 	// animation has reached (0..connectStageDone); connectStartFrame anchors the
 	// per-step dwell to m.frame so the steps advance on the one carrier beat. Under
@@ -8319,7 +8325,7 @@ func (m model) footer(w int) string {
 				left = stDim.Render("y run · n/esc deny")
 			}
 		default:
-			left = stDim.Render("type to ask  ·  /model  ·  /clear  ·  /persona  ·  esc exits AGENT")
+			left = stDim.Render("type to ask  ·  /model  ·  /operator  ·  /clear  ·  esc exits AGENT")
 			if m.narrow() {
 				left = stDim.Render("ask · /model · esc exit")
 			}


### PR DESCRIPTION
## AGENT [0] desk UX — 3 founder-approved refinements

Spec-first (RED → GREEN), low-effort, reusing the existing DESK / `deskMarquee` /
`djBrandArt` machinery. Build-and-hold: do not merge (coordinator merges).

### The 3 refinements

**1. First-time-per-model desk focus.** When a band IS tuned (`resolveAgentModel()`
non-empty) and a guest is detected, the FIRST AGENT entry for that model this session
surfaces the DESK focused with the cursor on the DJ row. A new `operatorSeenModels`
set (sibling to `recentBands`) records the model at the point focus is taken, so a
second entry for the same model stays ask-focused, and switching to a different model
re-surfaces the desk once for it. The R3 escape behavior is preserved exactly:
type-through de-focuses and lands the char in the ask box (zero chars lost), Enter-on-DJ
focuses ask, Enter-on-guest opens the pre-launch plate, esc exits. A live holder with no
resolved model (disconnected / odd re-entry) still keeps the ask focused. The focused
desk shows a one-line hint in the status slot:
`↑↓ choose an operator · ⏎ DJ keeps the mic · type to just ask · esc exits`.

**2. DJ art on the static landing.** `deskRosterView` now renders the resident DJ's
house plate (`djBrandArt`, mono+red) above the roster on the unfocused static preview /
band-tuned re-entry, reusing `operatorBrandArtBlock` (NO_COLOR / ASCII / narrow fallbacks
included). Guest plates still render on focus/selection only — ONE HUE, ONE BEAT preserved.

**3. /operator discoverability.**
- Footer: `/persona` → `/operator` (holds ~88 cols; `/persona` stays in `/help` +
  Tab-complete). Narrow variant unchanged.
- In-body idle help: adds `/operator hands the mic` next to `/model switches`.
- `/help` already carried the `/operator` line; the busy-state hint is left unchanged
  (`/operator` is refused mid-turn — not advertised when blocked).

### Two rulings applied
- **Once per model, per session** — `operatorSeenModels`, marked at focus, never cleared
  (an esc-exit keeps the record).
- **Cursor on the DJ row** on first surface.

### Before / after

Footer (default, non-narrow):
```
- type to ask  ·  /model  ·  /clear  ·  /persona  ·  esc exits AGENT
+ type to ask  ·  /model  ·  /operator  ·  /clear  ·  esc exits AGENT
```

Static DESK preview (band tuned, desk not focused):
```
   ▌ THE DESK    who can take the mic on qwen3-32b-fp8
+    ((•))
+    \(R)/   ROGER·AI · DJ
+    ╰───╯   resident · the house agent · dj.md
     operator     wire       status
   ◉ DJ           in the TUI  resident · dj.md persona · read/list auto, write/run confirm
     opencode     hands off   guest · on PATH · patches into your open channel
```

In-body idle help:
```
- enter asks  ·  /model switches  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  …
+ enter asks  ·  /model switches  ·  /operator hands the mic  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  …
```

### Specs (RED → GREEN)
- `features/operator/desk_entry.feature`: first-entry-surfaces (focus + cursor on DJ +
  model marked seen), second-entry-same-model stays ask-focused, different-model
  re-surfaces, type-through de-focus, no-guests never steals focus, focused-desk hint,
  and the live-holder-with-no-resolved-model invariant.
- `features/operator/desk_view.feature`: static DJ house plate on the unfocused preview;
  footer shows `/operator` and not `/persona`; idle help names `/operator hands the mic`.
- RED captured (the 6 new-behavior scenarios failed for the right reasons: the
  connected-first-time focus didn't happen, the static DJ plate was absent, `/operator`
  absent from the footer + idle help). GREEN after implementation; all 312 operator
  scenarios pass.
- Step helpers `firstRosterRowIsDJ` / `djRowCarriesRedMark` were re-targeted to locate
  the DJ row by content (the plate now sits above the column header) — a harness
  adaptation to the new layout, not a weakened assertion.

### Verification
- `go build ./...`, `go vet ./internal/tui ./internal/operator` clean.
- `go test ./internal/tui ./internal/operator` (godog strict) green; `-race ./internal/tui`
  green.
- `make cover-gate` PASS — every package ≥ 90% (internal/tui 92.5%, internal/operator
  93.8%, total 92.3%).

### Doc amendment
`GUEST-OPERATOR-PLATES.md` §6 + `GUEST-OPERATORS.md` §3 amended (separate repo
`rogerai-internal-docs`, pushed through its own claude-audit gate → PASS): "the static
preview shows the resident DJ's house plate (mono+red); guest plates render on
focus/selection only."
