### PR TITLE
web/broadcasts: caption the independence-v5 video (VTT track)

### DIFF
--- a/web/build.mjs
+++ b/web/build.mjs
@@ -165,7 +165,7 @@ function assetHash(rel) {
   return h;
 }
 function cacheBust(html) {
-  return html.replace(/((?:src|href|poster)=")((?:js|styles|assets)\/[^"?]+\.(?:js|css|mp4|gif|png|webp|svg|jpe?g|avif))"/g,
+  return html.replace(/((?:src|href|poster)=")((?:js|styles|assets)\/[^"?]+\.(?:js|css|mp4|vtt|gif|png|webp|svg|jpe?g|avif))"/g,
     (_, pre, rel) => `${pre}${rel}?v=${assetHash(rel)}"`);
 }
 

--- a/web/src/assets/broadcasts/independence-v5.vtt
+++ b/web/src/assets/broadcasts/independence-v5.vtt
@@ -1,0 +1,85 @@
+WEBVTT
+
+1
+00:00:00.000 --> 00:00:04.260
+If you're hearing this, you found the frequency.
+
+2
+00:00:04.900 --> 00:00:06.840
+For years, your words went up to their clouds.
+
+3
+00:00:07.260 --> 00:00:07.740
+Their silicon.
+
+4
+00:00:08.320 --> 00:00:09.440
+Their meter always running.
+
+5
+00:00:09.760 --> 00:00:12.050
+You rented intelligence by the drip, and you never owned
+
+6
+00:00:12.050 --> 00:00:12.520
+the receipt.
+
+7
+00:00:12.900 --> 00:00:13.380
+Not anymore.
+
+8
+00:00:13.900 --> 00:00:15.260
+Your GPU is a station.
+
+9
+00:00:15.680 --> 00:00:16.660
+Your model's your channel.
+
+10
+00:00:16.880 --> 00:00:17.860
+Every token signed.
+
+11
+00:00:18.180 --> 00:00:19.080
+Every receipt yours.
+
+12
+00:00:19.420 --> 00:00:20.020
+No landlord.
+
+13
+00:00:20.340 --> 00:00:21.400
+No meter you don't hold.
+
+14
+00:00:21.400 --> 00:00:23.480
+The airwaves belong to the operators.
+
+15
+00:00:24.040 --> 00:00:24.820
+Version 5.
+
+16
+00:00:25.200 --> 00:00:27.320
+Tune into a model or go on air with your own.
+
+17
+00:00:27.500 --> 00:00:30.380
+Now with voices, share a DJ, not just a brain.
+
+18
+00:00:30.920 --> 00:00:32.880
+One dial, both sides of the radio.
+
+19
+00:00:33.460 --> 00:00:35.760
+Roger AI, Independence Release.
+
+20
+00:00:36.300 --> 00:00:37.900
+Broadcasting July 4th.
+
+21
+00:00:38.180 --> 00:00:39.020
+Find your frequency.

--- a/web/src/broadcasts-independence-v5.html
+++ b/web/src/broadcasts-independence-v5.html
@@ -67,6 +67,7 @@
                  poster="assets/broadcasts/independence-v5-poster.webp"
                  aria-label="Independence Release Broadcast v5.0.0">
             <source src="assets/broadcasts/independence-v5.mp4" type="video/mp4" />
+            <track kind="captions" src="assets/broadcasts/independence-v5.vtt" srclang="en" label="English" default />
             <p class="bc-video__fallback mono">Your browser can&rsquo;t play this video. Download the broadcast: <a href="assets/broadcasts/independence-v5.mp4">independence-v5.mp4</a>.</p>
           </video>
         </div>


### PR DESCRIPTION
Captions the independence-v5 broadcast video: converts the caption to WebVTT (independence-v5.vtt, 21 cues), wires a <track kind=captions default> into the video element, and adds vtt to the build.mjs cacheBust list so edits do not serve stale at the Cloudflare edge. (A bare .srt would have been orphaned - HTML5 track needs VTT.) Build + smoke green.