### PR TITLE
fix(pricing): floor every price and token count

### DIFF
--- a/cmd/rogerai-broker/audio.go
+++ b/cmd/rogerai-broker/audio.go
@@ -357,7 +357,11 @@ func (b *broker) audioRelayCore(w http.ResponseWriter, r *http.Request, spec aud
 			pin = 0
 		}
 	}
-	cost := float64(units) * pin / 1e6
+	// Floor via the same chokepoint as the relay settle path (maxCost 0 = no upper cap here;
+	// audio's hold == cost, counted up front). units is broker-owned and pin is registration-
+	// floored, so this is defense in depth - it keeps the "cost is never negative/non-finite"
+	// invariant uniform at EVERY settle writer, not reliant on the cost > 0 guards below.
+	cost := clampSettleCost(float64(units)*pin/1e6, 0)
 	if pricing.free {
 		cost = 0
 	}

--- a/cmd/rogerai-broker/price_floor_bdd_test.go
+++ b/cmd/rogerai-broker/price_floor_bdd_test.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cucumber/godog"
 	"github.com/rogerai-fyi/roger/internal/protocol"
@@ -194,6 +195,25 @@ func (s *pfState) costPreparedForSettlement() error {
 	return nil
 }
 
+func (s *pfState) recountCompletion(n string) error {
+	s.entryComp = s.b.settleRecount("n1", "req_r", "m", "some completion text", int(parseF(n)))
+	return nil
+}
+func (s *pfState) recountPrompt(n string) error {
+	s.entryProm = s.b.settleRecountPrompt("n1", "req_r", "m", "some prompt text", int(parseF(n)), 100)
+	return nil
+}
+
+func (s *pfState) persistedNegativeNode() error {
+	reg := protocol.NodeRegistration{
+		NodeID: "n1", PubKey: s.nodePubHex, BridgeToken: "tok", TS: time.Now().Unix(),
+		Offers: []protocol.ModelOffer{{Model: "m", Ctx: 4096, PriceOut: -1000}},
+	}
+	return s.b.db.(*store.Mem).UpsertNode(store.NodeRecord{NodeID: "n1", Reg: reg, LastSeen: time.Now().Unix()})
+}
+
+func (s *pfState) rehydrates() error { s.b.rehydrateNodes(); return nil }
+
 // --- Then -------------------------------------------------------------------
 
 func (s *pfState) rejectedWith(msg string) error {
@@ -254,6 +274,13 @@ func (s *pfState) billedCompletionIs(n string) error {
 	}
 	return nil
 }
