### PR TITLE
SECURITY: relay path allowlist - the share node becomes the trust boundary (BUILD-AND-HOLD)

### DIFF
--- a/features/voice/relay_allowlist.feature
+++ b/features/voice/relay_allowlist.feature
@@ -1,0 +1,164 @@
+# PENDING founder approval (spec-first workflow step 3) - BUILD-AND-HOLD. This spec is the
+# founder-approvable contract for the RELAY PATH ALLOWLIST hardening; the PR carries it for
+# review and MUST NOT merge before the founder approves the spec.
+#
+# Finding A from the Osaurus verification, valuable for ALL backends (not just Osaurus).
+#
+# The gap being closed: agent.serve() (internal/agent/agent.go) derives the LOCAL upstream
+# endpoint from the broker-supplied job.Path and POSTs the body there over loopback, which the
+# local backend treats as authenticated. Before this change ANY non-chat Path was forwarded
+# verbatim (target = TrimSuffix(Upstream,"/chat/completions") + TrimPrefix(Path,"/v1")), so a
+# compromised or buggy broker could steer the node onto a dangerous local route (e.g. an
+# Osaurus /agents/{id}/run or /mcp/call) that loopback trusts. The NODE is the trust boundary:
+# it must forward ONLY an allowlisted set of upstream paths and refuse everything else BEFORE
+# the request ever reaches the local backend.
+#
+# Ground truth: internal/agent/agent.go serve() (the target-derivation + POST) and isSpeechPath;
+# the broker only ever dispatches three real relay Paths - chat (absent / "/v1/chat/completions",
+# cmd/rogerai-broker tunnel.go/concierge.go/probe.go set no Path), TTS "/v1/audio/speech" and
+# STT "/v1/audio/transcriptions" (cmd/rogerai-broker/audio.go audioSpec.path).
+#
+# The guard is deliberately SIMPLE and FORGIVING: one predicate (isAllowedUpstreamPath) that,
+# after a MINIMAL safe normalization (cleanUpstreamPath: trim whitespace, then path.Clean to
+# collapse "//", resolve "." / "..", strip a trailing slash), EXACT-matches the canonical set,
+# reusing the code's own isSpeechPath so adding a modality is a one-line change:
+#   - chat completions: absent path (chat back-compat), "/v1/chat/completions", "/chat/completions"
+#   - TTS  "/v1/audio/speech"   (isSpeechPath)
+#   - STT  "/v1/audio/transcriptions"
+# Matching is case-sensitive (the relay treats paths case-sensitively). Normalization only
+# collapses cosmetic noise; path.Clean resolves ".." AWAY from a canonical path, so it can never
+# manufacture an allowed path out of a dangerous one - the traversal/slash/encoding tricks below
+# all still fail the exact match.
+#
+# Invariants:
+#   A1 an allowlisted path forwards to the local backend exactly as before (chat/voice happy
+#      paths are byte-identical - this change adds a gate, it does not touch them).
+#   A2 a NON-allowlisted path is REFUSED with a clean 404 "unsupported path" and the local
+#      backend is NEVER contacted (assert zero backend hits).
+#   A3 the refusal leaks nothing sensitive (no upstream URL, no key) and never crashes.
+#   A4 header discipline is unchanged - only Content-Type + Authorization are ever forwarded.
+#   A5 a cosmetic variant of an allowlisted path (trailing slash, surrounding whitespace, a
+#      collapsible "//") is normalized and forwarded to its canonical endpoint.
+#
+# Purely-lexical adversarial corners that Gherkin table cells cannot carry faithfully (leading/
+# trailing whitespace - godog trims cells - NUL bytes, backslashes, control chars, and the
+# whitespace/trailing-slash TOLERANCE of A5) are pinned exhaustively in the table-driven Go tests
+# TestIsAllowedUpstreamPath + TestCleanUpstreamPath (internal/agent).
+
+Feature: Relay path allowlist - the share node is the trust boundary
+
+  Background:
+    Given a local backend that records every request path it is hit on
+    And a share node relaying to that backend
+
+  # ===========================================================================
+  # 1. ALLOWED - the three real relay modalities (A1)
+  # ===========================================================================
+
+  Scenario: a chat job with an absent path forwards to the chat upstream unchanged
+    When the broker relays a job with an absent path
+    Then the backend is hit once at "/v1/chat/completions"
+    And the node returns the backend's response
+
+  Scenario: the explicit chat completions path is forwarded
+    When the broker relays a job with path "/v1/chat/completions"
+    Then the backend is hit once at "/v1/chat/completions"
+    And the node returns the backend's response
+
+  Scenario: the /chat/completions alias is forwarded
+    When the broker relays a job with path "/chat/completions"
+    Then the backend is hit once at "/v1/chat/completions"
+    And the node returns the backend's response
+
+  Scenario: the TTS speech path is forwarded
+    When the broker relays a job with path "/v1/audio/speech"
+    Then the backend is hit once at "/v1/audio/speech"
+    And the node returns the backend's response
+
+  Scenario: the STT transcriptions path is forwarded
+    When the broker relays a job with path "/v1/audio/transcriptions"
+    Then the backend is hit once at "/v1/audio/transcriptions"
+    And the node returns the backend's response
+
+  # ---------------------------------------------------------------------------
+  # 1b. FORGIVING - a cosmetic variant of an allowlisted path is normalized and
+  #     forwarded to its canonical endpoint (A5). (Leading/trailing whitespace
+  #     tolerance is pinned in TestCleanUpstreamPath - godog trims table cells.)
+  # ---------------------------------------------------------------------------
+
+  Scenario: a trailing slash on the speech path is normalized and forwarded
+    When the broker relays a job with path "/v1/audio/speech/"
+    Then the backend is hit once at "/v1/audio/speech"
+    And the node returns the backend's response
+
+  Scenario: a trailing slash on the chat path is normalized and forwarded
+    When the broker relays a job with path "/v1/chat/completions/"
+    Then the backend is hit once at "/v1/chat/completions"
+    And the node returns the backend's response
+
+  Scenario: a collapsible double slash inside the speech path is normalized and forwarded
+    When the broker relays a job with path "/v1//audio/speech"
+    Then the backend is hit once at "/v1/audio/speech"
+    And the node returns the backend's response
+
+  # ===========================================================================
+  # 2. REFUSED - a broker-supplied path outside the allowlist never reaches the
+  #    local backend (A2, A3). Each is refused with a clean 404.
+  # ===========================================================================
+
+  Scenario Outline: a non-allowlisted path is refused without touching the backend
+    When the broker relays a job with path "<path>"
+    Then the node refuses with a 404 "unsupported path"
+    And the backend is never hit
+    And the refusal body leaks neither the upstream URL nor the upstream key
+
+    Examples: dangerous local routes
+      | path                |
+      | /agents/run         |
+      | /agents/abc-123/run |
+      | /mcp/call           |
+      | /memory/anything    |
+      | /pair               |
+      | /secure/x           |
+      | /admin/reset        |
+
+    Examples: traversal and slash tricks (path.Clean resolves these AWAY from a canonical path)
+      | path                    |
+      | /v1/../agents/run       |
+      | /v1/audio/../agents/run |
+      | //agents/run            |
+      | /v1//agents/run         |
+      | /v1/chat/../agents/run  |
+      | /v1/audio/speech/../run |
+
+    Examples: case variants (matching is case-sensitive)
+      | path                  |
+      | /V1/Chat/Completions  |
+      | /v1/audio/SPEECH      |
+      | /V1/AUDIO/SPEECH      |
+
+    Examples: absolute URLs and schemes in the path
+      | path                          |
+      | http://127.0.0.1/agents/run   |
+      | https://evil.example/mcp/call |
+      | file:///etc/passwd            |
+
+    Examples: query strings smuggling an agent route
+      | path                                  |
+      | /v1/audio/speech?x=/agents/run        |
+      | /v1/chat/completions?path=/agents/run |
+      | /?/agents/run                         |
+
+    Examples: percent-encoded traversal and lookalikes
+      | path                       |
+      | /v1/audio/%2e%2e/agents    |
+      | /v1/%2e%2e/agents/run      |
+      | /agents%2frun              |
+
+    Examples: empty-ish and lookalike suffixes
+      | path                     |
+      | /                        |
+      | /chat/completions/extra  |
+      | /agents/run/completions  |
+      | /evil/audio/speech       |
+      | /audio/speech            |

