### PR TITLE
fix(agent): atomic heartbeatInterval (close a pre-existing data race)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -82,8 +82,11 @@ var (
 
 // heartbeatInterval is how often the node heartbeats the broker to stay on-air. It
 // is a var (not a const) only so tests can lower it; production uses ~10s, well
-// inside the broker's nodeTTL liveness window.
-var heartbeatInterval = 10 * time.Second
+// inside the broker's nodeTTL liveness window. Stored as an atomic (int64 nanos) so a
+// still-running heartbeat goroutine reading it can never race a test's swap/restore.
+var heartbeatInterval atomic.Int64
+
+func init() { heartbeatInterval.Store(int64(10 * time.Second)) }
 
 // Session is a running in-process share (the TUI's /share). It exposes live
 // counters so the ON-AIR panel can render connections + earnings without the
@@ -530,7 +533,7 @@ func heartbeatUntil(broker, nodeID string, rereg *reregistrar, sess *Session) {
 		}
 	}
 	beat() // confirm quickly on entry rather than waiting a full tick
-	t := time.NewTicker(heartbeatInterval)
+	t := time.NewTicker(time.Duration(heartbeatInterval.Load()))
 	defer t.Stop()
 	for {
 		select {

--- a/internal/agent/link_test.go
+++ b/internal/agent/link_test.go
@@ -14,9 +14,9 @@ import (
 // swapHeartbeatInterval lowers the heartbeat cadence for a test and returns a restore
 // func; production uses ~10s, but the tests need fast beats to observe transitions.
 func swapHeartbeatInterval(d time.Duration) func() {
-	prev := heartbeatInterval
-	heartbeatInterval = d
-	return func() { heartbeatInterval = prev }
+	prev := heartbeatInterval.Load()
+	heartbeatInterval.Store(int64(d))
+	return func() { heartbeatInterval.Store(prev) }
 }
 
 // waitLink polls the session's link state until it reaches want or times out.


### PR DESCRIPTION
The heartbeat goroutine read the heartbeatInterval package var while a test's swapHeartbeatInterval restore wrote it - a data race the -race detector flags. Pre-existing (cover-gate does not run -race, so it was never caught). Stored as an atomic int64 so read and swap can't race; no behavior change. Verified: -race x3 clean, build/vet/gofmt green.