+func (s *pfState) billedPromptIs(n string) error {
+	want := int(parseF(n))
+	if s.entryProm != want {
+		return fmt.Errorf("billed prompt tokens = %d, want %d", s.entryProm, want)
+	}
+	return nil
+}
 
 func (s *pfState) costAppliedIs(v string) error {
 	if s.appliedCost != parseF(v) {
@@ -284,6 +311,10 @@ func TestPriceFloorBDD(t *testing.T) {
 			sc.Step(`^the node returns a receipt claiming (\S+) completion tokens$`, st.returnsCompletionTokens)
 			sc.Step(`^the node returns a receipt claiming (\S+) prompt tokens$`, st.returnsPromptTokens)
 			sc.Step(`^the node returns a receipt claiming (\S+) prompt and (\S+) completion tokens$`, st.returnsBothTokens)
+			sc.Step(`^the relay re-counts a claim of (\S+) completion tokens$`, st.recountCompletion)
+			sc.Step(`^the relay re-counts a claim of (\S+) prompt tokens$`, st.recountPrompt)
+			sc.Step(`^a persisted node registration carrying a negative output price$`, st.persistedNegativeNode)
+			sc.Step(`^the broker re-hydrates its node registry$`, st.rehydrates)
 			sc.Step(`^the node claims (\S+) completion tokens$`, st.nodeClaimsCompletion)
 			sc.Step(`^a request settles at a computed cost of (\S+) credits$`, st.settlesAtCost)
 			sc.Step(`^the cost is prepared for settlement$`, st.costPreparedForSettlement)
@@ -297,6 +328,8 @@ func TestPriceFloorBDD(t *testing.T) {
 			sc.Step(`^the recorded completion tokens are not negative$`, st.recordedCompletionNotNegative)
 			sc.Step(`^the recorded prompt tokens are not negative$`, st.recordedPromptNotNegative)
 			sc.Step(`^the billed completion tokens are (\S+)$`, st.billedCompletionIs)
+			sc.Step(`^the billed completion count is (\S+)$`, st.billedCompletionIs)
+			sc.Step(`^the billed prompt count is (\S+)$`, st.billedPromptIs)
 			sc.Step(`^the settled cost applied is (\S+)$`, st.costAppliedIs)
 			sc.Step(`^the cost applied is (\S+)$`, st.costAppliedIs)
 		},

--- a/cmd/rogerai-broker/price_floor_bdd_test.go
+++ b/cmd/rogerai-broker/price_floor_bdd_test.go
@@ -1,0 +1,313 @@
+package main
+
+// price_floor_bdd_test.go makes features/pricing/price_floor.feature EXECUTABLE. It drives the
+// REAL paths that a negative price / negative token count would exploit:
+//   - node registration via registerWith (the public #1 sibling of the grant-price mint),
+//   - the settle cost clamp via clampSettleCost (the extracted relay chokepoint),
+//   - the recorded token counts via a real Finalize read back with EntriesByUser (the
+//     billedTokens floor).
+// Every assertion reads broker/store state back. parseF lives in grant_price_safety_bdd_test.go
+// (same package).
+
+import (
+	"context"
+	"crypto/ed25519"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+type pfState struct {
+	t *testing.T
+
+	b          *broker
+	userPriv   ed25519.PrivateKey
+	nodePriv   ed25519.PrivateKey
+	nodePubHex string
+
+	offer    protocol.ModelOffer
+	signUser bool
+	code     int
+	msg      string
+
+	// settle / token axis
+	payer       string
+	startBal    float64
+	endBal      float64
+	appliedCost float64
+	maxCost     float64
+	rec         protocol.UsageReceipt
+	entryProm   int
+	entryComp   int
+}
+
+func (s *pfState) reset() {
+	s.b, s.userPriv, s.nodePriv, s.nodePubHex = newBandBroker(s.t)
+	s.offer = protocol.ModelOffer{Model: "m", Ctx: 4096}
+	s.signUser = true
+	s.code, s.msg = 0, ""
+	s.payer = "cons"
+	s.startBal, s.endBal, s.appliedCost = 0, 0, 0
+	s.maxCost = 1000
+	s.rec = protocol.UsageReceipt{}
+	s.entryProm, s.entryComp = 0, 0
+}
+
+// fund gives the consumer wallet a real starting balance.
+func (s *pfState) fund(v float64) error {
+	s.startBal = v
+	_, err := s.b.db.(*store.Mem).AddCredits(s.payer, v)
+	return err
+}
+
+// doRegister drives the real register handler with the current offer + signUser flag.
+func (s *pfState) doRegister() error {
+	s.code, s.msg = registerWith(s.t, s.b, "n1", s.nodePriv, s.nodePubHex, s.userPriv, s.signUser, s.offer, false, false)
+	return nil
+}
+
+// settleReceipt models the relay: cost = clampSettleCost(CostWith2(claimed tokens)), then a real
+// Finalize captures it. Uses held=0 to isolate the cost SIGN (endBal = startBal - appliedCost),
+// so a negative cost that escaped the floor would show up as a raised balance.
+func (s *pfState) settleReceipt() error {
+	s.rec.RequestID = "req_pf"
+	s.appliedCost = clampSettleCost(s.rec.CostWith2(s.rec.PromptTokens, s.rec.CompletionTokens), s.maxCost)
+	bal, err := s.b.db.Finalize(s.payer, "n1", 0, s.appliedCost, 0, s.rec)
+	if err != nil {
+		return err
+	}
+	s.endBal = bal
+	// Read the recorded entry back (records billedTokens) to assert the counts are floored.
+	es, err := s.b.db.EntriesByUser(s.payer, 0, 1<<62)
+	if err != nil {
+		return err
+	}
+	for _, e := range es {
+		if e.RequestID == s.rec.RequestID {
+			s.entryProm, s.entryComp = e.PromptTokens, e.CompletionTokens
+		}
+	}
+	return nil
+}
+
+// --- Given ------------------------------------------------------------------
+
+func (s *pfState) ownerRegOutPrice(v string) error {
+	s.offer.PriceOut = parseF(v)
+	s.signUser = true
+	return nil
+}
+func (s *pfState) ownerRegInPrice(v string) error {
+	s.offer.PriceIn = parseF(v)
+	s.signUser = true
+	return nil
+}
+
+func (s *pfState) ownerRegWindowPrice(v string) error {
+	s.offer.Schedule = []protocol.PriceWindow{{
+		Start: "00:00", End: "23:59", Days: []int{0, 1, 2, 3, 4, 5, 6}, Out: parseF(v),
+	}}
+	s.signUser = true
+	return nil
+}
+
+func (s *pfState) anonRegOutPrice(v string) error {
+	s.offer.PriceOut = parseF(v)
+	s.signUser = false
+	return nil
+}
+func (s *pfState) anonRegFree(v string) error {
+	s.offer.PriceOut = parseF(v)
+	s.signUser = false
+	return nil
+}
+
+func (s *pfState) pricedOfferAndConsumer(v string) error {
+	s.rec.PriceIn, s.rec.PriceOut = 1000, 1000
+	return s.fund(parseF(v))
+}
+
+func (s *pfState) pricedOfferAndRecount(n string) error {
+	s.rec.PriceIn, s.rec.PriceOut = 1000, 1000
+	s.rec.BrokerCompletionTokens = int(parseF(n))
+	return s.fund(10)
+}
+
+func (s *pfState) consumerBalance(v string) error { return s.fund(parseF(v)) }
+
+func (s *pfState) requestCostNotFinite() error {
+	s.rec.RequestID = "req_inf"
+	return nil
+}
+
+// --- When -------------------------------------------------------------------
+
+func (s *pfState) registeredPublic() error { return s.doRegister() }
+
+func (s *pfState) returnsCompletionTokens(n string) error {
+	s.rec.CompletionTokens = int(parseF(n))
+	return s.settleReceipt()
+}
+func (s *pfState) returnsPromptTokens(n string) error {
+	s.rec.PromptTokens = int(parseF(n))
+	return s.settleReceipt()
+}
+func (s *pfState) returnsBothTokens(p, c string) error {
+	s.rec.PromptTokens = int(parseF(p))
+	s.rec.CompletionTokens = int(parseF(c))
+	return s.settleReceipt()
+}
+
+func (s *pfState) nodeClaimsCompletion(n string) error {
+	s.rec.CompletionTokens = int(parseF(n))
+	s.rec.RequestID = "req_recount"
+	if _, err := s.b.db.Finalize(s.payer, "n1", 0, 0, 0, s.rec); err != nil {
+		return err
+	}
+	es, _ := s.b.db.EntriesByUser(s.payer, 0, 1<<62)
+	for _, e := range es {
+		if e.RequestID == s.rec.RequestID {
+			s.entryComp = e.CompletionTokens
+		}
+	}
+	return nil
+}
+
+func (s *pfState) settlesAtCost(v string) error {
+	s.rec.RequestID = "req_floor"
+	s.appliedCost = clampSettleCost(parseF(v), s.maxCost)
+	bal, err := s.b.db.Finalize(s.payer, "n1", 0, s.appliedCost, 0, s.rec)
+	if err != nil {
+		return err
+	}
+	s.endBal = bal
+	return nil
+}
+
+func (s *pfState) costPreparedForSettlement() error {
+	s.appliedCost = clampSettleCost(math.Inf(1), s.maxCost)
+	return nil
+}
+
+// --- Then -------------------------------------------------------------------
+
+func (s *pfState) rejectedWith(msg string) error {
+	if s.code != 400 {
+		return fmt.Errorf("register = %d, want 400 (%q); msg=%q", s.code, msg, s.msg)
+	}
+	if !strings.Contains(s.msg, msg) {
+		return fmt.Errorf("rejection %q does not contain %q", s.msg, msg)
+	}
+	return nil
+}
+
+func (s *pfState) notOnMarket() error {
+	if p := s.b.liveModelProviders()["m"]; p != 0 {
+		return fmt.Errorf("model m has %d providers on the market, want 0 (rejected node must not appear)", p)
+	}
+	return nil
+}
+
+func (s *pfState) accepted() error {
+	if s.code != 200 {
+		return fmt.Errorf("register = %d, want 200; msg=%q", s.code, s.msg)
+	}
+	return nil
+}
+
+func (s *pfState) costNotNegative() error {
+	if s.appliedCost < 0 {
+		return fmt.Errorf("settled cost = %v, want >= 0", s.appliedCost)
+	}
+	return nil
+}
+
+func (s *pfState) balanceNotIncreased() error {
+	if s.endBal > s.startBal+1e-9 {
+		return fmt.Errorf("balance rose from %v to %v through the settle (credit minted)", s.startBal, s.endBal)
+	}
+	return nil
+}
+
+func (s *pfState) recordedCompletionNotNegative() error {
+	if s.entryComp < 0 {
+		return fmt.Errorf("recorded completion tokens = %d, want >= 0", s.entryComp)
+	}
+	return nil
+}
+func (s *pfState) recordedPromptNotNegative() error {
+	if s.entryProm < 0 {
+		return fmt.Errorf("recorded prompt tokens = %d, want >= 0", s.entryProm)
+	}
+	return nil
+}
+
+func (s *pfState) billedCompletionIs(n string) error {
+	want := int(parseF(n))
+	if s.entryComp != want {
+		return fmt.Errorf("billed completion tokens = %d, want %d", s.entryComp, want)
+	}
+	return nil
+}
+
+func (s *pfState) costAppliedIs(v string) error {
+	if s.appliedCost != parseF(v) {
+		return fmt.Errorf("applied cost = %v, want %s", s.appliedCost, v)
+	}
+	return nil
+}
+
+func TestPriceFloorBDD(t *testing.T) {
+	st := &pfState{t: t}
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				st.reset()
+				return ctx, nil
+			})
+			sc.Step(`^an owner registers a node with output price (\S+) per 1M$`, st.ownerRegOutPrice)
+			sc.Step(`^an owner registers a node with input price (\S+) per 1M$`, st.ownerRegInPrice)
+			sc.Step(`^an owner registers a node whose scheduled window price is (\S+) per 1M$`, st.ownerRegWindowPrice)
+			sc.Step(`^an anonymous \(unsigned\) node registers with output price (\S+) per 1M$`, st.anonRegOutPrice)
+			sc.Step(`^an anonymous \(unsigned\) node registers free at (\S+) per 1M$`, st.anonRegFree)
+			sc.Step(`^a priced offer and a consumer with a starting balance of (\S+) credits$`, st.pricedOfferAndConsumer)
+			sc.Step(`^a priced offer and a broker re-count of (\S+) completion tokens$`, st.pricedOfferAndRecount)
+			sc.Step(`^a consumer with a starting balance of (\S+) credits$`, st.consumerBalance)
+			sc.Step(`^a request whose computed cost is not finite$`, st.requestCostNotFinite)
+
+			sc.Step(`^the node is registered as a public station$`, st.registeredPublic)
+			sc.Step(`^the node returns a receipt claiming (\S+) completion tokens$`, st.returnsCompletionTokens)
+			sc.Step(`^the node returns a receipt claiming (\S+) prompt tokens$`, st.returnsPromptTokens)
+			sc.Step(`^the node returns a receipt claiming (\S+) prompt and (\S+) completion tokens$`, st.returnsBothTokens)
+			sc.Step(`^the node claims (\S+) completion tokens$`, st.nodeClaimsCompletion)
+			sc.Step(`^a request settles at a computed cost of (\S+) credits$`, st.settlesAtCost)
+			sc.Step(`^the cost is prepared for settlement$`, st.costPreparedForSettlement)
+
+			sc.Step(`^the registration is rejected with "([^"]*)"$`, st.rejectedWith)
+			sc.Step(`^the node does not appear on the market$`, st.notOnMarket)
+			sc.Step(`^no anonymous negative-priced node is on the market$`, st.notOnMarket)
+			sc.Step(`^the registration is accepted$`, st.accepted)
+			sc.Step(`^the settled cost is not negative$`, st.costNotNegative)
+			sc.Step(`^the consumer balance is not increased by the settle$`, st.balanceNotIncreased)
+			sc.Step(`^the recorded completion tokens are not negative$`, st.recordedCompletionNotNegative)
+			sc.Step(`^the recorded prompt tokens are not negative$`, st.recordedPromptNotNegative)
+			sc.Step(`^the billed completion tokens are (\S+)$`, st.billedCompletionIs)
+			sc.Step(`^the settled cost applied is (\S+)$`, st.costAppliedIs)
+			sc.Step(`^the cost applied is (\S+)$`, st.costAppliedIs)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/pricing/price_floor.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("price-floor scenarios failed (see godog output above)")
+	}
+}

--- a/cmd/rogerai-broker/pricesafety.go
+++ b/cmd/rogerai-broker/pricesafety.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -40,6 +41,39 @@ func effectiveRelayMaxOut(reqMaxOut float64) float64 {
 		return reqMaxOut
 	}
 	return consumerDefaultMaxOut()
+}
+
+// clampSettleCost bounds a computed settle cost on BOTH sides before it is captured. The
+// LOWER bound is a money invariant: Finalize does `wallet += held - cost`, so a negative (or
+// non-finite) cost would MINT spendable credit into the consumer's wallet - the same class as
+// the negative-price / negative-token mints. It floors to 0. The UPPER bound is maxCost (>0),
+// the consumer's authorized hold, so the broker never captures more than was authorized.
+func clampSettleCost(cost, maxCost float64) float64 {
+	if math.IsNaN(cost) || math.IsInf(cost, 0) || cost < 0 {
+		return 0
+	}
+	if maxCost > 0 && cost > maxCost {
+		cost = maxCost
+	}
+	return cost
+}
+
+// registerPriceFloor is the symmetric twin of registerPriceCeiling: it rejects a NEGATIVE base
+// or scheduled-window price on any offer. The register path bounded prices only ABOVE (the
+// ceiling); a negative price passed, was not treated as "priced" (so it skipped the login
+// gate), and settled to a negative cost that mints. Returns "" when every price is >= 0.
+func registerPriceFloor(offers []protocol.ModelOffer) string {
+	for _, o := range offers {
+		if o.PriceIn < 0 || o.PriceOut < 0 {
+			return "price cannot be negative"
+		}
+		for _, win := range o.Schedule {
+			if !win.Free && (win.In < 0 || win.Out < 0) {
+				return "schedule window price cannot be negative"
+			}
+		}
+	}
+	return ""
 }
 
 // registerPriceCeiling returns a non-empty rejection message if any offer (base price