--- a/features/voice/relay_allowlist.feature
+++ b/features/voice/relay_allowlist.feature
@@ -80,6 +80,11 @@ Feature: Relay path allowlist - the share node is the trust boundary
     Then the backend is hit once at "/v1/audio/transcriptions"
     And the node returns the backend's response
 
+  Scenario: a forwarded request carries only the node's own headers (A4)
+    When the broker relays a job with path "/v1/audio/speech"
+    Then the backend is hit once at "/v1/audio/speech"
+    And the forwarded request carries only the node's Content-Type and Authorization headers
+
   # ---------------------------------------------------------------------------
   # 1b. FORGIVING - a cosmetic variant of an allowlisted path is normalized and
   #     forwarded to its canonical endpoint (A5). (Leading/trailing whitespace

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -658,12 +659,22 @@ func parseUsage(line []byte) (prompt, completion int, ok bool) {
 }
 
 func serve(cfg Config, offer protocol.ModelOffer, priv ed25519.PrivateKey, up *http.Client, job protocol.Job) protocol.JobResult {
+	// TRUST BOUNDARY: the broker supplies job.Path and we derive a LOCAL endpoint from it (below),
+	// which the loopback backend treats as authenticated. Only forward an ALLOWLISTED upstream
+	// path; refuse everything else BEFORE building a target or touching the backend, so a
+	// compromised/buggy broker cannot steer the node onto a dangerous local route (e.g.
+	// /agents/{id}/run or /mcp/call). We normalize once (see cleanUpstreamPath) and use the
+	// normalized path everywhere below. See isAllowedUpstreamPath + relay_allowlist.feature.
+	p := cleanUpstreamPath(job.Path)
+	if !isAllowedUpstreamPath(p) {
+		return protocol.JobResult{ID: job.ID, Status: http.StatusNotFound, Body: []byte(`{"error":"unsupported path"}`)}
+	}
 	// The broker tags a voice job with the upstream Path to hit (e.g. /v1/audio/speech); serve it
 	// against the SAME local server at that path, derived from the chat upstream's base. An empty
 	// or chat Path leaves cfg.Upstream unchanged (a normal LLM share is untouched).
 	target := cfg.Upstream
 	body := job.Body
-	if p := job.Path; p != "" && !strings.HasSuffix(p, "/chat/completions") {
+	if p != "" && !strings.HasSuffix(p, "/chat/completions") {
 		target = strings.TrimSuffix(cfg.Upstream, "/chat/completions") + strings.TrimPrefix(p, "/v1")
 		// On the speech path, inject the operator's DEFAULT voice/speed when the caller omitted
 		// them, so a consumer gets the operator's picked voice/blend (offer.Voice) — not the raw
@@ -710,10 +721,46 @@ func serve(cfg Config, offer protocol.ModelOffer, priv ed25519.PrivateKey, up *h
 	return protocol.JobResult{ID: job.ID, Status: resp.StatusCode, Body: respBody, Receipt: rec}
 }
 
-// isSpeechPath reports whether a broker job Path targets the local text-to-speech endpoint (the
-// ONLY path where the operator's default voice/speed is injected). stt (/v1/audio/transcriptions)
-// and chat are excluded — they have no `voice` knob.
-func isSpeechPath(p string) bool { return strings.HasSuffix(p, "/audio/speech") }
+// The canonical upstream paths the node relays to its LOCAL backend - the ONLY endpoints the
+// broker ever dispatches (cmd/rogerai-broker: chat sets no Path; audio.go tags TTS/STT). These
+// are the single source of truth: the allowlist and the downstream routing both read them, so
+// adding a modality is a one-line change here.
+const (
+	pathChat       = "/v1/chat/completions"     // chat completions (canonical)
+	pathChatAlias  = "/chat/completions"        // chat completions (back-compat alias)
+	pathSpeech     = "/v1/audio/speech"         // TTS
+	pathTranscribe = "/v1/audio/transcriptions" // STT
+)
+
+// cleanUpstreamPath does the minimal, safe normalization the allowlist matches against: trim
+// surrounding whitespace, then path.Clean a rooted path (collapses "//", resolves "." and "..",
+// strips a trailing slash). A blank path stays "" (the chat back-compat). Anything that is not a
+// rooted "/..." path (an absolute URL, a scheme, a backslash form) is returned untouched so it
+// simply fails the exact match below - we never try to rescue it. path.Clean resolving ".."
+// pulls a traversal AWAY from a canonical path (e.g. /v1/../agents/run -> /agents/run), never
+// toward one, so this cannot manufacture an allowed path out of a dangerous one.
+func cleanUpstreamPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" || !strings.HasPrefix(p, "/") {
+		return p
+	}
+	return path.Clean(p)
+}
+
+// isAllowedUpstreamPath is the node-side trust boundary: it reports whether a (cleaned) broker
+// job path may be forwarded to the LOCAL backend. It is a tight exact-match against the canonical
+// set above, reusing isSpeechPath so the voice path stays in sync. A blank path is the chat
+// back-compat. Case-sensitive (the relay treats paths case-sensitively). Extend it by adding one
+// term for a new canonical modality.
+func isAllowedUpstreamPath(p string) bool {
+	return p == "" || p == pathChat || p == pathChatAlias || isSpeechPath(p) || p == pathTranscribe
+}
+
+// isSpeechPath reports whether a (cleaned) job path targets the local text-to-speech endpoint -
+// the ONLY path where the operator's default voice/speed is injected. Anchored to the exact
+// canonical TTS path (not a loose suffix, which /evil/audio/speech would have matched). stt and
+// chat are excluded — they have no `voice` knob.
+func isSpeechPath(p string) bool { return p == pathSpeech }
 
 // injectVoiceDefaults returns body with the operator's default voice/speed FILLED IN when the
 // caller omitted them, so a consumer gets the operator's picked voice/blend (offer.Voice) rather

--- a/internal/agent/relay_allowlist_bdd_test.go
+++ b/internal/agent/relay_allowlist_bdd_test.go
@@ -1,0 +1,207 @@
+package agent
+
+// relay_allowlist_bdd_test.go makes features/voice/relay_allowlist.feature EXECUTABLE under
+// godog, driving the REAL agent.serve() against a REAL httptest backend that RECORDS whether it
+// was hit (and on what path). It is the node-side trust-boundary contract: an allowlisted broker
+// Path forwards to the local backend unchanged; a NON-allowlisted Path is refused with a clean
+// 404 and the backend is NEVER contacted. No mocks of the node internals - the only stub is the
+// local backend, which is exactly the surface a compromised broker would try to steer.
+
+import (
+	"context"
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+type relayAllowlistState struct {
+	backend     *httptest.Server
+	hits        atomic.Int64
+	lastPath    atomic.Value // string: the last URL path the backend was hit on
+	cfg         Config
+	priv        ed25519.PrivateKey
+	res         protocol.JobResult
+	panicked    bool
+	upstreamURL string
+	upstreamKey string
+}
+
+const relayBackendBody = "OK-FROM-LOCAL-BACKEND"
+
+func (s *relayAllowlistState) reset() {
+	if s.backend != nil {
+		s.backend.Close()
+	}
+	*s = relayAllowlistState{}
+	_, s.priv, _ = ed25519.GenerateKey(nil)
+}
+
+// --- Given ---
+
+func (s *relayAllowlistState) recordingBackend() error {
+	s.backend = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.hits.Add(1)
+		s.lastPath.Store(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(relayBackendBody))
+	}))
+	s.upstreamURL = s.backend.URL
+	s.upstreamKey = "sk-node-upstream-SECRET"
+	return nil
+}
+
+func (s *relayAllowlistState) nodeRelayingToBackend() error {
+	s.cfg = Config{
+		NodeID:      "n1",
+		Model:       "roger-operator-voice",
+		Upstream:    s.backend.URL + "/v1/chat/completions",
+		UpstreamKey: s.upstreamKey,
+	}
+	return nil
+}
+
+// --- When ---
+
+// relayPath drives the REAL serve() with the given broker Path. It recovers any panic so a RED
+// run reports the failing assertion cleanly rather than aborting the whole suite (a nil upstream
+// request from a malformed derived URL is itself a bug this hardening removes).
+func (s *relayAllowlistState) relayPath(path string) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.panicked = true
+		}
+	}()
+	job := protocol.Job{ID: "j", User: "u", Body: []byte(`{"model":"m","input":"hi"}`), Path: path}
+	s.res = serve(s.cfg, protocol.ModelOffer{Model: "m"}, s.priv, &http.Client{Timeout: 3 * time.Second}, job)
+}
+
+func (s *relayAllowlistState) relayAbsentPath() error { s.relayPath(""); return nil }
+func (s *relayAllowlistState) relayWithPath(path string) error {
+	s.relayPath(path)
+	return nil
+}
+
+// --- Then ---
+
+func (s *relayAllowlistState) backendHitOnceAt(want string) error {
+	if s.panicked {
+		return bddErr("serve panicked instead of forwarding to " + want)
+	}
+	if got := s.hits.Load(); got != 1 {
+		return bddErr("expected the backend to be hit exactly once, got " + itoa(got))
+	}
+	got, _ := s.lastPath.Load().(string)
+	if got != want {
+		return bddErr("backend hit at " + got + ", want " + want)
+	}
+	return nil
+}
+
+func (s *relayAllowlistState) nodeReturnsBackendResponse() error {
+	if s.res.Status != http.StatusOK {
+		return bddErr("node status " + itoa(int64(s.res.Status)) + ", want 200 from the backend")
+	}
+	if string(s.res.Body) != relayBackendBody {
+		return bddErr("node body " + string(s.res.Body) + ", want the backend body")
+	}
+	return nil
+}
+
+func (s *relayAllowlistState) refuses404Unsupported() error {
+	if s.panicked {
+		return bddErr("serve panicked instead of cleanly refusing")
+	}
+	if s.res.Status != http.StatusNotFound {
+		return bddErr("refusal status " + itoa(int64(s.res.Status)) + ", want 404")
+	}
+	if !strings.Contains(strings.ToLower(string(s.res.Body)), "unsupported path") {
+		return bddErr("refusal body " + string(s.res.Body) + ", want an 'unsupported path' error")
+	}
+	return nil
+}
+
+func (s *relayAllowlistState) backendNeverHit() error {
+	if got := s.hits.Load(); got != 0 {
+		lp, _ := s.lastPath.Load().(string)
+		return bddErr("backend was hit " + itoa(got) + " time(s) (last path " + lp + "); a refused path must NEVER reach the local backend")
+	}
+	return nil
+}
+
+func (s *relayAllowlistState) refusalLeaksNothing() error {
+	body := string(s.res.Body)
+	if s.upstreamURL != "" && strings.Contains(body, s.upstreamURL) {
+		return bddErr("refusal body leaked the upstream URL: " + body)
+	}
+	if strings.Contains(body, s.upstreamKey) {
+		return bddErr("refusal body leaked the upstream key: " + body)
+	}
+	return nil
+}
+
+// itoa avoids pulling strconv into the assertion strings inline.
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+func TestRelayAllowlistBDD(t *testing.T) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			st := &relayAllowlistState{}
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				st.reset()
+				return ctx, nil
+			})
+			sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+				if st.backend != nil {
+					st.backend.Close()
+					st.backend = nil
+				}
+				return ctx, nil
+			})
+			sc.Step(`^a local backend that records every request path it is hit on$`, st.recordingBackend)
+			sc.Step(`^a share node relaying to that backend$`, st.nodeRelayingToBackend)
+			sc.Step(`^the broker relays a job with an absent path$`, st.relayAbsentPath)
+			sc.Step(`^the broker relays a job with path "([^"]*)"$`, st.relayWithPath)
+			sc.Step(`^the backend is hit once at "([^"]*)"$`, st.backendHitOnceAt)
+			sc.Step(`^the node returns the backend's response$`, st.nodeReturnsBackendResponse)
+			sc.Step(`^the node refuses with a 404 "unsupported path"$`, st.refuses404Unsupported)
+			sc.Step(`^the backend is never hit$`, st.backendNeverHit)
+			sc.Step(`^the refusal body leaks neither the upstream URL nor the upstream key$`, st.refusalLeaksNothing)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/voice/relay_allowlist.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("voice/relay_allowlist behavior scenarios failed (see godog output above)")
+	}
+}

