### PR TITLE
fix(grants): reject negative grant price (credit-mint fix)

### DIFF
--- a/cmd/rogerai-broker/grant_price_safety_bdd_test.go
+++ b/cmd/rogerai-broker/grant_price_safety_bdd_test.go
@@ -1,0 +1,328 @@
+package main
+
+// grant_price_safety_bdd_test.go makes features/grants/grant_price_safety.feature an
+// EXECUTABLE Cucumber suite. It drives the REAL owner-auth grant HTTP path (b.grants ->
+// grantCreate / grantByID PATCH, signed exactly like grants_http_test.go) plus the billing
+// chokepoint (store.Grant.GrantPrice) and the settle math (store.HoldFor + Finalize) that a
+// negative price would exploit. Every assertion reads STORE state back.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+type gpsState struct {
+	db     *store.Mem
+	b      *broker
+	priv   ed25519.PrivateKey
+	pubHex string
+
+	code    int    // last HTTP status
+	body    string // last HTTP body
+	grantID string
+
+	// billing-chokepoint + settle regression
+	billIn, billOut float64
+	startBal        float64
+	endBal          float64
+	settledCost     float64
+}
+
+func (s *gpsState) reset() {
+	s.db = store.NewMem()
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s.priv = priv
+	s.pubHex = hex.EncodeToString(pub)
+	s.b = &broker{db: s.db, priv: priv, grantRL: loadRateLimiter(), rl: loadRateLimiter(), pubOfUser: map[string]string{}}
+	_ = s.db.BindOwner(store.Owner{GitHubID: 1, Login: "owner", Pubkey: s.pubHex})
+	s.code, s.body, s.grantID = 0, "", ""
+	s.billIn, s.billOut = 0, 0
+	s.startBal, s.endBal, s.settledCost = 0, 0, 0
+}
+
+func parseF(v string) float64 { f, _ := strconv.ParseFloat(v, 64); return f }
+
+// --- HTTP drivers -----------------------------------------------------------
+
+// post signs and drives POST /grants with the given body map.
+func (s *gpsState) post(body map[string]any) {
+	raw, _ := json.Marshal(body)
+	r := httptest.NewRequest(http.MethodPost, "/grants", bytes.NewReader(raw))
+	signReq(r, s.priv, raw)
+	w := httptest.NewRecorder()
+	s.b.grants(w, r)
+	s.code, s.body = w.Code, w.Body.String()
+}
+
+// patch signs and drives PATCH /grants/{id}.
+func (s *gpsState) patch(id string, body map[string]any) {
+	raw, _ := json.Marshal(body)
+	r := httptest.NewRequest(http.MethodPatch, "/grants/"+id, bytes.NewReader(raw))
+	signReq(r, s.priv, raw)
+	w := httptest.NewRecorder()
+	s.b.grants(w, r)
+	s.code, s.body = w.Code, w.Body.String()
+}
+
+func (s *gpsState) onlyGrant() (store.Grant, bool) {
+	gs, _ := s.db.GrantsByOwner(s.pubHex)
+	if len(gs) != 1 {
+		return store.Grant{}, false
+	}
+	return gs[0], true
+}
+
+// --- Given ------------------------------------------------------------------
+
+func (s *gpsState) ownerAuthed() error { return nil } // reset() already bound the owner
+
+func (s *gpsState) existingPricedGrant(in, out string) error {
+	s.post(map[string]any{"name": "priced", "free": false, "price_in": parseF(in), "price_out": parseF(out)})
+	if s.code != http.StatusOK {
+		return fmt.Errorf("setup create = %d, want 200: %s", s.code, s.body)
+	}
+	g, ok := s.onlyGrant()
+	if !ok {
+		return fmt.Errorf("setup: expected exactly one grant")
+	}
+	s.grantID = g.ID
+	return nil
+}
+
+// storedNegativeGrant plants a grant carrying a negative price DIRECTLY in the store,
+// simulating a legacy/corrupt row so the billing-chokepoint clamp is exercised end to end.
+// free/self select the early-return branches of GrantPrice (which precede the clamp).
+func (s *gpsState) storedNegativeGrant(in, out string) error {
+	return s.plantNegative(store.Grant{PriceIn: parseF(in), PriceOut: parseF(out)})
+}
+func (s *gpsState) storedNegativeFreeGrant(in, out string) error {
+	return s.plantNegative(store.Grant{Free: true, PriceIn: parseF(in), PriceOut: parseF(out)})
+}
+func (s *gpsState) storedNegativeSelfGrant(in, out string) error {
+	return s.plantNegative(store.Grant{Self: true, PriceIn: parseF(in), PriceOut: parseF(out)})
+}
+
+func (s *gpsState) plantNegative(g store.Grant) error {
+	g.ID, g.SecretHash, g.Owner, g.Label = "grant_neg", "h_neg", s.pubHex, "neg"
+	if err := s.db.CreateGrant(g); err != nil {
+		return err
+	}
+	s.grantID = g.ID
+	return nil
+}
+
+func (s *gpsState) ownerStartingBalance(v string) error {
+	s.startBal = parseF(v)
+	// Fund the owner's sponsor wallet (their unified account wallet).
+	w := s.b.ownerSponsorWallet(s.pubHex)
+	_, err := s.db.AddCredits(w, s.startBal)
+	return err
+}
+
+func (s *gpsState) ownerRunsNegativeGrant() error {
+	// A custom-priced grant with a NEGATIVE out-price, owned by this owner, bound to their node.
+	g := store.Grant{
+		ID: "grant_exploit", SecretHash: "h_exploit", Owner: s.pubHex, Label: "exploit",
+		Free: false, PriceIn: 0, PriceOut: -1000,
+	}
+	if err := s.db.CreateGrant(g); err != nil {
+		return err
+	}
+	s.grantID = g.ID
+	return nil
+}
+
+// --- When -------------------------------------------------------------------
+
+func (s *gpsState) mints(in, out string) error {
+	s.post(map[string]any{"name": "m", "free": false, "price_in": parseF(in), "price_out": parseF(out)})
+	return nil
+}
+
+func (s *gpsState) patchesOut(v string) error {
+	s.patch(s.grantID, map[string]any{"price_out": parseF(v)})
+	return nil
+}
+func (s *gpsState) patchesIn(v string) error {
+	s.patch(s.grantID, map[string]any{"price_in": parseF(v)})
+	return nil
+}
+func (s *gpsState) patchesRevoked() error {
+	s.patch(s.grantID, map[string]any{"revoked": true})
+	return nil
+}
+
+func (s *gpsState) readsBillingPrice() error {
+	g, ok := s.onlyGrant()
+	if !ok {
+		// stored-negative grant path plants a single grant too
+		gs, _ := s.db.GrantsByOwner(s.pubHex)
+		if len(gs) != 1 {
+			return fmt.Errorf("expected one grant to read the billing price of")
+		}
+		g = gs[0]
+	}
+	s.billIn, s.billOut = g.GrantPrice()
+	return nil
+}
+
+// settlesThroughGrant models exactly what the relay does for a custom-priced grant: the
+// OWNER's sponsor wallet is the payer, cost = tokens/1e6 * grant out-price, and the money is
+// captured via HoldFor + Finalize. 1,000,000 completion tokens keeps the math a clean multiple.
+func (s *gpsState) settlesThroughGrant() error {
+	gs, _ := s.db.GrantsByOwner(s.pubHex)
+	var g store.Grant
+	for _, cand := range gs {
+		if cand.ID == s.grantID {
+			g = cand
+		}
+	}
+	_, out := g.GrantPrice()
+	const outTokens = 1_000_000.0
+	s.settledCost = (outTokens / 1e6) * out
+	payer := s.b.ownerSponsorWallet(s.pubHex)
+	rec := protocol.UsageReceipt{RequestID: "req_exploit", Model: "m", CompletionTokens: int(outTokens)}
+	// Reserve a hold (an estimate the relay places up front), then finalize at the real cost.
+	held := 1.0
+	if _, err := s.db.HoldFor(payer, rec.RequestID, held); err != nil {
+		return err
+	}
+	bal, err := s.db.Finalize(payer, "node1", held, s.settledCost, 0, rec)
+	if err != nil {
+		return err
+	}
+	s.endBal = bal
+	return nil
+}
+
+// --- Then -------------------------------------------------------------------
+
+func (s *gpsState) rejectedWith(msg string) error {
+	if s.code != http.StatusBadRequest {
+		return fmt.Errorf("status = %d, want 400 (%q): %s", s.code, msg, s.body)
+	}
+	if !strings.Contains(s.body, msg) {
+		return fmt.Errorf("body %q does not contain %q", s.body, msg)
+	}
+	return nil
+}
+
+func (s *gpsState) noGrantCreated() error {
+	gs, _ := s.db.GrantsByOwner(s.pubHex)
+	if len(gs) != 0 {
+		return fmt.Errorf("expected 0 grants, found %d", len(gs))
+	}
+	return nil
+}
+
+func (s *gpsState) grantCreated() error {
+	if s.code != http.StatusOK {
+		return fmt.Errorf("status = %d, want 200: %s", s.code, s.body)
+	}
+	return nil
+}
+
+func (s *gpsState) grantUpdated() error {
+	if s.code != http.StatusOK {
+		return fmt.Errorf("status = %d, want 200: %s", s.code, s.body)
+	}
+	return nil
+}
+
+func (s *gpsState) storedHasPrice(in, out string) error {
+	g, ok := s.onlyGrant()
+	if !ok {
+		return fmt.Errorf("expected exactly one stored grant")
+	}
+	if g.PriceIn != parseF(in) || g.PriceOut != parseF(out) {
+		return fmt.Errorf("stored price = %v/%v, want %s/%s", g.PriceIn, g.PriceOut, in, out)
+	}
+	return nil
+}
+
+func (s *gpsState) billingInIs(v string) error {
+	if s.billIn != parseF(v) {
+		return fmt.Errorf("billing in = %v, want %s", s.billIn, v)
+	}
+	return nil
+}
+
+func (s *gpsState) billingOutIs(v string) error {
+	if s.billOut != parseF(v) {
+		return fmt.Errorf("billing out = %v, want %s", s.billOut, v)
+	}
+	return nil
+}
+
+func (s *gpsState) balanceNotIncreased() error {
+	if s.endBal > s.startBal+1e-9 {
+		return fmt.Errorf("balance rose from %v to %v through the settle (credit minted)", s.startBal, s.endBal)
+	}
+	return nil
+}
+
+func (s *gpsState) costNeverNegative() error {
+	if s.settledCost < 0 {
+		return fmt.Errorf("settled cost = %v, want >= 0", s.settledCost)
+	}
+	return nil
+}
+
+func TestGrantPriceSafetyBDD(t *testing.T) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			st := &gpsState{}
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				st.reset()
+				return ctx, nil
+			})
+			sc.Step(`^an owner authenticated to manage grants$`, st.ownerAuthed)
+			sc.Step(`^an existing grant with price_in (\S+) and price_out (\S+)$`, st.existingPricedGrant)
+			sc.Step(`^a grant whose stored price_in is (\S+) and price_out is (\S+)$`, st.storedNegativeGrant)
+			sc.Step(`^a free grant whose stored price_in is (\S+) and price_out is (\S+)$`, st.storedNegativeFreeGrant)
+			sc.Step(`^a self grant whose stored price_in is (\S+) and price_out is (\S+)$`, st.storedNegativeSelfGrant)
+			sc.Step(`^an owner with a starting balance of (\S+) credits$`, st.ownerStartingBalance)
+			sc.Step(`^that owner runs a negative-priced grant against their own node$`, st.ownerRunsNegativeGrant)
+
+			sc.Step(`^the owner mints a grant with price_in (\S+) and price_out (\S+)$`, st.mints)
+			sc.Step(`^the owner patches price_out to (\S+)$`, st.patchesOut)
+			sc.Step(`^the owner patches price_in to (\S+)$`, st.patchesIn)
+			sc.Step(`^the owner patches only revoked to true$`, st.patchesRevoked)
+			sc.Step(`^the billing price of the grant is read$`, st.readsBillingPrice)
+			sc.Step(`^a request settles through that grant$`, st.settlesThroughGrant)
+
+			sc.Step(`^the request is rejected with "([^"]*)"$`, st.rejectedWith)
+			sc.Step(`^no grant is created for that owner$`, st.noGrantCreated)
+			sc.Step(`^the grant is created$`, st.grantCreated)
+			sc.Step(`^the grant is updated$`, st.grantUpdated)
+			sc.Step(`^the stored grant has price_in (\S+) and price_out (\S+)$`, st.storedHasPrice)
+			sc.Step(`^the stored grant still has price_in (\S+) and price_out (\S+)$`, st.storedHasPrice)
+			sc.Step(`^the billing input price is (\S+)$`, st.billingInIs)
+			sc.Step(`^the billing output price is (\S+)$`, st.billingOutIs)
+			sc.Step(`^the owner's balance is not increased by the settle$`, st.balanceNotIncreased)
+			sc.Step(`^the settled cost is never negative$`, st.costNeverNegative)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/grants/grant_price_safety.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("grant price-safety scenarios failed (see godog output above)")
+	}
+}

