### PR TITLE
agent[0]: clear the focused-desk hint when focus returns to the ask box

### DIFF
--- a/features/operator/desk_entry.feature
+++ b/features/operator/desk_entry.feature
@@ -82,6 +82,12 @@ Feature: THE DESK takes focus on the AGENT [0] landing
     And the ask box has focus
     And the ask box echoes "h"
 
+  Scenario: Typing through clears the focused-desk hint (no stale arrow-selection advice)
+    Given an AGENT session whose last band "gpt-oss-20b" is still on air
+    And the desk scan lands guest "opencode"
+    When the user types "h"
+    Then the AGENT footer does not show "↑↓ choose an operator"
+
   Scenario: A tuned first-entry with NO guests keeps the ask box focused (zero-guest invariant)
     Given an AGENT session whose last band "gpt-oss-20b" is still on air
     When the desk scan lands no guests

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -480,7 +480,7 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 				// The resident DJ: hand focus to the ask box.
 				m.deskFocused = false
 				m.agentIn.Focus()
-				m.status = stDim.Render("the DJ has the mic · type to ask · esc exits")
+				m.status = stDim.Render(djHasMicStatus)
 				return m, textinput.Blink
 			}
 			ds := deskGuests(m.operatorDetections)
@@ -492,9 +492,11 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if isPrintableKey(k) {
 			// Type-through: the DJ is implied. De-focus the desk and let the rune land in
-			// the ask box via the text-entry Update below.
+			// the ask box via the text-entry Update below. Clear the focused-desk hint so the
+			// status line stops advertising arrow-selection (mirrors the enter-on-DJ path).
 			m.deskFocused = false
 			m.agentIn.Focus()
+			m.status = stDim.Render(djHasMicStatus)
 		}
 	}
 	// Text-entry mode: enter submits (or QUEUES while a turn runs - see the enter case),

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -160,6 +160,7 @@ func (m model) onOperatorDetected(msg operatorDetectedMsg) (tea.Model, tea.Cmd) 
 			m.deskFocused = false
 			m.deskCursor = 0
 			m.agentIn.Focus()
+			m.status = stDim.Render(djHasMicStatus) // drop the now-stale focused-desk hint
 		} else {
 			if max := m.deskRowCount() - 1; m.deskCursor > max {
 				m.deskCursor = max
@@ -201,6 +202,11 @@ func (m model) onOperatorDetected(msg operatorDetectedMsg) (tea.Model, tea.Cmd) 
 // deskFocusHint is the one-line status shown while THE DESK holds focus: how to pick an
 // operator, keep the DJ, or just start asking. Mirrors the /operator picker footer voice.
 const deskFocusHint = "↑↓ choose an operator · ⏎ DJ keeps the mic · type to just ask · esc exits"
+
+// djHasMicStatus replaces deskFocusHint the moment the desk hands focus back to the ask box
+// (enter-on-DJ, type-through, or a guest set that empties under focus) so the status line
+// never keeps advertising arrow-selection that no longer applies.
+const djHasMicStatus = "the DJ has the mic · type to ask · esc exits"
 
 // deskEntryEligible reports whether the AGENT is on the FRESH landing where THE DESK may
 // take focus: AGENT mode, no channel/model, the ask box empty (nothing typed), the


### PR DESCRIPTION
Completes the first-time-DESK refinement: a shared djHasMicStatus constant replaces deskFocusHint the moment the desk hands focus back to the ask box (enter-on-DJ, type-through, or a guest set that empties under focus), so the status line stops advertising arrow-selection that no longer applies. Spec-first with a DISCRIMINATING scenario (verified RED - the stale hint persists without the fix - then GREEN). internal/tui godog strict green, gofmt-clean. (Redone in a clean worktree after the first attempt hit the Syncthing corruption + an audit-caught tautological assertion.)