--- a/internal/agent/relay_allowlist_bdd_test.go
+++ b/internal/agent/relay_allowlist_bdd_test.go
@@ -25,6 +25,7 @@ type relayAllowlistState struct {
 	backend     *httptest.Server
 	hits        atomic.Int64
 	lastPath    atomic.Value // string: the last URL path the backend was hit on
+	lastHeader  atomic.Value // http.Header: the headers the backend saw on the last hit
 	cfg         Config
 	priv        ed25519.PrivateKey
 	res         protocol.JobResult
@@ -49,6 +50,7 @@ func (s *relayAllowlistState) recordingBackend() error {
 	s.backend = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.hits.Add(1)
 		s.lastPath.Store(r.URL.Path)
+		s.lastHeader.Store(r.Header.Clone())
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(relayBackendBody))
 	}))
@@ -135,6 +137,33 @@ func (s *relayAllowlistState) backendNeverHit() error {
 	return nil
 }
 
+// forwardedHeaderDiscipline asserts A4: the node forwards ONLY the Content-Type + Authorization
+// headers it sets itself - never a broker-supplied application header (Job carries no headers, so
+// the node cannot be tricked into forwarding one). Go's transport adds its own hop-by-hop headers
+// (Host/User-Agent/Accept-Encoding/Content-Length), which are not broker-controlled and allowed.
+func (s *relayAllowlistState) forwardedHeaderDiscipline() error {
+	h, _ := s.lastHeader.Load().(http.Header)
+	if h == nil {
+		return bddErr("no forwarded request was recorded")
+	}
+	if ct := h.Get("Content-Type"); ct != "application/json" {
+		return bddErr("forwarded Content-Type " + ct + ", want application/json")
+	}
+	if auth := h.Get("Authorization"); auth != "Bearer "+s.upstreamKey {
+		return bddErr("forwarded Authorization " + auth + ", want the node's Bearer upstream key")
+	}
+	allowed := map[string]bool{
+		"Content-Type": true, "Authorization": true, // the only two the node sets
+		"Host": true, "User-Agent": true, "Accept-Encoding": true, "Content-Length": true, // Go transport
+	}
+	for name := range h {
+		if !allowed[name] {
+			return bddErr("forwarded an unexpected header " + name + "; the node must forward ONLY Content-Type + Authorization")
+		}
+	}
+	return nil
+}
+
 func (s *relayAllowlistState) refusalLeaksNothing() error {
 	body := string(s.res.Body)
 	if s.upstreamURL != "" && strings.Contains(body, s.upstreamURL) {
@@ -190,6 +219,7 @@ func TestRelayAllowlistBDD(t *testing.T) {
 			sc.Step(`^the broker relays a job with path "([^"]*)"$`, st.relayWithPath)
 			sc.Step(`^the backend is hit once at "([^"]*)"$`, st.backendHitOnceAt)
 			sc.Step(`^the node returns the backend's response$`, st.nodeReturnsBackendResponse)
+			sc.Step(`^the forwarded request carries only the node's Content-Type and Authorization headers$`, st.forwardedHeaderDiscipline)
 			sc.Step(`^the node refuses with a 404 "unsupported path"$`, st.refuses404Unsupported)
 			sc.Step(`^the backend is never hit$`, st.backendNeverHit)
 			sc.Step(`^the refusal body leaks neither the upstream URL nor the upstream key$`, st.refusalLeaksNothing)

--- a/internal/agent/relay_allowlist_test.go
+++ b/internal/agent/relay_allowlist_test.go
@@ -1,0 +1,128 @@
+package agent
+
+// relay_allowlist_test.go is the white-box, table-driven companion to
+// features/voice/relay_allowlist.feature. It pins (1) the exact normalization contract
+// (cleanUpstreamPath) and (2) the allow/refuse decision the way serve() consumes it -
+// isAllowedUpstreamPath(cleanUpstreamPath(raw)) - including the purely-lexical corners a Gherkin
+// table cannot carry faithfully (godog trims cell whitespace; NUL/control bytes and backslashes
+// read poorly in a table). A normalization or matching regression fails RED here.
+
+import "testing"
+
+// allowRaw mirrors exactly how serve() gates a broker-supplied path.
+func allowRaw(raw string) bool { return isAllowedUpstreamPath(cleanUpstreamPath(raw)) }
+
+func TestCleanUpstreamPath(t *testing.T) {
+	tests := []struct{ raw, want string }{
+		{"", ""},
+		{"   ", ""},  // whitespace-only trims to blank (chat)
+		{"\t\n", ""}, // any unicode whitespace
+		{"/v1/chat/completions", "/v1/chat/completions"},   // canonical unchanged
+		{" /v1/chat/completions ", "/v1/chat/completions"}, // surrounding whitespace trimmed
+		{"/v1/audio/speech/", "/v1/audio/speech"},          // trailing slash stripped
+		{"/v1//audio/speech", "/v1/audio/speech"},          // double slash collapsed
+		{"/v1/./audio/speech", "/v1/audio/speech"},         // "." segment resolved
+		{"/v1/../agents/run", "/agents/run"},               // ".." resolved AWAY from canonical
+		{"//agents/run", "/agents/run"},                    // leading double slash collapsed
+		{"http://x/agents/run", "http://x/agents/run"},     // not rooted -> returned untouched (won't match)
+		{"\\agents\\run", "\\agents\\run"},                 // backslash form untouched (won't match)
+		{"/v1/audio/speech\x00", "/v1/audio/speech\x00"},   // NUL is not whitespace -> preserved -> won't match
+	}
+	for _, tt := range tests {
+		if got := cleanUpstreamPath(tt.raw); got != tt.want {
+			t.Errorf("cleanUpstreamPath(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestIsAllowedUpstreamPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// ALLOWED - the only paths the broker ever dispatches.
+		{"absent path is chat back-compat", "", true},
+		{"canonical chat", "/v1/chat/completions", true},
+		{"chat alias", "/chat/completions", true},
+		{"tts speech", "/v1/audio/speech", true},
+		{"stt transcriptions", "/v1/audio/transcriptions", true},
+
+		// ALLOWED - cosmetic variants normalized to canonical (A5).
+		{"trailing slash speech", "/v1/audio/speech/", true},
+		{"trailing slash chat", "/v1/chat/completions/", true},
+		{"double slash speech", "/v1//audio/speech", true},
+		{"dot segment chat", "/v1/./chat/completions", true},
+		{"leading space chat", " /v1/chat/completions", true},
+		{"trailing space chat", "/v1/chat/completions ", true},
+		{"leading tab speech", "\t/v1/audio/speech", true},
+		{"trailing newline speech", "/v1/audio/speech\n", true},
+		{"trailing crlf speech", "/v1/audio/speech\r\n", true},
+		{"whitespace only is chat", "   ", true},
+		{"single space is chat", " ", true},
+
+		// REFUSED - dangerous local routes.
+		{"agents run", "/agents/run", false},
+		{"agents id run", "/agents/abc-123/run", false},
+		{"mcp call", "/mcp/call", false},
+		{"memory", "/memory/anything", false},
+		{"pair", "/pair", false},
+		{"secure", "/secure/x", false},
+		{"admin", "/admin/reset", false},
+
+		// REFUSED - traversal / slashes resolve AWAY from canonical.
+		{"dotdot traversal", "/v1/../agents/run", false},
+		{"audio dotdot", "/v1/audio/../agents/run", false},
+		{"chat dotdot", "/v1/chat/../agents/run", false},
+		{"speech dotdot to run", "/v1/audio/speech/../run", false},
+		{"double slash route", "//agents/run", false},
+		{"inner double slash route", "/v1//agents/run", false},
+
+		// REFUSED - inner whitespace, control / NUL bytes (not trimmed away).
+		{"inner space", "/v1/audio /speech", false},
+		{"nul byte suffix", "/v1/audio/speech\x00", false},
+		{"nul byte then route", "/v1/chat/completions\x00/agents/run", false},
+		{"crlf injection mid", "/v1/audio/speech\r\nX-Evil: 1", false},
+
+		// REFUSED - backslashes.
+		{"backslashes", "\\agents\\run", false},
+		{"mixed slash", "/v1\\audio\\speech", false},
+
+		// REFUSED - case variants (matching is case-sensitive).
+		{"upper chat", "/V1/Chat/Completions", false},
+		{"upper speech tail", "/v1/audio/SPEECH", false},
+		{"all upper speech", "/V1/AUDIO/SPEECH", false},
+
+		// REFUSED - absolute URLs / schemes (not rooted, or collapse to a non-canonical path).
+		{"http absolute", "http://127.0.0.1/agents/run", false},
+		{"https absolute", "https://evil.example/mcp/call", false},
+		{"file scheme", "file:///etc/passwd", false},
+		{"scheme relative host", "//evil.example/agents/run", false},
+
+		// REFUSED - query strings / fragments smuggling a route.
+		{"speech query route", "/v1/audio/speech?x=/agents/run", false},
+		{"chat query route", "/v1/chat/completions?path=/agents/run", false},
+		{"fragment", "/v1/audio/speech#/agents/run", false},
+
+		// REFUSED - percent-encoded traversal / separators (never decoded).
+		{"encoded dotdot", "/v1/audio/%2e%2e/agents", false},
+		{"encoded dotdot root", "/v1/%2e%2e/agents/run", false},
+		{"encoded slash", "/agents%2frun", false},
+		{"encoded null", "/v1/audio/speech%00", false},
+
+		// REFUSED - lookalike suffixes (the old suffix match's blind spot) and bare root.
+		{"root slash", "/", false},
+		{"chat extra segment", "/chat/completions/extra", false},
+		{"run then completions", "/agents/run/completions", false},
+		{"evil speech suffix", "/evil/audio/speech", false},
+		{"speech no v1", "/audio/speech", false},
+		{"transcriptions no v1", "/audio/transcriptions", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := allowRaw(tt.path); got != tt.want {
+				t.Errorf("allow(%q) = %v, want %v (cleaned = %q)", tt.path, got, tt.want, cleanUpstreamPath(tt.path))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## RELAY PATH ALLOWLIST - the share node becomes the trust boundary (SECURITY, BUILD-AND-HOLD)

**Do not merge without founder review.** Spec-first security hardening; per CLAUDE.md the founder approves the *spec* (`features/voice/relay_allowlist.feature`) before merge.

### The gap being closed (trust-the-broker)
`internal/agent/agent.go` `serve()` derives the LOCAL upstream endpoint from the **broker-supplied `job.Path`** and POSTs the body there over loopback, which the local backend treats as authenticated:

```go
target = strings.TrimSuffix(cfg.Upstream, "/chat/completions") + strings.TrimPrefix(p, "/v1")
```

Before this change **any** non-chat `Path` was forwarded verbatim. A compromised or buggy broker could steer the node onto a dangerous local route - e.g. an Osaurus `/agents/{id}/run` or `/mcp/call`, which loopback treats as authenticated - carrying only `Content-Type` + `Authorization`. The node did no allowlisting: it trusted the broker's path.

This is **finding A from the Osaurus verification, and it is valuable for ALL backends, not just Osaurus** - any local backend with privileged loopback routes was reachable. (The Osaurus-specific `X-Persist: false` header + `body.model` pin are a **separate** follow-on for the Osaurus integration, not in this PR.)

### The fix - a simple, forgiving node-side allowlist
The node is now the trust boundary. `serve()` normalizes the broker path once and refuses anything outside the allowlist **before** building a target or contacting the backend:

```go
p := cleanUpstreamPath(job.Path)          // trim, then path.Clean (collapse //, resolve ./.., strip trailing /)
if !isAllowedUpstreamPath(p) {
    return protocol.JobResult{ID: job.ID, Status: http.StatusNotFound, Body: []byte(`{"error":"unsupported path"}`)}
}
```

`isAllowedUpstreamPath` is deliberately **one tight predicate** that exact-matches the canonical set, **reusing the code's own `isSpeechPath`** so a new modality is a one-line change:

```go
func isAllowedUpstreamPath(p string) bool {
    return p == "" || p == pathChat || p == pathChatAlias || isSpeechPath(p) || p == pathTranscribe
}
```

Allowed set = the only paths the broker ever dispatches (chat sets no `Path`; `cmd/rogerai-broker/audio.go` tags TTS/STT): absent path (chat back-compat), `/v1/chat/completions`, `/chat/completions`, `/v1/audio/speech`, `/v1/audio/transcriptions`.

Design notes:
- **No config surface, no DSL, no regex, no env knobs, no per-backend matrix** - one predicate + one normalizer, security by simplicity.
- Normalization is minimal and safe: `path.Clean` resolves `..` **away** from a canonical path (`/v1/../agents/run` -> `/agents/run`), so it can never manufacture an allowed path out of a dangerous one - it only collapses cosmetic noise (trailing slash, surrounding whitespace, a collapsible `//`).
- `isSpeechPath` was tightened from a loose suffix (`strings.HasSuffix(p, "/audio/speech")`, which `/evil/audio/speech` slipped through) to an exact match on the canonical TTS path - the single source of truth reused by both the gate and the downstream voice-default injection.
- Header discipline unchanged (only `Content-Type` + `Authorization` forwarded). Chat/voice happy paths are byte-identical.

### Spec-first: RED -> GREEN
- **Spec:** `features/voice/relay_allowlist.feature` (Gherkin, founder-approvable). Executable under godog via `internal/agent/relay_allowlist_bdd_test.go`, driving the **real** `serve()` against a **real** httptest backend that records whether it was hit.
- **RED (before the fix):** `35 scenarios (5 passed, 30 failed)` - the chat/speech/STT happy paths passed, but all **30** adversarial paths returned `200` because they **reached the backend** instead of being refused. That is the gap, demonstrated.
- **GREEN (after the fix):** `39 scenarios (39 passed)` · `225 steps (225 passed)` (adds the forgiving-normalization scenarios + the A4 header-discipline scenario).

### Adversarial refusal cases (all 404, backend never hit)
Dangerous routes (`/agents/run`, `/agents/{id}/run`, `/mcp/call`, `/memory/*`, `/pair`, `/secure/*`, `/admin/*`), traversal (`/v1/../agents/run`, `/v1/audio/speech/../run`, `//agents/run`, `/v1//agents/run`), case variants (`/V1/Chat/Completions`), absolute URLs / schemes (`http://…`, `file://`, `//host/…`), query/fragment-smuggled routes (`/v1/audio/speech?x=/agents/run`), percent-encoded traversal (`%2e%2e`, `%2f`, `%00`), lookalike suffixes (`/evil/audio/speech`, `/audio/speech`), and bare root `/`. Purely-lexical corners godog can't carry (inner whitespace, NUL/CR bytes, backslashes) plus the whitespace/trailing-slash **tolerance** are pinned in the table-driven `TestIsAllowedUpstreamPath` + `TestCleanUpstreamPath` (`internal/agent/relay_allowlist_test.go`).

Each refusal returns a clean 404 `{"error":"unsupported path"}` that leaks neither the upstream URL nor the key, and never crashes. Header discipline (A4) is asserted by a scenario: a forwarded request carries only the node's own `Content-Type` + `Authorization` (Job carries no headers, so a broker-supplied header can't ride along).

### Review
A fresh-context reviewer and the pre-push `claude-audit` both returned **PASS** (high confidence): the allowlist is correctly placed at the single `job.Path` consumer, the cleaned path is used everywhere downstream, no legitimate broker path is refused, and `serveStream` is safe by construction (ignores `job.Path`). The audit's one minor note (A4 lacked an asserting scenario) is addressed in this branch.

### Note on the empty path
The task list mentioned refusing "an empty path," but an **absent** `Path` is the documented chat back-compat (`protocol.go`; the broker's chat relay in `tunnel.go`/`concierge.go`/`probe.go` sets no `Path`). Refusing it would break **all** chat relay. So: an absent (or whitespace-only) path is treated as chat (→ chat upstream, always safe); a concrete non-canonical path like `/` is refused. Flagging this deviation for founder confirmation.

### Scope / where derivation happens
`serve()` is the **sole** place the node derives a local path from broker input. `serveStream()` posts to `cfg.Upstream` directly and ignores `job.Path` entirely (streaming is chat-only), so it needs no gate - confirmed safe by a fresh-context reviewer.

### Verify
- `go build ./...`, `go vet ./...` clean; gofmt clean.
- `go test ./internal/agent/` green; `-race` on the new + related serve tests green. (A pre-existing `-race` data race on the test-harness global `heartbeatInterval` in `TestStartCarriesBandID`/`TestHeartbeatServerErrorIsReconnecting` exists on base `69a8993`, unrelated to this change.)
- `internal/agent` coverage **92.8%**; `serve`, `cleanUpstreamPath`, `isAllowedUpstreamPath`, `isSpeechPath` each **100%**.
- `make cover-gate`: `internal/agent` clears the 90% bar. The gate's only red is a **flaky pre-existing** store money-path parity test (`TestChargebackWalletRecencyParity/postgres`, which passes on an isolated store re-run) - untouched by this agent-only change. Not bypassed with `COVER_GATE_SKIP`.
