### PR TITLE
osaurus: supply integration - detection, relay hardenings, operator listing

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -1003,6 +1003,11 @@ needs no login. When you earn, payouts are 120-day hold, $25 min, monthly.
 	if *upKey == "" && savedKey != "" && (up == "" || sameEndpoint(up, savedUp)) {
 		*upKey = savedKey
 	}
+	// osaurusBrand records that DETECTION already fingerprinted the resolved upstream as Osaurus
+	// (a real GET / banner match during the scan). It is authoritative and, unlike a fresh probe at
+	// Config time, cannot fail open if the local server is momentarily slow - so the Osaurus-only
+	// hardenings (X-Persist + model-pin) never silently drop out under load. OR-ed with the probe below.
+	osaurusBrand := false
 	if up == "" {
 		// Saved keyed upstream: try it WITH its key first (the broad DetectFull scan does
 		// not carry the saved key), so a custom keyed endpoint is reused without a re-prompt.
@@ -1042,6 +1047,7 @@ needs no login. When you earn, payouts are 120-day hold, $25 min, monthly.
 			}
 		}
 		up = pick.Chat
+		osaurusBrand = pick.Name == "osaurus" // detection's authoritative fingerprint (see above)
 		// A key-protected upstream the detector authenticated to (from env or the guided
 		// paste) carries its working key on the Found; adopt it unless --upstream-key was
 		// given explicitly, so the agent forwards jobs with the same Bearer.
@@ -1086,8 +1092,11 @@ needs no login. When you earn, payouts are 120-day hold, $25 min, monthly.
 		// from the environment (OPENAI_API_KEY / friends) for THIS endpoint and confirm
 		// reachability - but NEVER block here, the agent self-heals if the server is
 		// momentarily down (the same reason the explicit path skips a hard preflight).
-		if f, st := detectProbeKey(up, ""); st == detect.Reachable && f.Key != "" {
-			*upKey = f.Key
+		if f, st := detectProbeKey(up, ""); st == detect.Reachable {
+			if f.Key != "" {
+				*upKey = f.Key
+			}
+			osaurusBrand = osaurusBrand || f.Name == "osaurus" // capture the brand on the explicit path too
 		}
 	}
 	// --modality is the operator's override for the --upstream path, where auto-detection (which
@@ -1191,8 +1200,12 @@ needs no login. When you earn, payouts are 120-day hold, $25 min, monthly.
 	if msg := softPriceWarn(*broker, mdl, *priceOut); msg != "" {
 		fmt.Println(msg)
 	}
