### PR TITLE
web/nav: brand the Source link with the GitHub octocat mark

### DIFF
--- a/web/src/_partials/nav.html
+++ b/web/src/_partials/nav.html
@@ -42,7 +42,10 @@
         {{#unless variant=marketing}}<a class="nav__link nav__util" href="/voices.html">Voices</a>{{/unless}}
         <a class="nav__link nav__util" href="/manual.html">Manual</a>
 {{#if variant=marketing}}
-        <a class="nav__link nav__util nav__link--ghost" href="https://github.com/rogerai-fyi/roger">Source</a>
+        <a class="nav__link nav__util nav__link--ghost nav__source" href="https://github.com/rogerai-fyi/roger" aria-label="View the source on GitHub">
+          <svg class="nav__source__mark" viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path></svg>
+          Source
+        </a>
 {{/if}}
         <a class="nav__link nav__util" href="/login.html" data-session-login>Log in</a>
 {{#if variant=marketing}}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -350,6 +350,10 @@ html.js [data-reveal].is-revealed { opacity: 1; transform: none; }
   color: var(--ink-900); background: var(--white); box-shadow: none;
 }
 .nav__link--ghost:hover { border-color: var(--live); color: var(--ink-900); }
+/* the GitHub source pill: octocat mark + label, tinting to the signal red on hover */
+.nav__source { gap: 6px; }
+.nav__source__mark { flex: none; transition: color var(--d-2); }
+.nav__source:hover .nav__source__mark { color: var(--live); }
 @media (prefers-reduced-motion: reduce) {
   .nav__link:not(.nav__link--ghost)::after { transition: none; }
 }


### PR DESCRIPTION
The nav Source link (marketing pages) was plain text. Adds the GitHub octocat mark (inline SVG, currentColor so it themes for light/dark) inside the existing ghost pill, tinting to the signal red on hover to match the brand. No new assets (inline SVG, CSP-safe).