--- a/cmd/rogerai-broker/recount.go
+++ b/cmd/rogerai-broker/recount.go
@@ -127,6 +127,9 @@ func (c recountConfig) sidecarCount(model, text string) (tokens int, exact bool,
 // goroutine (OFF the hot path), reusing this single sidecar result so the relay path
 // never double-calls the sidecar. Returns `claimed` immediately when re-count is off.
 func (b *broker) settleRecount(nodeID, requestID, model, completion string, claimed int) int {
+	if claimed < 0 {
+		claimed = 0 // a negative node-claimed count never bills, records, signs, or logs negative
+	}
 	if !b.recount.enabled() || completion == "" || claimed <= 0 {
 		return claimed
 	}
@@ -160,6 +163,9 @@ func (b *broker) settleRecount(nodeID, requestID, model, completion string, clai
 // It never inflates a claim (we only ever bill the lesser count), and it returns the
 // claim unchanged when re-count is off and the byte floor was not breached.
 func (b *broker) settleRecountPrompt(nodeID, requestID, model, prompt string, claimed, bodyLen int) int {
+	if claimed < 0 {
+		claimed = 0 // a negative node-claimed count never bills, records, signs, or logs negative
+	}
 	// Defense 1: the zero-doubt byte floor (no sidecar needed). Clamp billing to the only
 	// physically-possible upper bound ALWAYS (safe for the consumer, makes input inflation
 	// unprofitable), but only PERMABAN when the claim exceeds the body by more than any

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -1083,6 +1083,18 @@ func (b *broker) rehydrateNodes() {
 		// claim from an old release); rec.Confidential is the broker's stored VERDICT, so
 		// re-hydrate memory + the mirror re-publish below with the verdict, never the claim.
 		reg.Confidential = rec.Confidential
+		// Drop a persisted reg that violates the price floor or ceiling (e.g. a pre-fix
+		// negative-price row): re-ingesting it would let it rejoin the market and win
+		// cheapest-first routing. Mint-safe (clampSettleCost floors the cost), but a bad
+		// price must not resurface across a restart - the same bounds register enforces.
+		if msg := registerPriceFloor(reg.Offers); msg != "" {
+			log.Printf("re-hydrate: dropping node %s (persisted price below floor: %s)", reg.NodeID, msg)
+			continue
+		}
+		if msg := registerPriceCeiling(reg.Offers); msg != "" {
+			log.Printf("re-hydrate: dropping node %s (persisted price above ceiling: %s)", reg.NodeID, msg)
+			continue
+		}
 		b.nodes[reg.NodeID] = reg
 		b.lastSeen[reg.NodeID] = time.Unix(rec.LastSeen, 0)
 		b.confidential[reg.NodeID] = rec.Confidential

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -229,6 +229,14 @@ func (b *broker) register(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, http.StatusBadRequest, msg)
 		return
 	}
+	// ...and the symmetric FLOOR: a negative price would settle to a negative cost that mints
+	// credit (Finalize: wallet += held - cost), and a negative price is not "priced" so it would
+	// also skip the login-to-monetize gate below - an anonymous mint. Runs unconditionally here
+	// alongside the ceiling.
+	if msg := registerPriceFloor(reg.Offers); msg != "" {
+		jsonErr(w, http.StatusBadRequest, msg)
+		return
+	}
 	// Login-to-monetize / login-to-go-private: a node advertising a NONZERO price is
 	// an earning node, AND a node going PRIVATE (its own discovery visibility is a
 	// per-owner resource) both HARD-REQUIRE a GitHub-linked owner bound to the signing
@@ -1765,10 +1773,7 @@ func (b *broker) relay(w http.ResponseWriter, r *http.Request) {
 			// SignBroker is called AFTER the broker counts are assigned so the broker
 			// counter-signature covers them (the node-sig excludes them via signingBytes).
 			rec.SignBroker(b.priv)
-			cost := rec.CostWith2(billedPrompt, billedCompletion)
-			if maxCost > 0 && cost > maxCost {
-				cost = maxCost // never capture more than was authorized
-			}
+			cost := clampSettleCost(rec.CostWith2(billedPrompt, billedCompletion), maxCost)
 			newBal, ferr := b.settleRequest(payer, node.NodeID, maxCost, cost, rec, grantID, pricing.free)
 			if ferr != nil {
 				// Settle failed - leave settled=false so the deferred ReleaseHold
@@ -2090,10 +2095,7 @@ func (b *broker) relayStream(w http.ResponseWriter, t *nodeTunnel, node protocol
 			rec.BrokerPromptTokens, rec.BrokerCompletionTokens = billedPrompt, billedCompletion
 			// SignBroker AFTER the broker counts are assigned (covers them).
 			rec.SignBroker(b.priv)
-			cost := rec.CostWith2(billedPrompt, billedCompletion)
-			if maxCost > 0 && cost > maxCost {
-				cost = maxCost
-			}
+			cost := clampSettleCost(rec.CostWith2(billedPrompt, billedCompletion), maxCost)
 			if _, ferr := b.settleRequest(user, node.NodeID, maxCost, cost, rec, grantID, pricing.free); ferr != nil {
 				// settle failed - leave settled=false so the deferred ReleaseHold refunds
 				log.Printf("stream settle FAILED user=%s node=%s: %v - releasing hold", user, node.NodeID, ferr)

--- a/features/pricing/price_floor.feature
+++ b/features/pricing/price_floor.feature
@@ -1,0 +1,122 @@
+# GLOBAL PRICE FLOOR: the symmetric twin of the price CEILING. Every price and every token
+# count that feeds the cost multiplication must be bounded BELOW (>= 0, and finite), because
+# settle computes `cost = tokens * price / 1e6` and Finalize does `wallet += held - cost` -
+# so a NEGATIVE cost (from a negative price OR a negative token count) MINTS spendable credit
+# into a wallet. The codebase already bounds these values ABOVE (registerPriceCeiling, the
+# cost > maxCost clamp, the recount that only LOWERS a token claim); this file pins the
+# missing lower bound.
+#
+# WHY THIS FILE EXISTS (2026-07-08 adversarial sweep, siblings of the grant-price mint):
+#   GRANT price (fixed): features/grants/grant_price_safety.feature.
+#   #1 REGISTER price (this file): cmd/rogerai-broker/tunnel.go register runs ONLY
+#     registerPriceCeiling (upper). A negative price passes; worse, offersPriced tests `> 0`
+#     so a negative price is not even "priced" -> the login-to-monetize gate (tunnel.go)
+#     does not fire -> an ANONYMOUS node can register it. pickFor prefers the "cheapest",
+#     routing a consumer to it; CostWith2 (internal/protocol/protocol.go) returns a negative
+#     cost; the cost > maxCost clamp is upper-only; Finalize (internal/store/store.go) mints
+#     to the CONSUMER's wallet. This is the public, consumer-facing, anonymous variant.
+#   #2 TOKEN counts (this file): billedTokens (internal/store/store.go) sets
+#     promptTok = rec.PromptTokens (node-supplied int) and the broker recount only replaces
+#     it when strictly LOWER - never floors a negative. A node-signed receipt claiming a
+#     negative completion/prompt count yields a negative cost and mints the same way. The
+#     void gate (recount.go) checks completion TEXT, not the token sign, so it does not stop it.
+#
+# GROUND TRUTH: cmd/rogerai-broker/tunnel.go (register, settle), pricesafety.go
+#   (validateOfferInput = the non-negative guard; registerPriceCeiling = the upper one),
+#   internal/protocol/protocol.go (ActivePrice, CostWith2), internal/store/store.go
+#   (billedTokens, Finalize: wallet += held - cost).
+
+Feature: Global price floor — no price or token count can be negative (never mint)
+
+  # ---- #1: node registration rejects a negative price (the public sibling of the ceiling) ----
+
+  Rule: A public node registration rejects a negative price
+
+    Scenario: A node registering with a negative output price is rejected
+      Given an owner registers a node with output price -1000 per 1M
+      When the node is registered as a public station
+      Then the registration is rejected with "price cannot be negative"
+      And the node does not appear on the market
+
+    Scenario: A node registering with a negative input price is rejected
+      Given an owner registers a node with input price -50 per 1M
+      When the node is registered as a public station
+      Then the registration is rejected with "price cannot be negative"
+      And the node does not appear on the market
+
+    Scenario: A negative scheduled-window price is rejected
+      Given an owner registers a node whose scheduled window price is -10 per 1M
+      When the node is registered as a public station
+      Then the registration is rejected with "price cannot be negative"
+
+    Scenario: A negative price is not treated as free and cannot skip the login gate
+      Given an anonymous (unsigned) node registers with output price -1000 per 1M
+      When the node is registered as a public station
+      Then the registration is rejected with "price cannot be negative"
+      And no anonymous negative-priced node is on the market
+
+    Scenario: A free (0/0) public registration is still accepted with no login
+      Given an anonymous (unsigned) node registers free at 0 per 1M
+      When the node is registered as a public station
+      Then the registration is accepted
+
+    Scenario: A within-bounds positive price is accepted
+      Given an owner registers a node with output price 5 per 1M
+      When the node is registered as a public station
+      Then the registration is accepted
+
+  # ---- #2: a node-signed receipt with a negative token count never mints ----
+
+  Rule: A settled receipt never bills a negative token count
+
+    Scenario: A receipt claiming negative completion tokens does not mint
+      Given a priced offer and a consumer with a starting balance of 10 credits
+      When the node returns a receipt claiming -1000000 completion tokens
+      Then the settled cost is not negative
+      And the consumer balance is not increased by the settle
+      And the recorded completion tokens are not negative
+
+    Scenario: A receipt claiming negative prompt tokens does not mint
+      Given a priced offer and a consumer with a starting balance of 10 credits
+      When the node returns a receipt claiming -1000000 prompt tokens
+      Then the settled cost is not negative
+      And the consumer balance is not increased by the settle
+      And the recorded prompt tokens are not negative
+
+    Scenario: A positive over-report is still recounted DOWN, never up (regression pin)
+      Given a priced offer and a broker re-count of 100 completion tokens
+      When the node claims 5000 completion tokens
+      Then the billed completion tokens are 100
+
+    Scenario: A negative broker re-count is ignored and the claim is used (then floored)
+      Given a priced offer and a broker re-count of -5 completion tokens
+      When the node claims 100 completion tokens
+      Then the billed completion tokens are 100
+
+    Scenario: A receipt with BOTH token axes negative does not mint
+      Given a priced offer and a consumer with a starting balance of 10 credits
+      When the node returns a receipt claiming -500 prompt and -500 completion tokens
+      Then the settled cost is not negative
+      And the consumer balance is not increased by the settle
+      And the recorded prompt tokens are not negative
+      And the recorded completion tokens are not negative
+
+  # ---- Defense in depth: the settled cost is bounded below by zero ----
+
+  Rule: Settlement cost is floored at zero
+
+    Scenario: A negative computed cost is floored to zero before it debits a wallet
+      Given a consumer with a starting balance of 10 credits
+      When a request settles at a computed cost of -500 credits
+      Then the settled cost applied is 0
+      And the consumer balance is not increased by the settle
+
+    Scenario: A non-finite price never reaches a wallet
+      Given a request whose computed cost is not finite
+      When the cost is prepared for settlement
+      Then the cost applied is 0
+
+    Scenario: A cost above the authorized maximum is still capped at the maximum (upper bound intact)
+      Given a consumer with a starting balance of 10 credits
+      When a request settles at a computed cost of 5000 credits
+      Then the settled cost applied is 1000

--- a/features/pricing/price_floor.feature
+++ b/features/pricing/price_floor.feature
@@ -65,6 +65,13 @@ Feature: Global price floor — no price or token count can be negative (never m
       When the node is registered as a public station
       Then the registration is accepted
 
+    # A restart re-hydrates persisted registrations; the same floor must gate that ingest so a
+    # pre-fix negative-price row cannot rejoin the market and win cheapest-first routing.
+    Scenario: A persisted node with a negative price is dropped on re-hydrate
+      Given a persisted node registration carrying a negative output price
+      When the broker re-hydrates its node registry
+      Then the node does not appear on the market
+
   # ---- #2: a node-signed receipt with a negative token count never mints ----
 
   Rule: A settled receipt never bills a negative token count
@@ -100,6 +107,14 @@ Feature: Global price floor — no price or token count can be negative (never m
       And the consumer balance is not increased by the settle
       And the recorded prompt tokens are not negative
       And the recorded completion tokens are not negative
+
+    # The floor is applied at the re-count source, so a negative claim can never leak into the
+    # response headers, the logs, or the broker-SIGNED token counts either - not just the ledger.
+    Scenario: A negative claimed token count is floored before headers, logs, and the broker signature
+      When the relay re-counts a claim of -1000000 completion tokens
+      And the relay re-counts a claim of -1000000 prompt tokens
+      Then the billed completion count is 0
+      And the billed prompt count is 0
 
   # ---- Defense in depth: the settled cost is bounded below by zero ----
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -979,6 +979,15 @@ func billedTokens(rec protocol.UsageReceipt) (promptTok, completionTok int) {
 	if rec.BrokerCompletionTokens > 0 && rec.BrokerCompletionTokens < completionTok {
 		completionTok = rec.BrokerCompletionTokens
 	}
+	// Floor at 0: a node-signed receipt claiming a NEGATIVE count would otherwise record a
+	// negative billed count and (via CostWith2) a negative cost that mints. The broker recount
+	// only ever LOWERS a claim, so it never restores a floored value.
+	if promptTok < 0 {
+		promptTok = 0
+	}
+	if completionTok < 0 {
+		completionTok = 0
+	}
 	return promptTok, completionTok
 }
 


### PR DESCRIPTION
Floors negative prices + token counts across the register, window, audio, recount, and re-hydrate paths (the credit-mint sibling class beyond the grant fix already merged). Pinned by features/pricing/price_floor.feature + price_floor_bdd_test.go. Lifted cleanly onto current main from a stale branch (so it reverts nothing). Detail: rogerai-internal-docs.