+	// Osaurus shares Jan's :1337 and needs two relay hardenings (X-Persist + model-pin). Decide
+	// ONCE here whether the resolved upstream is Osaurus (root-banner fingerprint) so the relay
+	// applies them without re-probing per job; a no-op flag for every other backend.
+	osaurusUpstream := osaurusBrand || detect.IsOsaurus(strings.TrimSuffix(up, "/chat/completions"))
 	cfgRun := agent.Config{
-		Broker: *broker, Upstream: up, UpstreamKey: *upKey,
+		Broker: *broker, Upstream: up, UpstreamKey: *upKey, Osaurus: osaurusUpstream,
 		// HW carries the PRIVACY-BUCKETED class (multi-gpu / single-gpu / apple / cpu),
 		// NOT the raw CPU/GPU string - so a consumer learns the band's tier without the
 		// node leaking its exact rig.

--- a/features/relay/osaurus_hardening.feature
+++ b/features/relay/osaurus_hardening.feature
@@ -1,0 +1,132 @@
+# PENDING founder approval (spec-first workflow step 3) - BUILD-AND-HOLD. This spec is the
+# founder-approvable contract for the two OSAURUS-SPECIFIC relay hardenings (finding C +
+# model-pin from the source-level Osaurus verification). The PR carries it for review and MUST
+# NOT merge before the founder approves the spec.
+#
+# Context: the relay path allowlist (features/voice/relay_allowlist.feature, already on main)
+# made the NODE the trust boundary - it forwards ONLY chat/voice paths, never /agents,/mcp,
+# /memory. These two hardenings are the remaining Osaurus-SPECIFIC gaps that were deliberately
+# NOT shipped with the allowlist, because they only make sense once the upstream is known to be
+# Osaurus:
+#
+#   1. X-PERSIST: FALSE. Osaurus persists /v1/chat/completions conversations to the OWNER's
+#      local chat history by default unless the request carries "X-Persist: false" (a later
+#      "history backfill" can then distill that history into the owner's MEMORY). Without the
+#      header, public tuner traffic would (a) pollute the owner's chat history and (b) open a
+#      prompt-injection path into their memory. The relay already forwards ONLY Content-Type +
+#      Authorization (tuners cannot smuggle X-Osaurus-Agent-Id or any other header); this adds
+#      ONE node-authored header, "X-Persist: false", and ONLY when the upstream is Osaurus.
+#
+#   2. MODEL PIN. The relay forwards the tuner's request body as-is, so a tuner could name a
+#      DIFFERENT locally-installed model and force Osaurus to load it (memory pressure on the
+#      owner's Mac; serving a model the owner never offered). For an Osaurus upstream the node
+#      rewrites body.model to the OFFERED model (cfg.Model) - the single model this node put on
+#      the band - so the tuner can only ever exercise what was offered.
+#
+# Ground truth: internal/agent/agent.go serve() (non-stream, builds upReq at the Content-Type /
+# Authorization block) and serveStream() (streaming, same header block) - BOTH tuner-reachable,
+# so BOTH get the header + the pin. "Is this upstream Osaurus?" is decided ONCE at share time by
+# the root-banner fingerprint (detect.isOsaurus, GET / => "Osaurus Server is running!") and
+# carried as Config.Osaurus; the relay never re-probes per job.
+#
+# Scope guard (do-NOT, from the brief): this touches EXACTLY the chat relay to an Osaurus
+# /v1/chat/completions upstream. It does NOT relax the shipped allowlist, does NOT reference
+# /agents,/mcp,/memory, and does NOT change behavior for any NON-Osaurus backend.
+#
+# Invariants:
+#   B1 On an Osaurus upstream, a relayed request carries the node-authored header
+#      "X-Persist: false" (non-stream AND streaming).
+#   B2 On a NON-Osaurus upstream, NO X-Persist header is added - byte-identical to today.
+#   B3 On an Osaurus upstream, the forwarded body.model is PINNED to the offered model
+#      (cfg.Model): a different name is rewritten, an absent/empty name is filled, the correct
+#      name is left as the offer. The tuner can never force a model the owner did not offer.
+#   B4 On a NON-Osaurus upstream, body.model is forwarded UNCHANGED (no rewrite).
+#   B5 Header discipline is otherwise unchanged: the only headers the backend ever sees are the
+#      node's Content-Type, Authorization, and (Osaurus-only) X-Persist. No tuner header leaks.
+#   B6 A body the node cannot parse as JSON is forwarded byte-for-byte (a request we can't parse
+#      can't force-load a model anyway); the X-Persist header is still added on Osaurus (it is
+#      independent of the body).
+#
+# Purely-lexical corners (a body with an unusual but valid model type, the exact header casing)
+# are pinned in the table-driven Go tests alongside this BDD (internal/agent).
+
+Feature: Osaurus relay hardening - no history pollution, no model smuggling
+
+  Background:
+    Given a local backend that records the path, headers, and body it is hit on
+    And the node offers model "gpt-oss-20b"
+
+  # ===========================================================================
+  # 1. X-PERSIST: FALSE - only on an Osaurus upstream (B1, B2)
+  # ===========================================================================
+
+  Scenario: a chat relay to an Osaurus upstream carries X-Persist false
+    Given the upstream is Osaurus
+    When the broker relays a chat job
+    Then the forwarded request carries the header "X-Persist: false"
+
+  Scenario: a streaming chat relay to an Osaurus upstream carries X-Persist false
+    Given the upstream is Osaurus
+    When the broker relays a streaming chat job
+    Then the forwarded request carries the header "X-Persist: false"
+
+  Scenario: a chat relay to a NON-Osaurus upstream adds no X-Persist header
+    Given the upstream is not Osaurus
+    When the broker relays a chat job
+    Then the forwarded request carries no X-Persist header
+
+  # The STREAM path re-implements the flag logic separately from serve(), so it gets its own
+  # non-Osaurus coverage (a regression there would silently mark a non-Osaurus stream no-persist).
+  Scenario: a streaming chat relay to a NON-Osaurus upstream adds no X-Persist header
+    Given the upstream is not Osaurus
+    When the broker relays a streaming chat job
+    Then the forwarded request carries no X-Persist header
+
+  # ===========================================================================
+  # 2. MODEL PIN - the tuner can only exercise the offered model (B3, B4)
+  # ===========================================================================
+
+  Scenario: a tuner naming a different model is pinned back to the offer
+    Given the upstream is Osaurus
+    When the broker relays a chat job naming model "llama-3.3-70b"
+    Then the forwarded body has model "gpt-oss-20b"
+
+  Scenario: a tuner omitting the model is filled with the offer
+    Given the upstream is Osaurus
+    When the broker relays a chat job naming model ""
+    Then the forwarded body has model "gpt-oss-20b"
+
+  Scenario: a tuner naming the offered model passes through as the offer
+    Given the upstream is Osaurus
+    When the broker relays a chat job naming model "gpt-oss-20b"
+    Then the forwarded body has model "gpt-oss-20b"
+
+  Scenario: a streaming tuner naming a different model is pinned back to the offer
+    Given the upstream is Osaurus
+    When the broker relays a streaming chat job naming model "llama-3.3-70b"
+    Then the forwarded body has model "gpt-oss-20b"
+
+  Scenario: a streaming NON-Osaurus upstream forwards the tuner's model unchanged
+    Given the upstream is not Osaurus
+    When the broker relays a streaming chat job naming model "llama-3.3-70b"
+    Then the forwarded body has model "llama-3.3-70b"
+
+  Scenario: a NON-Osaurus upstream forwards the tuner's model unchanged
+    Given the upstream is not Osaurus
+    When the broker relays a chat job naming model "llama-3.3-70b"
+    Then the forwarded body has model "llama-3.3-70b"
+
+  # ===========================================================================
+  # 3. DISCIPLINE - no tuner header leak; an unparseable body is not corrupted (B5, B6)
+  # ===========================================================================
+
+  Scenario: the forwarded request leaks no tuner headers
+    Given the upstream is Osaurus
+    When the broker relays a chat job
+    Then the backend sees only the node's Content-Type, Authorization, and X-Persist headers
+
+  Scenario: an unparseable body is forwarded byte-for-byte but still marked no-persist
+    Given the upstream is Osaurus
+    When the broker relays a chat job with an unparseable body
+    Then the forwarded body is unchanged
+    And the forwarded request carries the header "X-Persist: false"

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -57,7 +57,14 @@ type Config struct {
 	BridgeToken  string
 	Confidential bool
 	Private      bool // go on air as a PRIVATE band (hidden; freq-code only)
-	Schedule     []protocol.PriceWindow
+	// Osaurus is set ONCE at share time when the upstream fingerprints as an Osaurus server
+	// (detect.IsOsaurus). It gates the Osaurus-only relay hardenings in serve/serveStream: the
+	// node adds "X-Persist: false" (so tuner traffic never lands in the owner's Osaurus chat
+	// history / memory) and pins the request body's model to Model (so a tuner cannot name a
+	// different local model to force-load it). No effect for any other backend. The relay never
+	// re-probes per job - the fingerprint is decided once and carried here.
+	Osaurus  bool
+	Schedule []protocol.PriceWindow
 	// Voice: the offer's modality + display metadata (set only when sharing a voice/audio model,
 	// from the detected server; empty modality = chat, so a normal LLM share is unchanged).
 	Modality string // "" / "chat" | "tts" | "stt"
@@ -573,10 +580,20 @@ func isStream(body []byte) bool {
 // node asks the upstream to include a usage chunk so we can meter the stream.
 func serveStream(cfg Config, offer protocol.ModelOffer, priv ed25519.PrivateKey, token string, job protocol.Job) protocol.UsageReceipt {
 	client := &http.Client{Timeout: 10 * time.Minute} // streams can be long
-	upReq, _ := http.NewRequest(http.MethodPost, cfg.Upstream, bytes.NewReader(withUsageOption(job.Body)))
+	// Osaurus hardening (Config.Osaurus, decided once at share time): pin the model to the offer
+	// and mark the request no-persist so tuner traffic can't force-load a different local model
+	// or land in the owner's Osaurus history/memory. A no-op for any other backend.
+	body := job.Body
+	if cfg.Osaurus {
+		body = pinModel(body, cfg.Model)
+	}
+	upReq, _ := http.NewRequest(http.MethodPost, cfg.Upstream, bytes.NewReader(withUsageOption(body)))
 	upReq.Header.Set("Content-Type", "application/json")
 	if cfg.UpstreamKey != "" {
 		upReq.Header.Set("Authorization", "Bearer "+cfg.UpstreamKey)
+	}
+	if cfg.Osaurus {
+		upReq.Header.Set("X-Persist", "false")
 	}
 	resp, err := client.Do(upReq)
 	if err != nil {
@@ -633,7 +650,7 @@ func serveStream(cfg Config, offer protocol.ModelOffer, priv ed25519.PrivateKey,
 // usage chunk (OpenAI streaming) - needed to meter the stream.
 func withUsageOption(body []byte) []byte {
 	var m map[string]json.RawMessage
-	if json.Unmarshal(body, &m) != nil {
+	if json.Unmarshal(body, &m) != nil || m == nil { // `null` unmarshals to a nil map - avoid the nil-map assign panic
 		return body
 	}
 	m["stream_options"] = json.RawMessage(`{"include_usage":true}`)
@@ -641,6 +658,28 @@ func withUsageOption(body []byte) []byte {
 		return b
 	}
 	return body
+}
+
+// pinModel rewrites the JSON body's "model" field to the offered model - the Osaurus hardening
+// that stops a tuner from naming a DIFFERENT locally-installed model to force-load it (memory
+// pressure on the owner's Mac; serving a model the owner never put on the band). The node offers
+// exactly ONE model, so a pinned body can only ever exercise that one: a different name is
+// rewritten, an absent/empty name is filled, the correct name stays. A body that does not parse
+// as JSON is returned byte-for-byte (an unparseable request can't force-load a model, and we
+// never corrupt a body we can't read - same discipline as withUsageOption).
+func pinModel(body []byte, model string) []byte {
+	var m map[string]json.RawMessage
+	// json.Unmarshal of the literal `null` SUCCEEDS into a NIL map (no error), so the nil check is
+	// load-bearing: without it the m["model"] assignment below panics on a nil map, and a bare `null`
+	// request body from a tuner would crash the node (pollLoop has no recover). A null / non-object /
+	// unparseable body can't force-load a model anyway, so forward it byte-for-byte.
+	if json.Unmarshal(body, &m) != nil || m == nil {
+		return body
+	}
+	mb, _ := json.Marshal(model) // a string always marshals
+	m["model"] = json.RawMessage(mb)
+	out, _ := json.Marshal(m) // a map of already-valid RawMessages always marshals
+	return out
 }
 
 // parseUsage extracts token counts from an SSE "data: {...usage...}" line.
@@ -687,10 +726,23 @@ func serve(cfg Config, offer protocol.ModelOffer, priv ed25519.PrivateKey, up *h
 			body = injectVoiceDefaults(job.Body, offer.Voice, offer.Speed)
 		}
 	}
+	// Osaurus hardening (Config.Osaurus, decided once at share time): pin the model to the offer
+	// and mark the request no-persist so tuner traffic can't force-load a different local model or
+	// land in the owner's Osaurus history/memory. Scoped to the CHAT path ONLY (per the spec's scope
+	// guard): the model-pin/persist concepts are chat-specific, and applying them on a voice
+	// (speech/transcribe) job would clobber that request's own model field. A no-op for any other
+	// backend. Chat = the non-voice branch above (absent path or a /chat/completions suffix).
+	osaurusChat := cfg.Osaurus && (p == "" || strings.HasSuffix(p, "/chat/completions"))
+	if osaurusChat {
+		body = pinModel(body, cfg.Model)
+	}
 	upReq, _ := http.NewRequest(http.MethodPost, target, bytes.NewReader(body))
 	upReq.Header.Set("Content-Type", "application/json")
 	if cfg.UpstreamKey != "" {
 		upReq.Header.Set("Authorization", "Bearer "+cfg.UpstreamKey)
+	}
+	if osaurusChat {
+		upReq.Header.Set("X-Persist", "false")
 	}
 	resp, err := up.Do(upReq)
 	if err != nil {

--- a/internal/agent/osaurus_hardening_bdd_test.go
+++ b/internal/agent/osaurus_hardening_bdd_test.go
@@ -1,0 +1,312 @@
+package agent
+
+// osaurus_hardening_bdd_test.go makes features/relay/osaurus_hardening.feature EXECUTABLE under
+// godog, driving the REAL agent.serve() and agent.serveStream() against a REAL httptest backend
+// that RECORDS the path, headers, and body it is hit on. It is the Osaurus-only safety contract:
+// on an Osaurus upstream the node adds "X-Persist: false" and pins the body model to the offer;
+// on any other backend nothing changes. No mocks of the node internals - the only stubs are the
+// local backend (the surface Osaurus presents) and the broker (the stream sink).
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+type osaHardState struct {
+	backend    *httptest.Server
+	broker     *httptest.Server
+	lastHeader atomic.Value // http.Header seen by the backend on the last hit
+	lastBody   atomic.Value // []byte the backend received on the last hit
+	sentBody   []byte       // the tuner body handed to the relay (for the "unchanged" assertion)
+	cfg        Config
+	priv       ed25519.PrivateKey
+}
+
+const osaBackendBody = `{"usage":{"prompt_tokens":1,"completion_tokens":1}}`
+const osaUpstreamKey = "sk-node-upstream-SECRET"
+
+func (s *osaHardState) reset() {
+	if s.backend != nil {
+		s.backend.Close()
+	}
+	if s.broker != nil {
+		s.broker.Close()
+	}
+	*s = osaHardState{}
+	_, s.priv, _ = ed25519.GenerateKey(nil)
+}
+
+// --- Given ---
+
+func (s *osaHardState) recordingBackend() error {
+	s.backend = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.lastHeader.Store(r.Header.Clone())
+		s.lastBody.Store(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(osaBackendBody))
+	}))
+	// The broker only needs to swallow the stream + result POSTs the streaming path makes.
+	s.broker = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	return nil
+}
+
+func (s *osaHardState) offersModel(model string) error {
+	s.cfg = Config{
+		NodeID:      "n1",
+		Model:       model,
+		Upstream:    s.backend.URL + "/v1/chat/completions",
+		UpstreamKey: osaUpstreamKey,
+		Broker:      s.broker.URL,
+	}
+	return nil
+}
+
+func (s *osaHardState) upstreamIsOsaurus() error    { s.cfg.Osaurus = true; return nil }
+func (s *osaHardState) upstreamIsNotOsaurus() error { s.cfg.Osaurus = false; return nil }
+
+// --- When ---
+
+// bodyNaming builds a chat body: a named model, an ABSENT model (name == ""), or a plain body.
+func bodyNaming(model string) []byte {
+	if model == "" {
+		return []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	}
+	return []byte(fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":"hi"}]}`, model))
+}
+
+func (s *osaHardState) doServe(body []byte) {
+	s.sentBody = body
+	job := protocol.Job{ID: "j", User: "u", Body: body}
+	_ = serve(s.cfg, protocol.ModelOffer{Model: s.cfg.Model}, s.priv, &http.Client{Timeout: 3 * time.Second}, job)
+}
+
+func (s *osaHardState) doServeStream(body []byte) {
+	s.sentBody = body
+	job := protocol.Job{ID: "j", User: "u", Body: body}
+	_ = serveStream(s.cfg, protocol.ModelOffer{Model: s.cfg.Model}, s.priv, "tok", job)
+}
+
+func (s *osaHardState) relayChatJob() error { s.doServe(bodyNaming(s.cfg.Model)); return nil }
+func (s *osaHardState) relayStreamingChatJob() error {
+	s.doServeStream([]byte(`{"stream":true,"messages":[]}`))
+	return nil
+}
+func (s *osaHardState) relayChatNaming(model string) error { s.doServe(bodyNaming(model)); return nil }
+func (s *osaHardState) relayStreamNaming(model string) error {
+	if model == "" {
+		s.doServeStream([]byte(`{"stream":true,"messages":[]}`))
+	} else {
+		s.doServeStream([]byte(fmt.Sprintf(`{"model":%q,"stream":true,"messages":[]}`, model)))
+	}
+	return nil
+}
+func (s *osaHardState) relayUnparseable() error { s.doServe([]byte("this is not json")); return nil }
+
+// --- Then ---
+
+func (s *osaHardState) header() (http.Header, error) {
+	h, _ := s.lastHeader.Load().(http.Header)
+	if h == nil {
+		return nil, bddErr("no forwarded request was recorded")
+	}
+	return h, nil
+}
+
+func (s *osaHardState) carriesHeader(name, value string) error {
+	h, err := s.header()
+	if err != nil {
+		return err
+	}
+	if got := h.Get(name); got != value {
+		return bddErr(fmt.Sprintf("forwarded %s = %q, want %q", name, got, value))
+	}
+	return nil
+}
+
+func (s *osaHardState) carriesNoXPersist() error {
+	h, err := s.header()
+	if err != nil {
+		return err
+	}
+	if got := h.Get("X-Persist"); got != "" {
+		return bddErr("a non-Osaurus upstream must get NO X-Persist header, got " + got)
+	}
+	return nil
+}
+
+func (s *osaHardState) bodyHasModel(want string) error {
+	b, _ := s.lastBody.Load().([]byte)
+	var m struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return bddErr("forwarded body is not JSON: " + string(b))
+	}
+	if m.Model != want {
+		return bddErr(fmt.Sprintf("forwarded model = %q, want %q", m.Model, want))
+	}
+	return nil
+}
+
+func (s *osaHardState) onlyNodeHeaders() error {
+	h, err := s.header()
+	if err != nil {
+		return err
+	}
+	if ct := h.Get("Content-Type"); ct != "application/json" {
+		return bddErr("forwarded Content-Type " + ct + ", want application/json")
+	}
+	if auth := h.Get("Authorization"); auth != "Bearer "+osaUpstreamKey {
+		return bddErr("forwarded Authorization " + auth + ", want the node's Bearer upstream key")
+	}
+	allowed := map[string]bool{
+		"Content-Type": true, "Authorization": true, "X-Persist": true, // the node's own headers
+		"Host": true, "User-Agent": true, "Accept-Encoding": true, "Content-Length": true, // Go transport
+	}
+	for name := range h {
+		if !allowed[name] {
+			return bddErr("forwarded an unexpected header " + name + "; no tuner header may leak")
+		}
+	}
+	return nil
+}
+
+func (s *osaHardState) forwardedBodyUnchanged() error {
+	b, _ := s.lastBody.Load().([]byte)
+	if string(b) != string(s.sentBody) {
+		return bddErr("forwarded body " + string(b) + ", want byte-for-byte " + string(s.sentBody))
+	}
+	return nil
+}
+
+func TestOsaurusHardeningBDD(t *testing.T) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			st := &osaHardState{}
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				st.reset()
+				return ctx, nil
+			})
+			sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+				if st.backend != nil {
+					st.backend.Close()
+					st.backend = nil
+				}
+				if st.broker != nil {
+					st.broker.Close()
+					st.broker = nil
+				}
+				return ctx, nil
+			})
+			sc.Step(`^a local backend that records the path, headers, and body it is hit on$`, st.recordingBackend)
+			sc.Step(`^the node offers model "([^"]*)"$`, st.offersModel)
+			sc.Step(`^the upstream is Osaurus$`, st.upstreamIsOsaurus)
+			sc.Step(`^the upstream is not Osaurus$`, st.upstreamIsNotOsaurus)
+			sc.Step(`^the broker relays a chat job$`, st.relayChatJob)
+			sc.Step(`^the broker relays a streaming chat job$`, st.relayStreamingChatJob)
+			sc.Step(`^the broker relays a chat job naming model "([^"]*)"$`, st.relayChatNaming)
+			sc.Step(`^the broker relays a streaming chat job naming model "([^"]*)"$`, st.relayStreamNaming)
+			sc.Step(`^the broker relays a chat job with an unparseable body$`, st.relayUnparseable)
+			sc.Step(`^the forwarded request carries the header "([^"]+): ([^"]+)"$`, st.carriesHeader)
+			sc.Step(`^the forwarded request carries no X-Persist header$`, st.carriesNoXPersist)
+			sc.Step(`^the forwarded body has model "([^"]*)"$`, st.bodyHasModel)
+			sc.Step(`^the backend sees only the node's Content-Type, Authorization, and X-Persist headers$`, st.onlyNodeHeaders)
+			sc.Step(`^the forwarded body is unchanged$`, st.forwardedBodyUnchanged)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/relay/osaurus_hardening.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("relay/osaurus_hardening behavior scenarios failed (see godog output above)")
+	}
+}
+
+// TestPinModel pins the purely-lexical corners the Gherkin table cannot carry: a body with no
+// model key, a valid-but-unusual model value, and an unparseable body (returned byte-for-byte).
+func TestPinModel(t *testing.T) {
+	const offer = "gpt-oss-20b"
+	cases := []struct {
+		name string
+		in   string
+		want string // expected model field after pin (or "" to assert byte-for-byte passthrough)
+	}{
+		{"different model rewritten", `{"model":"llama-3.3-70b","x":1}`, offer},
+		{"absent model filled", `{"messages":[]}`, offer},
+		{"empty model filled", `{"model":"","messages":[]}`, offer},
+		{"correct model kept", `{"model":"gpt-oss-20b"}`, offer},
+		{"numeric-ish model coerced", `{"model":"123"}`, offer},
+	}
+	for _, c := range cases {
+		got := pinModel([]byte(c.in), offer)
+		var m struct {
+			Model string `json:"model"`
+		}
+		if err := json.Unmarshal(got, &m); err != nil {
+			t.Errorf("%s: pinned body not JSON: %s", c.name, got)
+			continue
+		}
+		if m.Model != c.want {
+			t.Errorf("%s: model = %q, want %q", c.name, m.Model, c.want)
+		}
+	}
+
+	// An unparseable body is returned byte-for-byte (never corrupted).
+	raw := []byte("not json at all")
+	if got := pinModel(raw, offer); string(got) != string(raw) {
+		t.Errorf("unparseable body should pass through unchanged, got %s", got)
+	}
+	// REGRESSION: the literal `null` unmarshals to a NIL map (no error) - pinModel must NOT panic on
+	// the nil-map assignment (a bare `null` body from a tuner would otherwise crash the node).
+	if got := pinModel([]byte("null"), offer); string(got) != "null" {
+		t.Errorf("null body should pass through unchanged, got %s", got)
+	}
+	// withUsageOption has the same latent nil-map hazard on the stream path - guard confirmed.
+	if got := withUsageOption([]byte("null")); string(got) != "null" {
+		t.Errorf("withUsageOption(null) should pass through unchanged, got %s", got)
+	}
+	// A body that is valid JSON but not an object (an array) is also passed through unchanged.
+	arr := []byte(`["a","b"]`)
+	if got := pinModel(arr, offer); string(got) != string(arr) {
+		t.Errorf("non-object JSON should pass through unchanged, got %s", got)
+	}
+}
+
+// TestPinModelStripsSmuggledOtherFields confirms the pin only touches "model" and preserves the
+// rest of the tuner's request (messages, temperature, etc.) so a legitimate request still works.
+func TestPinModelPreservesOtherFields(t *testing.T) {
+	in := `{"model":"evil","messages":[{"role":"user","content":"hi"}],"temperature":0.7}`
+	got := pinModel([]byte(in), "safe-model")
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(got, &m); err != nil {
+		t.Fatalf("pinned body not JSON: %s", got)
+	}
+	if !strings.Contains(string(m["model"]), "safe-model") {
+		t.Errorf("model not pinned: %s", got)
+	}
+	if _, ok := m["messages"]; !ok {
+		t.Errorf("messages dropped by pin: %s", got)
+	}
+	if _, ok := m["temperature"]; !ok {
+		t.Errorf("temperature dropped by pin: %s", got)
+	}
+}

