### PR TITLE
release: v5.2.2 prep (ship the relay path allowlist)

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -40,7 +40,7 @@ import (
 //
 // The default below is the fallback for a plain `go build`. Keep it in sync with
 // releases. Use semver, optionally with a prerelease suffix (e.g. 4.8.0-beta.1).
-var Version = "5.2.1"
+var Version = "5.2.2"
 
 // The production broker is the default - `rogerai` works out of the box, no config.
 // Override per-session with ROGER_BROKER=... or persist with `roger config set broker`.

--- a/web/src/manual.html
+++ b/web/src/manual.html
@@ -35,7 +35,7 @@
         </p>
         <div class="man-cover__meta">
           <span>Set: <b>rogerai</b></span>
-          <span>Version: <b data-cli-version>v5.2.1</b></span>
+          <span>Version: <b data-cli-version>v5.2.2</b></span>
           <span>Broker: <b>broker.rogerai.fyi</b></span>
           <span>Protocol: <b>OpenAI-compatible</b></span>
         </div>
@@ -921,7 +921,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
           <section class="man-sec" id="s9">
             <span class="man-sec__no">§9 · Command reference</span>
             <h2>Every command, every key</h2>
-            <p>The full surface as of <b data-cli-version>v5.2.1</b>: the top-level CLI
+            <p>The full surface as of <b data-cli-version>v5.2.2</b>: the top-level CLI
               commands with their key flags, then the in-app keys and slash commands grouped
               by context. Run any command with <code>--help</code> for its flags; advanced
               flags hide behind <code>--advanced</code>. Run <code>rogerai</code> with no
@@ -1201,6 +1201,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
               Newest first. The set self-updates - <code>roger upgrade</code> pulls the
               latest, <code>roger upgrade --check</code> just reports.</p>
             <div class="man-plate">
+              <div class="man-plate__row"><span class="man-plate__k">v5.2.2</span><span class="man-plate__v">A hardened share node - when you SHARE your GPU, the node now relays only to the chat and voice endpoints on your local backend, nothing else.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.2.1</span><span class="man-plate__v">The AGENT desk, refined - THE DESK now opens once per model per session (cursor on the DJ, just type to chat), guests show their brand plates, and <code>/operator</code> sits in the footer. Plus <code>roger use --raw</code> to keep raw model output.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.2.0</span><span class="man-plate__v">Guest Operators, dialed in. Press <code>[0]</code> and the AGENT desk auto-tunes a free band and lets you pick your operator on THE DESK. Plus agent-ready and vision badges on the band list (agent-ready verified by a live tool-call probe), and strict agents like hermes no longer stall on reasoning models.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.1.0</span><span class="man-plate__v">GUEST OPERATORS - hand the mic to your own agent CLI (opencode, hermes, aider) from the AGENT desk with <code>/operator</code>. It runs on your tuned band through a hardened local OpenAI-compatible proxy, with a $2 session spend budget and throwaway scratch configs so your own setups are never touched.</span></div>


### PR DESCRIPTION
Patch release shipping the one unreleased node-facing change since v5.2.1: the relay path allowlist (#49).

## Changes
- `cmd/rogerai/main.go`: `Version` 5.2.1 -> 5.2.2
- `web/src/manual.html`: version badges -> v5.2.2, plus a new v5.2.2 changelog row

## Changelog entry
> A hardened share node - when you SHARE your GPU, the node now relays only to the chat and voice endpoints on your local backend, nothing else.

## Verification
- `node web/build.mjs` builds cleanly (29 pages), new changelog row renders in dist
- `go build ./cmd/rogerai` stamps `rogerai 5.2.2`
- `go test ./test/smoke` passes (link crawler, no placeholder hrefs)
- `git grep 5.2.1` clean outside the changelog history row

## NOTE
HOLD - do not merge yet. Tagging happens after merge (the coordinator tags).