--- a/cmd/rogerai-broker/grants_http.go
+++ b/cmd/rogerai-broker/grants_http.go
@@ -135,6 +135,14 @@ func (b *broker) grantCreate(w http.ResponseWriter, r *http.Request, owner store
 		jsonErr(w, http.StatusBadRequest, "name required")
 		return
 	}
+	// Price floor (money invariant): a grant can never carry a negative price. A custom-priced
+	// grant bills the OWNER's own sponsor wallet, so a negative price would CREDIT that wallet at
+	// settle (Finalize: balance += held - cost) - minting spendable balance. validateOfferInput is
+	// the same non-negative guard the public-market register path uses (grants have no schedule).
+	if msg := validateOfferInput(req.PriceIn, req.PriceOut, nil); msg != "" {
+		jsonErr(w, http.StatusBadRequest, msg)
+		return
+	}
 	// Free is the default; a custom price (and not --free) makes it priced.
 	free := true
 	if req.Free != nil {
@@ -222,6 +230,20 @@ func (b *broker) grantByID(w http.ResponseWriter, r *http.Request, id string) {
 		var patch store.GrantPatch
 		if json.Unmarshal(body, &patch) != nil {
 			jsonErr(w, http.StatusBadRequest, "bad patch")
+			return
+		}
+		// Same price floor as create: reject a negative price BEFORE it is persisted. Only the
+		// fields the patch actually carries are checked (a nil field means "leave unchanged", and
+		// any already-stored price passed create's guard).
+		pin, pout := 0.0, 0.0
+		if patch.PriceIn != nil {
+			pin = *patch.PriceIn
+		}
+		if patch.PriceOut != nil {
+			pout = *patch.PriceOut
+		}
+		if msg := validateOfferInput(pin, pout, nil); msg != "" {
+			jsonErr(w, http.StatusBadRequest, msg)
 			return
 		}
 		g, ok, err := b.db.UpdateGrant(id, owner.Pubkey, patch)

--- a/features/grants/grant_price_safety.feature
+++ b/features/grants/grant_price_safety.feature
@@ -1,0 +1,116 @@
+# GRANT PRICE SAFETY: a grant can NEVER carry a negative price. This is a money invariant.
+#
+# WHY THIS FILE EXISTS (known-vulnerable regression, 2026-07-08 pre-launch audit):
+#   The public-market registration path already rejects negative prices via
+#   validateOfferInput ("price cannot be negative", cmd/rogerai-broker/pricesafety.go), but the
+#   GRANT paths did NOT. grantCreate (cmd/rogerai-broker/grants_http.go) and UpdateGrant
+#   (internal/store/grant.go applyPatch, via PATCH /grants/{id}) stored price_in/price_out with
+#   no sign check. A custom-priced grant is billed to the OWNER's own unified wallet
+#   (resolvePricing -> ownerSponsorWallet, cmd/rogerai-broker/grant.go). At settle, cost =
+#   tokens * price and balance += held - cost, so a NEGATIVE price yields a NEGATIVE cost and
+#   CREDITS the owner's wallet - minting spendable balance the owner can then spend on OTHER
+#   operators' real nodes. This file pins the fix at both the boundary (mint + edit reject) and
+#   the billing chokepoint (Grant.GrantPrice never returns a negative), forever.
+#
+# GROUND TRUTH:
+#   - grantCreateReq.PriceIn/PriceOut (grants_http.go): create body.
+#   - store.GrantPatch.PriceIn/PriceOut (*float64, nil = leave unchanged): edit body.
+#   - store.Grant.GrantPrice() -> (in, out): the single price source every settle path reads.
+#   - The public ceiling ($50/$100 per 1M) is enforced SEPARATELY by registerPriceCeiling;
+#     this file is only about the negative-price floor.
+
+Feature: Grant price safety — a grant can never carry a negative price
+
+  # ---- Minting (POST /grants) rejects a negative price at the boundary ----
+
+  Rule: Minting a grant rejects a negative price and stores nothing
+
+    Scenario: Mint with a negative output price is rejected
+      Given an owner authenticated to manage grants
+      When the owner mints a grant with price_in 1 and price_out -5
+      Then the request is rejected with "price cannot be negative"
+      And no grant is created for that owner
+
+    Scenario: Mint with a negative input price is rejected
+      Given an owner authenticated to manage grants
+      When the owner mints a grant with price_in -1 and price_out 5
+      Then the request is rejected with "price cannot be negative"
+      And no grant is created for that owner
+
+    Scenario: Mint with both prices negative is rejected
+      Given an owner authenticated to manage grants
+      When the owner mints a grant with price_in -2 and price_out -3
+      Then the request is rejected with "price cannot be negative"
+      And no grant is created for that owner
+
+    Scenario Outline: A non-negative mint price is accepted
+      Given an owner authenticated to manage grants
+      When the owner mints a grant with price_in <in> and price_out <out>
+      Then the grant is created
+      And the stored grant has price_in <in> and price_out <out>
+
+      Examples:
+        | in | out |
+        | 0  | 0   |
+        | 0  | 10  |
+        | 2  | 3   |
+
+  # ---- Editing (PATCH /grants/{id}) rejects a negative price at the boundary ----
+
+  Rule: Editing a grant rejects a negative price and leaves the stored price unchanged
+
+    Scenario: Patching the output price negative is rejected
+      Given an existing grant with price_in 2 and price_out 3
+      When the owner patches price_out to -4
+      Then the request is rejected with "price cannot be negative"
+      And the stored grant still has price_in 2 and price_out 3
+
+    Scenario: Patching the input price negative is rejected
+      Given an existing grant with price_in 2 and price_out 3
+      When the owner patches price_in to -1
+      Then the request is rejected with "price cannot be negative"
+      And the stored grant still has price_in 2 and price_out 3
+
+    Scenario: Patching a price to a non-negative value is accepted
+      Given an existing grant with price_in 2 and price_out 3
+      When the owner patches price_out to 7
+      Then the grant is updated
+      And the stored grant has price_in 2 and price_out 7
+
+    Scenario: A patch that omits the price fields leaves the price unchanged
+      Given an existing grant with price_in 2 and price_out 3
+      When the owner patches only revoked to true
+      Then the grant is updated
+      And the stored grant still has price_in 2 and price_out 3
+
+  # ---- Billing chokepoint: even a negative stored price never bills negative ----
+
+  Rule: Billing never reads a negative grant price (defense in depth)
+
+    Scenario: A grant carrying a negative stored price resolves to a non-negative billing price
+      Given a grant whose stored price_in is -2 and price_out is -3
+      When the billing price of the grant is read
+      Then the billing input price is 0
+      And the billing output price is 0
+
+    # Free/Self grants short-circuit to 0/0 in GrantPrice BEFORE the clamp, so a stale negative
+    # price on one can never bill negative either - pinned so a refactor of that early return
+    # can't quietly reintroduce the mint.
+    Scenario: A free grant with a stale negative stored price still bills nothing
+      Given a free grant whose stored price_in is -2 and price_out is -3
+      When the billing price of the grant is read
+      Then the billing input price is 0
+      And the billing output price is 0
+
+    Scenario: A self grant with a stale negative stored price still bills nothing
+      Given a self grant whose stored price_in is -2 and price_out is -3
+      When the billing price of the grant is read
+      Then the billing input price is 0
+      And the billing output price is 0
+
+    Scenario: A negative-priced grant cannot mint spendable credits for its owner
+      Given an owner with a starting balance of 10 credits
+      And that owner runs a negative-priced grant against their own node
+      When a request settles through that grant
+      Then the owner's balance is not increased by the settle
+      And the settled cost is never negative

--- a/internal/store/grant.go
+++ b/internal/store/grant.go
@@ -63,12 +63,22 @@ func (g Grant) Expired(now time.Time) bool {
 }
 
 // GrantPrice returns the price the grant bills at: 0/0 for a free or self grant,
-// else its custom (PriceIn, PriceOut).
+// else its custom (PriceIn, PriceOut). A negative stored price is clamped to 0 here -
+// the billing chokepoint every settle path reads - so even a legacy/corrupt negative
+// row can never yield a negative cost (which Finalize would turn into a minted credit).
+// The HTTP create/edit paths reject a negative price outright; this is defense in depth.
 func (g Grant) GrantPrice() (in, out float64) {
 	if g.Free || g.Self {
 		return 0, 0
 	}
-	return g.PriceIn, g.PriceOut
+	in, out = g.PriceIn, g.PriceOut
+	if in < 0 {
+		in = 0
+	}
+	if out < 0 {
+		out = 0
+	}
+	return in, out
 }
 
 // applyPatch returns g with the non-nil patch fields applied.


### PR DESCRIPTION
Money-path fix, lifted onto clean main (cherry-picked from a stale branch so it does not revert today's merges). A custom-priced grant is billed to the OWNER's own sponsor wallet and Finalize settles as wallet += held - cost, so a negative price yields a negative cost and MINTS spendable balance the owner can spend on other operators' real nodes. The public-market register path guarded this; grantCreate and the PATCH edit path did not.

Fix (defense in depth):
- grantCreate rejects negative price_in/price_out via validateOfferInput.
- grantByID PATCH validates price fields before UpdateGrant.
- Grant.GrantPrice() clamps a negative stored price to 0 (the billing chokepoint every settle path reads), so even a legacy/corrupt row can never bill negative.

Spec-first: features/grants/grant_price_safety.feature (14 scenarios incl. the mint-credits regression + Free/Self stale-price cases) via grant_price_safety_bdd_test.go, driving the real owner-auth HTTP handlers, real store, and real HoldFor+Finalize. Push gate: cover-gate + claude-audit PASS.