--- a/internal/agent/osaurus_live_e2e_test.go
+++ b/internal/agent/osaurus_live_e2e_test.go
@@ -1,0 +1,123 @@
+package agent
+
+// osaurus_live_e2e_test.go is the Mac-only LIVE integration check for the Osaurus supply
+// hardenings, run against a REAL Osaurus server on 127.0.0.1:1337. It is gated behind
+// OSAURUS_E2E=1 so it NEVER runs in CI or a normal `go test` (no external dependency in the
+// default suite); it is the reproducible evidence the founder brief (section 3) asks for.
+//
+//   OSAURUS_E2E=1 go test ./internal/agent/ -run TestOsaurusLiveE2E -v
+//
+// It proves, against the actual server, what the httptest BDD proves in isolation:
+//   1. detection brands the :1337 server "osaurus" (not "jan");
+//   2. the model-pin makes a tuner naming an UNINSTALLED model still serve the offer;
+//   3. the path allowlist refuses /agents (a route real Osaurus DOES expose, unauthenticated
+//      on loopback) with a clean 404 and never relays it.
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/detect"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+const osaLiveBase = "http://127.0.0.1:1337/v1"
+
+func TestOsaurusLiveE2E(t *testing.T) {
+	if os.Getenv("OSAURUS_E2E") != "1" {
+		t.Skip("live Osaurus E2E: set OSAURUS_E2E=1 with a local Osaurus serving on :1337")
+	}
+	if !detect.IsOsaurus(osaLiveBase) {
+		t.Fatalf("no Osaurus detected at %s (start it: osaurus serve)", osaLiveBase)
+	}
+
+	// The offered model = whatever Osaurus is actually serving (first from /v1/models).
+	found, st := detect.ProbeKey(osaLiveBase, "")
+	if st != detect.Reachable || len(found.Models) == 0 {
+		t.Fatalf("Osaurus not reachable / no models: status=%v models=%v", st, found.Models)
+	}
+	offered := found.Models[0]
+	if found.Name != "osaurus" {
+		t.Errorf("detection should brand the server osaurus, got %q", found.Name)
+	}
+	t.Logf("live Osaurus offered model = %q (branded %q)", offered, found.Name)
+
+	_, priv, _ := ed25519.GenerateKey(nil)
+	client := &http.Client{Timeout: 90 * time.Second}
+	cfg := Config{
+		NodeID:   "osaurus-e2e",
+		Model:    offered,
+		Upstream: "http://127.0.0.1:1337/v1/chat/completions",
+		Osaurus:  true,
+	}
+
+	// 1. MODEL-PIN: a tuner naming a model Osaurus does NOT have still gets served, because the
+	//    node pins body.model to the offer before relaying. Without the pin this 404s upstream.
+	t.Run("model pin serves the offer despite a bogus model name", func(t *testing.T) {
+		job := protocol.Job{ID: "e2e-pin", User: "u", Body: []byte(
+			`{"model":"totally-not-installed-9000","messages":[{"role":"user","content":"Reply with the single word OK"}],"max_tokens":8}`)}
+		res := serve(cfg, protocol.ModelOffer{Model: offered}, priv, client, job)
+		if res.Status != http.StatusOK {
+			t.Fatalf("pinned relay status = %d, want 200 (body: %s)", res.Status, truncate(res.Body))
+		}
+		var d struct {
+			Model   string `json:"model"`
+			Choices []struct {
+				Message struct {
+					Content string `json:"content"`
+				} `json:"message"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal(res.Body, &d); err != nil {
+			t.Fatalf("upstream response not JSON: %s", truncate(res.Body))
+		}
+		if len(d.Choices) == 0 {
+			t.Fatalf("no completion returned: %s", truncate(res.Body))
+		}
+		t.Logf("pin OK: bogus model served as %q, reply=%q", d.Model, strings.TrimSpace(d.Choices[0].Message.Content))
+
+		// Control: with the pin OFF, the same bogus model is rejected upstream (proves the pin
+		// is what saved it, not that Osaurus ignores the field).
+		noPinCfg := cfg
+		noPinCfg.Osaurus = false
+		ctl := serve(noPinCfg, protocol.ModelOffer{Model: offered}, priv, client, job)
+		if ctl.Status == http.StatusOK {
+			t.Logf("note: Osaurus accepted the bogus model even unpinned (status 200) - pin still normalizes it, but this build does not reject unknown models")
+		} else {
+			t.Logf("control OK: unpinned bogus model rejected upstream with status %d (the pin is load-bearing)", ctl.Status)
+		}
+	})
+
+	// 2. ALLOWLIST: /agents is a REAL Osaurus route (200, unauthenticated on loopback), yet the
+	//    node refuses to relay it - 404 "unsupported path", the backend is never contacted.
+	t.Run("allowlist refuses the agents route", func(t *testing.T) {
+		// Sanity: the dangerous route really is reachable, so the refusal below is meaningful.
+		if resp, err := http.Get("http://127.0.0.1:1337/agents"); err == nil {
+			t.Logf("real Osaurus GET /agents -> %d (reachable unauthenticated; this is the surface the allowlist guards)", resp.StatusCode)
+			resp.Body.Close()
+		}
+		job := protocol.Job{ID: "e2e-agents", User: "u", Path: "/agents/abc-123/run",
+			Body: []byte(`{"messages":[{"role":"user","content":"hi"}]}`)}
+		res := serve(cfg, protocol.ModelOffer{Model: offered}, priv, client, job)
+		if res.Status != http.StatusNotFound {
+			t.Fatalf("agents-route relay status = %d, want 404 (the node must refuse it)", res.Status)
+		}
+		if !strings.Contains(strings.ToLower(string(res.Body)), "unsupported path") {
+			t.Errorf("refusal body = %s, want an 'unsupported path' error", truncate(res.Body))
+		}
+		t.Logf("allowlist OK: /agents/{id}/run refused with %d %s", res.Status, truncate(res.Body))
+	})
+}
+
+func truncate(b []byte) string {
+	s := string(b)
+	if len(s) > 200 {
+		return s[:200] + "..."
+	}
+	return s
+}

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -180,6 +180,7 @@ func ProbeKey(rawURL, key string) (Found, Status) {
 		enrichCtx(&f, base)
 		classifyModalities(&f, base)
 		classifyCapabilities(&f, base)
+		brandOsaurus(&f)
 		return f, Reachable
 	case probeAuth:
 		return Found{BaseURL: base}, NeedsKey
@@ -249,6 +250,9 @@ func detectWith(priority []candidate) (found []Found, needKey []string) {
 			enrichCtx(&f, base)
 			classifyModalities(&f, base)
 			classifyCapabilities(&f, base)
+			// Osaurus shares Jan's :1337, so the port label is ambiguous — re-brand it
+			// from the served root banner before the offer goes on air.
+			brandOsaurus(&f)
 			found = append(found, f)
 		case probeAuth:
 			// Present but key-protected and no env key fit: surface it so the caller can
@@ -276,6 +280,47 @@ func detectWith(priority []candidate) (found []Found, needKey []string) {
 		}
 	}
 	return found, needKey
+}
+
+// osaurusBanner is the distinctive body Osaurus's root route returns (GET / on its
+// :1337 default — which it SHARES with Jan — or on a custom port). Matched as a substring
+// (not the exact bytes) so a trailing newline or the dino-emoji encoding can't cause a miss.
+const osaurusBanner = "Osaurus Server is running"
+
+// isOsaurus fingerprints the server at base (a .../v1 URL) as Osaurus by fetching its root
+// (GET /) and matching osaurusBanner. Osaurus squats Jan's default :1337 port, so the port
+// label alone ("jan") is ambiguous; this disambiguates it before `roger share` labels the
+// offer. Best-effort and short-timeout (the detection probe budget): a non-Osaurus server
+// does not match and keeps its original label. No key is sent — the banner is unauthenticated,
+// which keeps the probe consistent with the port-scan "never spray a key at it" policy.
+func isOsaurus(base string) bool {
+	root := strings.TrimSuffix(base, "/v1")
+	resp, err := authGet(root+"/", "")
+	if err != nil || resp == nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return strings.Contains(string(body), osaurusBanner)
+}
+
+// IsOsaurus reports whether the server at base (a .../v1 URL) fingerprints as Osaurus via its
+// root banner (GET /). Exported so `roger share` can decide ONCE, at share time, whether the
+// resolved upstream is Osaurus and set agent.Config.Osaurus - which gates the Osaurus-only relay
+// hardenings (X-Persist, model-pin) without the relay re-probing per job.
+func IsOsaurus(base string) bool { return isOsaurus(base) }
+
+// brandOsaurus re-labels a reachable server "osaurus" when its root banner fingerprints as
+// Osaurus, overriding the ambiguous source label ("jan" on the :1337 slot, or "port:N" /
+// "configured" on a custom port) so the on-air offer names the true backend. A no-op for any
+// server that does not match.
+func brandOsaurus(f *Found) {
+	if isOsaurus(f.BaseURL) {
+		f.Name = "osaurus"
+	}
 }
 
 // probeResult is probeModels' tri-state: a usable server, a key-protected one, or

--- a/internal/detect/osaurus_test.go
+++ b/internal/detect/osaurus_test.go
@@ -1,0 +1,132 @@
+package detect
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// osaurusServer mimics an Osaurus node: an OpenAI-compatible GET /v1/models PLUS the
+// distinctive root banner Osaurus returns at GET / — the fingerprint that disambiguates
+// it from Jan, which shares the default :1337 port.
+func osaurusServer(models ...string) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+		var data []map[string]string
+		for _, m := range models {
+			data = append(data, map[string]string{"id": m})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("Osaurus Server is running! 🦕"))
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestIsOsaurusFingerprint: the root-banner fingerprint is true ONLY for a real Osaurus
+// banner. A Jan-style server (no matching banner), a look-alike with a different root
+// body, and a dead endpoint all read as not-Osaurus.
+func TestIsOsaurusFingerprint(t *testing.T) {
+	osa := osaurusServer("gpt-oss-20b")
+	defer osa.Close()
+	jan := fakeServer("jan-model") // ServeMux 404s GET / — no banner
+	defer jan.Close()
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Jan API is running"))
+	}))
+	defer other.Close()
+
+	cases := []struct {
+		name string
+		base string
+		want bool
+	}{
+		{"osaurus banner", osa.URL + "/v1", true},
+		{"jan no banner", jan.URL + "/v1", false},
+		{"different banner", other.URL + "/v1", false},
+		{"dead endpoint", "http://127.0.0.1:1/v1", false},
+	}
+	for _, c := range cases {
+		if got := isOsaurus(c.base); got != c.want {
+			t.Errorf("%s: isOsaurus(%q) = %v, want %v", c.name, c.base, got, c.want)
+		}
+	}
+}
+
+// TestIsOsaurusExported: the exported wrapper `roger share` uses to set Config.Osaurus once at
+// share time - a thin wrapper over isOsaurus, tested directly so the earning/hardening entry point
+// is covered (not only via the OSAURUS_E2E-gated live test).
+func TestIsOsaurusExported(t *testing.T) {
+	osa := osaurusServer("gpt-oss-20b")
+	defer osa.Close()
+	jan := fakeServer("jan-model")
+	defer jan.Close()
+	if !IsOsaurus(osa.URL + "/v1") {
+		t.Error("IsOsaurus should be true for a real Osaurus banner")
+	}
+	if IsOsaurus(jan.URL + "/v1") {
+		t.Error("IsOsaurus should be false for a non-Osaurus server")
+	}
+	if IsOsaurus("http://127.0.0.1:1/v1") {
+		t.Error("IsOsaurus should be false for a dead endpoint")
+	}
+}
+
+// TestDetectBrandsOsaurus: a server sitting on the :1337 slot (labeled "jan" by port)
+// that fingerprints as Osaurus is re-branded "osaurus" so `roger share` labels the offer
+// with the true backend.
+func TestDetectBrandsOsaurus(t *testing.T) {
+	defer quietSources(t)()
+	srv := osaurusServer("gpt-oss-20b")
+	defer srv.Close()
+
+	old := probes
+	probes = []struct{ name, base string }{{"jan", srv.URL + "/v1"}}
+	defer func() { probes = old }()
+
+	found, _ := DetectFull()
+	if len(found) != 1 {
+		t.Fatalf("found %d servers, want 1: %+v", len(found), found)
+	}
+	if found[0].Name != "osaurus" {
+		t.Errorf("Osaurus on the jan/:1337 slot should re-brand to osaurus, got %q", found[0].Name)
+	}
+}
+
+// TestDetectKeepsJanName: a genuine Jan server (no Osaurus banner) on the same slot keeps
+// its "jan" label — the fingerprint must not re-brand every :1337 server.
+func TestDetectKeepsJanName(t *testing.T) {
+	defer quietSources(t)()
+	srv := fakeServer("jan-model") // no banner at GET /
+	defer srv.Close()
+
+	old := probes
+	probes = []struct{ name, base string }{{"jan", srv.URL + "/v1"}}
+	defer func() { probes = old }()
+
+	found, _ := DetectFull()
+	if len(found) != 1 || found[0].Name != "jan" {
+		t.Fatalf("a non-Osaurus server must keep its jan label, got %+v", found)
+	}
+}
+
+// TestProbeKeyBrandsOsaurus: the guided-fallback "paste a URL" path also re-brands an
+// Osaurus upstream, so a manually-configured Osaurus offer is labeled correctly.
+func TestProbeKeyBrandsOsaurus(t *testing.T) {
+	srv := osaurusServer("gpt-oss-20b")
+	defer srv.Close()
+
+	f, st := ProbeKey(srv.URL, "")
+	if st != Reachable {
+		t.Fatalf("ProbeKey status = %v, want Reachable", st)
+	}
+	if f.Name != "osaurus" {
+		t.Errorf("ProbeKey should brand an Osaurus upstream, got name %q", f.Name)
+	}
+}

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -375,7 +375,7 @@
         <article class="twoway__side">
           <div class="twoway__tag twoway__tag--air">go on air</div>
           <h3>Share a model</h3>
-          <p>Point RogerAI at your local backend (vLLM, llama.cpp, Ollama, LM Studio). Set a call-sign,
+          <p>Point RogerAI at your local backend (vLLM, llama.cpp, Ollama, LM Studio, Osaurus). Set a call-sign,
             a rate, and your hours. Flip the switch. You are on air.</p>
           <code class="twoway__cmd">roger share qwen3-coder-30b --rate 0.30</code>
         </article>
@@ -435,7 +435,7 @@
         </div>
         <div class="spec__row">
           <dt>Backends</dt>
-          <dd><span class="mono">vLLM · llama.cpp · Ollama · LM Studio · LiteLLM · any OpenAI-compatible</span></dd>
+          <dd><span class="mono">vLLM · llama.cpp · Ollama · LM Studio · Osaurus · LiteLLM · any OpenAI-compatible</span></dd>
         </div>
         <div class="spec__row">
           <dt>Reach</dt>


### PR DESCRIPTION
Lets a Mac running Osaurus put its served model on the band via roger share (built on the Mac, landed through the Linux cover-gate + claude-audit). Purely additive: Osaurus detection fingerprint (internal/detect), relay hardenings on the node (X-Persist:false so tuner traffic never pollutes the owner's Osaurus history; body.model pinned to the offered model so a tuner can't force-load another local model), and Osaurus in the operator backend listing. Pinned by features/relay/osaurus_hardening.feature (12 scenarios) + a gated live-E2E (OSAURUS_E2E=1). Builds on the already-merged path allowlist. Cover-gate PASS (agent 93.1%, detect 91.7%), -race clean (after the pre-existing heartbeat race fix, #60). Cherry-picked cleanly onto current main (the Mac branch was stale).