### PR TITLE
iap: StoreKit In-App Purchase top-ups + refund clawback (Apple Guideline 3.1.1)

### DIFF
--- a/cmd/rogerai-broker/iap.go
+++ b/cmd/rogerai-broker/iap.go
@@ -1,0 +1,408 @@
+package main
+
+// iap.go: StoreKit 2 In-App Purchase top-ups (Apple Guideline 3.1.1). The iOS app buys a consumable
+// and POSTs the signed StoreKit transaction (a JWS) here; the broker VERIFIES it server-side (the
+// client's word is never trusted) and credits the wallet through the SAME idempotent primitive Stripe
+// uses (CreditOnce -> KindTopup), so balance/history/-me are identical to a card top-up. Pricing is
+// round + 1:1 (a $10 product credits $10; RogerAI absorbs Apple's cut - see the productId map).
+//
+// Security posture mirrors the Stripe path and verifyAppleIdentityToken: credits derive from the
+// SIGNED transaction, never from client metadata; the JWS is checked to a PINNED Apple root; only
+// ES256 is accepted (alg-confusion defense); idempotent on Apple's transactionId so the purchase POST
+// and the app's Transaction.updates re-delivery can both fire without double-crediting.
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"log"
+	"math/big"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// iapProducts maps a StoreKit consumable product id to the USD face value credited 1:1 (founder:
+// round price points, no markup - RogerAI eats Apple's ~30%). The credited amount is server-
+// authoritative; the client-sent product_id is advisory and never trusted for the amount.
+var iapProducts = map[string]float64{
+	"fyi.rogerai.topup.5":  5,
+	"fyi.rogerai.topup.10": 10,
+	"fyi.rogerai.topup.20": 20,
+	"fyi.rogerai.topup.50": 50,
+}
+
+// iapBundleID is the only app whose transactions we credit.
+const iapBundleID = "fyi.rogerai.app"
+
+// appleRootG3PEM is Apple Root CA - G3, the trust anchor for StoreKit signed transactions. Pinned from
+// https://www.apple.com/certificateauthority/ ("Apple Root CA - G3", self-signed, valid 2014-2039);
+// verified SHA-256 fingerprint 63:34:3A:BF:B8:9A:6A:03:EB:B5:7E:9B:3F:5F:A7:BE:7C:4F:5C:75:6F:30:17:B3:
+// A8:C4:88:C3:65:3E:91:79. ROGERAI_APPLE_ROOT_PEM overrides it at runtime; if neither parses,
+// /iap/credit returns 503 (fail-closed, like unconfigured Stripe) so a misconfigured broker never credits
+// on an unverifiable transaction.
+const appleRootG3PEM = `-----BEGIN CERTIFICATE-----
+MIICQzCCAcmgAwIBAgIILcX8iNLFS5UwCgYIKoZIzj0EAwMwZzEbMBkGA1UEAwwS
+QXBwbGUgUm9vdCBDQSAtIEczMSYwJAYDVQQLDB1BcHBsZSBDZXJ0aWZpY2F0aW9u
+IEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcN
+MTQwNDMwMTgxOTA2WhcNMzkwNDMwMTgxOTA2WjBnMRswGQYDVQQDDBJBcHBsZSBS
+b290IENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9y
+aXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzB2MBAGByqGSM49
+AgEGBSuBBAAiA2IABJjpLz1AcqTtkyJygRMc3RCV8cWjTnHcFBbZDuWmBSp3ZHtf
+TjjTuxxEtX/1H7YyYl3J6YRbTzBPEVoA/VhYDKX1DyxNB0cTddqXl5dvMVztK517
+IDvYuVTZXpmkOlEKMaNCMEAwHQYDVR0OBBYEFLuw3qFYM4iapIqZ3r6966/ayySr
+MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMDA2gA
+MGUCMQCD6cHEFl4aXTQY2e3v9GwOAEZLuN+yRhHFD/3meoyhpmvOwgPUnPWTxnS4
+at+qIxUCMG1mihDK1A3UT82NQz60imOlM27jbdoXt2QfyFMm+YhidDkLF1vLUagM
+6BgD56KyKA==
+-----END CERTIFICATE-----`
+
+// appleRoot is the parsed trust anchor. nil => /iap/credit is 503. Set by loadAppleRoot() at startup;
+// tests set it directly to a test root so the verifier can be exercised with a generated chain.
+var appleRoot *x509.Certificate
+
+// loadAppleRoot parses the Apple root from ROGERAI_APPLE_ROOT_PEM (preferred) or the embedded const.
+func loadAppleRoot() {
+	pemStr := strings.TrimSpace(os.Getenv("ROGERAI_APPLE_ROOT_PEM"))
+	if pemStr == "" {
+		pemStr = strings.TrimSpace(appleRootG3PEM)
+	}
+	if pemStr == "" {
+		log.Printf("iap: no Apple root configured (set ROGERAI_APPLE_ROOT_PEM) - /iap/credit disabled")
+		return
+	}
+	if c := parseCertPEM(pemStr); c != nil {
+		appleRoot = c
+		log.Printf("iap: StoreKit top-ups enabled (Apple root loaded)")
+	} else {
+		log.Printf("iap: Apple root PEM invalid - /iap/credit disabled")
+	}
+}
+
+// parseCertPEM decodes one PEM CERTIFICATE block into an *x509.Certificate (nil on failure).
+func parseCertPEM(s string) *x509.Certificate {
+	blk, _ := pem.Decode([]byte(s))
+	if blk == nil {
+		return nil
+	}
+	c, err := x509.ParseCertificate(blk.Bytes)
+	if err != nil {
+		return nil
+	}
+	return c
+}
+
+// storeKitTxn is the subset of a StoreKit 2 JWSTransaction payload we enforce/use.
+type storeKitTxn struct {
+	BundleID              string `json:"bundleId"`
+	ProductID             string `json:"productId"`
+	TransactionID         string `json:"transactionId"`
+	OriginalTransactionID string `json:"originalTransactionId"`
+	Type                  string `json:"type"`
+	Environment           string `json:"environment"` // "Sandbox" | "Production"
+}
+
+// verifyJWSPayload verifies an Apple JWS and returns its raw decoded payload bytes. It enforces: ES256
+// only (alg-confusion defense); an x5c cert chain that verifies to `root` (the pinned Apple root) with
+// valid dates at `now`; and an ECDSA signature over the signing input made by the leaf key. It is the
+// crypto SHARED by a StoreKit signed transaction and an App Store Server Notification V2 (the same
+// signed-JWS envelope wraps different payload shapes). ok=false on any failure (the caller maps that to
+// one opaque status - never leak which check failed).
+func verifyJWSPayload(jws string, root *x509.Certificate, now time.Time) ([]byte, bool) {
+	if root == nil {
+		return nil, false
+	}
+	parts := strings.Split(jws, ".")
+	if len(parts) != 3 {
+		return nil, false
+	}
+	hdrJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, false
+	}
+	var hdr struct {
+		Alg string   `json:"alg"`
+		X5c []string `json:"x5c"`
+	}
+	if json.Unmarshal(hdrJSON, &hdr) != nil {
+		return nil, false
+	}
+	if hdr.Alg != "ES256" { // reject none/HS*/RS*/ES384 - alg-confusion / key-substitution defense
+		return nil, false
+	}
+	if len(hdr.X5c) == 0 {
+		return nil, false
+	}
+	// x5c entries are STANDARD-base64 DER certs, leaf first.
+	var certs []*x509.Certificate
+	for _, c := range hdr.X5c {
+		der, err := base64.StdEncoding.DecodeString(c)
+		if err != nil {
+			return nil, false
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			return nil, false
+		}
+		certs = append(certs, cert)
+	}
+	leaf := certs[0]
+	roots := x509.NewCertPool()
+	roots.AddCert(root)
+	inter := x509.NewCertPool()
+	for _, c := range certs[1:] {
+		inter.AddCert(c)
+	}
+	// Chain to the pinned root with valid dates. ExtKeyUsageAny: Apple's transaction-signing leaf is not
+	// a TLS server cert, so we must not require ServerAuth (the default) - date + chain to the pinned
+	// root is the trust we need.
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: inter,
+		CurrentTime:   now,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		return nil, false
+	}
+	pub, ok := leaf.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, false
+	}
+	// JWS ES256 signature is raw r||s (64 bytes), not ASN.1 DER.
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil || len(sig) != 64 {
+		return nil, false
+	}
+	sum := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	r := new(big.Int).SetBytes(sig[:32])
+	s := new(big.Int).SetBytes(sig[32:])
+	if !ecdsa.Verify(pub, sum[:], r, s) {
+		return nil, false
+	}
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, false
+	}
+	return payloadJSON, true
+}
+
+// verifyStoreKitJWS validates a StoreKit signed transaction JWS and returns its decoded payload.
+func verifyStoreKitJWS(jws string, root *x509.Certificate, now time.Time) (storeKitTxn, bool) {
+	payload, ok := verifyJWSPayload(jws, root, now)
+	if !ok {
+		return storeKitTxn{}, false
+	}
+	var txn storeKitTxn
+	if json.Unmarshal(payload, &txn) != nil {
+		return storeKitTxn{}, false
+	}
+	return txn, true
+}
+
+// iapWallet resolves the wallet an IAP credit lands on, requiring a web session OR a VERIFIED owner
+// signature (authed). Unlike checkoutWallet it rejects an unsigned request - an IAP credit with no
+// identified wallet must not succeed. A signed anon device key authes to its own pubkey wallet.
+func (b *broker) iapWallet(r *http.Request, body []byte) (string, bool) {
+	if _, sw, sok := b.webSession(r); sok {
+		return sw, true
+	}
+	if u, authed, iok := b.identityOf(r, body); iok && authed {
+		return b.walletOf(r, u), true
+	}
+	return "", false
+}
+
+// iapCredit handles POST /iap/credit: an owner-signed request carrying a StoreKit JWS transaction.
+// It verifies the JWS to the pinned Apple root, maps the product to a USD face value, and credits the
+// signed request's wallet ONCE (idempotent on Apple's transactionId). Response: {credited, balance, usd}.
+func (b *broker) iapCredit(w http.ResponseWriter, r *http.Request) {
+	if corsCredsPreflight(w, r) {
+		return
+	}
+	corsCreds(w, r)
+	if !allow(w, r, http.MethodPost) {
+		return
+	}
+	if appleRoot == nil {
+		jsonErr(w, http.StatusServiceUnavailable, "iap not configured")
+		return
+	}
+	body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	// Resolve the wallet to credit. Unlike the Stripe checkout (which tolerates an unsigned anon
+	// request because the Stripe session ties the payment to a wallet), an IAP credit MUST identify a
+	// wallet up front - the JWS proves a payment happened but not whose it is. So we require a web
+	// session OR a VERIFIED owner signature (authed); an unsigned request has no wallet and is refused.
+	// A signed anon device key still authes (authed=true, its own pubkey wallet - claimable on login).
+	user, ok := b.iapWallet(r, body)
+	if !ok {
+		jsonErr(w, http.StatusUnauthorized, "invalid request signature")
+		return
+	}
+	var req struct {
+		JWS       string `json:"jws"`
+		ProductID string `json:"product_id"`
+	}
+	if json.Unmarshal(body, &req) != nil || req.JWS == "" {
+		jsonErr(w, http.StatusBadRequest, "missing jws")
+		return
+	}
+	txn, ok := verifyStoreKitJWS(req.JWS, appleRoot, time.Now())
+	if !ok {
+		jsonErr(w, http.StatusUnauthorized, "invalid transaction")
+		return
+	}
+	if txn.BundleID != iapBundleID {
+		jsonErr(w, http.StatusBadRequest, "wrong app")
+		return
+	}
+	if txn.Type != "Consumable" {
+		jsonErr(w, http.StatusBadRequest, "unsupported product type")
+		return
+	}
+	// Environment gate (mirrors the sk_live fail-closed gate): in require-live mode a Sandbox
+	// transaction must never credit real balance.
+	if requireLive() && txn.Environment != "Production" {
+		jsonErr(w, http.StatusBadRequest, "sandbox transaction refused in production")
+		return
+	}
+	// The JWS is truth; a client product_id that disagrees is logged and ignored (like the Stripe
+	// metadata-vs-amount_total divergence check).
+	if req.ProductID != "" && req.ProductID != txn.ProductID {
+		log.Printf("iap: client product_id %q diverges from JWS %q - using the JWS", req.ProductID, txn.ProductID)
+	}
+	usd, ok := iapProducts[txn.ProductID]
+	if !ok {
+		jsonErr(w, http.StatusBadRequest, "unknown product")
+		return
+	}
+	creditUSD := b.bill.creditUSD
+	if creditUSD <= 0 {
+		creditUSD = 1 // IAP does not require Stripe to be configured; 1 credit = $1 default
+	}
+	credits := usd / creditUSD
+
+	// Atomic credit-once: idempotent on Apple's transactionId, so the purchase POST + the app's
+	// Transaction.updates re-delivery collapse to a single KindTopup row (never double-credits).
+	credited, newBal, err := b.db.CreditOnce("apple:"+txn.TransactionID, user, credits)
+	if err != nil {
+		jsonErr(w, http.StatusInternalServerError, "store error")
+		return
+	}
+	if credited {
+		log.Printf("iap: credited %s +%.4f -> %.4f (txn %s)", user, credits, newBal, txn.TransactionID)
+	} else {
+		log.Printf("iap: duplicate txn %s ignored", txn.TransactionID)
+	}
+	// Persist the Apple transaction -> wallet mapping so a later refund notification (Stage D, which
+	// carries no signed request) can resolve the wallet. Reuses the SAME charge-map machinery Stripe
+	// disputes use (WalletByCharge), keyed on the Apple transaction ids - no new store surface.
+	if err := b.db.LinkCharge("apple-txn-"+txn.TransactionID, "apple:"+txn.TransactionID, "apple:"+txn.OriginalTransactionID, user, credits); err != nil {
+		log.Printf("iap: LinkCharge(txn %s) failed: %v (refund clawback may not resolve this txn)", txn.TransactionID, err)
+	}
+
+	bal, _ := b.db.BalanceOf(user, b.seedFunds)
+	writeJSON(w, http.StatusOK, map[string]any{"credited": credited, "balance": bal, "usd": usd})
+}
+
+// appStoreNotificationV2 is the subset of an App Store Server Notification V2 decoded payload we act on.
+type appStoreNotificationV2 struct {
+	NotificationType string `json:"notificationType"`
+	Subtype          string `json:"subtype"`
+	NotificationUUID string `json:"notificationUUID"`
+	Data             struct {
+		BundleID              string `json:"bundleId"`
+		Environment           string `json:"environment"`
+		SignedTransactionInfo string `json:"signedTransactionInfo"`
+	} `json:"data"`
+}
+
+// iapNotifications handles POST /iap/notifications: Apple's App Store Server Notifications V2. Apple
+// (not a signed client) POSTs {"signedPayload": <JWS>}; the JWS is verified to the SAME pinned Apple
+// root as a credit. We act ONLY on REFUND - clawing back the credited amount through the SAME lineage
+// engine a Stripe refund uses (KindRefund + operator paid-lot reversal + platform-loss), idempotent so
+// an Apple redelivery claws back zero the second time. Every other notification type, a sandbox
+// notification in prod, and a refund for a transaction we never credited here are all acknowledged with
+// 200 so Apple stops retrying. Only an unverifiable / garbage payload is a 4xx.
+func (b *broker) iapNotifications(w http.ResponseWriter, r *http.Request) {
+	if !allow(w, r, http.MethodPost) {
+		return
+	}
+	if appleRoot == nil {
+		jsonErr(w, http.StatusServiceUnavailable, "iap not configured")
+		return
+	}
+	body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	var envlp struct {
+		SignedPayload string `json:"signedPayload"`
+	}
+	if json.Unmarshal(body, &envlp) != nil || envlp.SignedPayload == "" {
+		jsonErr(w, http.StatusBadRequest, "missing signedPayload")
+		return
+	}
+	now := time.Now()
+	payload, ok := verifyJWSPayload(envlp.SignedPayload, appleRoot, now)
+	if !ok {
+		jsonErr(w, http.StatusUnauthorized, "invalid notification signature")
+		return
+	}
+	var note appStoreNotificationV2
+	if json.Unmarshal(payload, &note) != nil {
+		jsonErr(w, http.StatusBadRequest, "bad notification payload")
+		return
+	}
+	if note.Data.BundleID != iapBundleID {
+		jsonErr(w, http.StatusBadRequest, "wrong app")
+		return
+	}
+	// Sandbox notification in require-live mode: acknowledge (so Apple stops retrying) but never touch
+	// real balance. Sandbox uses a separate notification URL anyway.
+	if requireLive() && note.Data.Environment != "Production" {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "ignored": "sandbox"})
+		return
+	}
+	// Only REFUND claws back; every other type is acknowledged without acting.
+	if note.NotificationType != "REFUND" {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "ignored": note.NotificationType})
+		return
+	}
+	// Verify + decode the inner signed transaction to learn WHICH transaction was refunded.
+	txn, ok := verifyStoreKitJWS(note.Data.SignedTransactionInfo, appleRoot, now)
+	if !ok {
+		jsonErr(w, http.StatusUnauthorized, "invalid transaction info")
+		return
+	}
+	// Resolve the wallet + the exact amount we credited for this transaction (persisted by iapCredit's
+	// LinkCharge). Unknown => a refund for a transaction we never credited here; acknowledge and no-op.
+	chargeRef := "apple:" + txn.TransactionID
+	wallet, credits, known, err := b.db.WalletByCharge(chargeRef)
+	if err != nil {
+		jsonErr(w, http.StatusInternalServerError, "store error")
+		return
+	}
+	if !known || wallet == "" {
+		log.Printf("iap: REFUND for unknown txn %s - no-op", txn.TransactionID)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "ignored": "unknown transaction"})
+		return
+	}
+	// Claw back through the SAME lineage engine a Stripe refund uses, idempotent in its own namespace
+	// ("applerefund:") so an Apple redelivery is a no-op. refundAmount is the exact amount credited, so
+	// the clawback can never exceed it regardless of the charge cap.
+	refundID := "applerefund:" + txn.TransactionID
+	chargeRefs := []string{chargeRef, "apple:" + txn.OriginalTransactionID}
+	res, eff, err := b.db.RefundLineage(refundID, chargeRefs, wallet, "apple-refund-"+txn.TransactionID, credits, now)
+	if err != nil {
+		jsonErr(w, http.StatusInternalServerError, "clawback error")
+		return
+	}
+	if res.AlreadyHandled {
+		log.Printf("iap: REFUND redelivery for txn %s ignored (already clawed back)", txn.TransactionID)
+	} else {
+		log.Printf("iap: REFUND txn %s clawed back %.4f from %s", txn.TransactionID, eff, wallet)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "clawed_back": eff})
+}

--- a/cmd/rogerai-broker/iap_test.go
+++ b/cmd/rogerai-broker/iap_test.go
@@ -1,0 +1,423 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// --- test PKI + JWS helpers (REAL crypto, no mocks) ---
+
+func genCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen ca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "test root"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(24 * time.Hour),
+		IsCA: true, KeyUsage: x509.KeyUsageCertSign, BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create ca: %v", err)
+	}
+	c, _ := x509.ParseCertificate(der)
+	return c, key
+}
+
+func genLeaf(t *testing.T, parent *x509.Certificate, parentKey *ecdsa.PrivateKey, notAfter time.Time) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen leaf key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2), Subject: pkix.Name{CommonName: "test leaf"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: notAfter, BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+	c, _ := x509.ParseCertificate(der)
+	return c, key
+}
+
+// makeJWS builds a StoreKit-style JWS: header{alg, x5c=std-base64 DER leaf..root}, payload, ES256 raw r||s.
+func makeJWS(t *testing.T, leafKey *ecdsa.PrivateKey, chain []*x509.Certificate, payload any, alg string) string {
+	t.Helper()
+	x5c := make([]string, len(chain))
+	for i, c := range chain {
+		x5c[i] = base64.StdEncoding.EncodeToString(c.Raw)
+	}
+	hb, _ := json.Marshal(map[string]any{"alg": alg, "x5c": x5c})
+	pb, _ := json.Marshal(payload)
+	signingInput := base64.RawURLEncoding.EncodeToString(hb) + "." + base64.RawURLEncoding.EncodeToString(pb)
+	sum := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(rand.Reader, leafKey, sum[:])
+	if err != nil {
+		t.Fatalf("sign jws: %v", err)
+	}
+	sig := make([]byte, 64)
+	r.FillBytes(sig[:32])
+	s.FillBytes(sig[32:])
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func goodTxn() storeKitTxn {
+	return storeKitTxn{
+		BundleID: iapBundleID, ProductID: "fyi.rogerai.topup.10", TransactionID: "txn-1",
+		OriginalTransactionID: "otxn-1", Type: "Consumable", Environment: "Sandbox",
+	}
+}
+
+// --- verifier unit tests (real chain) ---
+
+func TestVerifyStoreKitJWS(t *testing.T) {
+	root, rootKey := genCA(t)
+	leaf, leafKey := genLeaf(t, root, rootKey, time.Now().Add(time.Hour))
+	chain := []*x509.Certificate{leaf, root}
+	now := time.Now()
+
+	// valid
+	jws := makeJWS(t, leafKey, chain, goodTxn(), "ES256")
+	if txn, ok := verifyStoreKitJWS(jws, root, now); !ok || txn.TransactionID != "txn-1" || txn.ProductID != "fyi.rogerai.topup.10" {
+		t.Fatalf("valid jws should verify, got ok=%v txn=%+v", ok, txn)
+	}
+	// nil root -> false
+	if _, ok := verifyStoreKitJWS(jws, nil, now); ok {
+		t.Error("nil root must not verify")
+	}
+	// wrong (unrelated) root -> chain fails
+	other, _ := genCA(t)
+	if _, ok := verifyStoreKitJWS(jws, other, now); ok {
+		t.Error("a JWS whose chain does not reach the pinned root must fail")
+	}
+	// alg != ES256 (alg-confusion) -> false, even though the bytes are ES256-signed
+	if _, ok := verifyStoreKitJWS(makeJWS(t, leafKey, chain, goodTxn(), "RS256"), root, now); ok {
+		t.Error("non-ES256 alg header must be rejected")
+	}
+	// tampered signature -> false
+	bad := jws[:len(jws)-2] + func() string {
+		if jws[len(jws)-1] == 'A' {
+			return "BB"
+		}
+		return "AA"
+	}()
+	if _, ok := verifyStoreKitJWS(bad, root, now); ok {
+		t.Error("tampered signature must be rejected")
+	}
+	// expired leaf -> false
+	expLeaf, expKey := genLeaf(t, root, rootKey, time.Now().Add(-time.Minute))
+	expJWS := makeJWS(t, expKey, []*x509.Certificate{expLeaf, root}, goodTxn(), "ES256")
+	if _, ok := verifyStoreKitJWS(expJWS, root, now); ok {
+		t.Error("expired leaf cert must be rejected")
+	}
+	// garbage
+	if _, ok := verifyStoreKitJWS("not.a.jws", root, now); ok {
+		t.Error("garbage must be rejected")
+	}
+}
+
+// --- handler tests (full flow: verify -> credit -> idempotency) ---
+
+func iapPost(t *testing.T, b *broker, priv ed25519.PrivateKey, jws, productID string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"jws": jws, "product_id": productID})
+	r := httptest.NewRequest(http.MethodPost, "/iap/credit", bytes.NewReader(body))
+	signReq(r, priv, body)
+	w := httptest.NewRecorder()
+	b.iapCredit(w, r)
+	return w
+}
+
+func decodeIAP(t *testing.T, w *httptest.ResponseRecorder) (credited bool, balance, usd float64) {
+	t.Helper()
+	var out struct {
+		Credited bool    `json:"credited"`
+		Balance  float64 `json:"balance"`
+		USD      float64 `json:"usd"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("bad response %q: %v", w.Body.String(), err)
+	}
+	return out.Credited, out.Balance, out.USD
+}
+
+func TestIAPCreditAndIdempotency(t *testing.T) {
+	root, rootKey := genCA(t)
+	leaf, leafKey := genLeaf(t, root, rootKey, time.Now().Add(time.Hour))
+	chain := []*x509.Certificate{leaf, root}
+	appleRoot = root
+	defer func() { appleRoot = nil }()
+
+	mem := store.NewMem()
+	b := &broker{db: mem, pubOfUser: map[string]string{}, seedFunds: 0}
+	_, priv, _ := ed25519.GenerateKey(nil)
+	jws := makeJWS(t, leafKey, chain, goodTxn(), "ES256")
+
+	// first credit
+	w := iapPost(t, b, priv, jws, "fyi.rogerai.topup.10")
+	if w.Code != http.StatusOK {
+		t.Fatalf("first credit status %d: %s", w.Code, w.Body.String())
+	}
+	credited, bal, usd := decodeIAP(t, w)
+	if !credited || bal != 10 || usd != 10 {
+		t.Fatalf("first credit = credited:%v bal:%v usd:%v, want true/10/10", credited, bal, usd)
+	}
+
+	// REPLAY the same transaction (the app's purchase POST + Transaction.updates can both fire):
+	// credits ZERO, balance unchanged.
+	w2 := iapPost(t, b, priv, jws, "fyi.rogerai.topup.10")
+	credited2, bal2, _ := decodeIAP(t, w2)
+	if credited2 {
+		t.Error("replayed transaction must not credit again")
+	}
+	if bal2 != 10 {
+		t.Errorf("balance after replay = %v, want 10 (no double-credit)", bal2)
+	}
+
+	// the refund-resolution mapping was persisted (Stage D reuses WalletByCharge on the Apple ref)
+	if wlt, cr, ok, _ := mem.WalletByCharge("apple:txn-1"); !ok || cr != 10 || wlt == "" {
+		t.Errorf("apple txn should map to the wallet for refund resolution, got ok=%v wallet=%q credits=%v", ok, wlt, cr)
+	}
+}
+
+func TestIAPCreditRejections(t *testing.T) {
+	root, rootKey := genCA(t)
+	leaf, leafKey := genLeaf(t, root, rootKey, time.Now().Add(time.Hour))
+	chain := []*x509.Certificate{leaf, root}
+	appleRoot = root
+	defer func() { appleRoot = nil }()
+	_, priv, _ := ed25519.GenerateKey(nil)
+
+	newB := func() *broker { return &broker{db: store.NewMem(), pubOfUser: map[string]string{}, seedFunds: 0} }
+	jwsOf := func(txn storeKitTxn) string { return makeJWS(t, leafKey, chain, txn, "ES256") }
+
+	cases := []struct {
+		name string
+		txn  storeKitTxn
+		want int
+	}{
+		{"wrong bundle", func() storeKitTxn { x := goodTxn(); x.BundleID = "com.evil.app"; return x }(), http.StatusBadRequest},
+		{"wrong type", func() storeKitTxn { x := goodTxn(); x.Type = "Auto-Renewable Subscription"; return x }(), http.StatusBadRequest},
+		{"unknown product", func() storeKitTxn { x := goodTxn(); x.ProductID = "fyi.rogerai.topup.999"; return x }(), http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		w := iapPost(t, newB(), priv, jwsOf(c.txn), "")
+		if w.Code != c.want {
+			t.Errorf("%s: status %d, want %d (%s)", c.name, w.Code, c.want, w.Body.String())
+		}
+	}
+
+	// unsigned request -> 401
+	body, _ := json.Marshal(map[string]string{"jws": jwsOf(goodTxn())})
+	r := httptest.NewRequest(http.MethodPost, "/iap/credit", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	newB().iapCredit(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("unsigned request status %d, want 401", w.Code)
+	}
+
+	// unconfigured root -> 503
+	appleRoot = nil
+	w503 := iapPost(t, newB(), priv, jwsOf(goodTxn()), "")
+	if w503.Code != http.StatusServiceUnavailable {
+		t.Errorf("unconfigured root status %d, want 503", w503.Code)
+	}
+	appleRoot = root // restore for defer symmetry (defer sets nil anyway)
+}
+
+// TestLoadAppleRoot covers the startup config: parsing a PEM root and loading it from the env
+// (and the fail-closed branches - no root / invalid PEM leave appleRoot nil so /iap/credit is 503).
+func TestLoadAppleRoot(t *testing.T) {
+	root, _ := genCA(t)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: root.Raw})
+
+	if parseCertPEM(string(pemBytes)) == nil {
+		t.Fatal("a valid CERTIFICATE PEM should parse")
+	}
+	if parseCertPEM("not a pem block") != nil {
+		t.Error("garbage should not parse")
+	}
+	if parseCertPEM("-----BEGIN CERTIFICATE-----\nZm9v\n-----END CERTIFICATE-----") != nil {
+		t.Error("a PEM block with non-cert DER should not parse")
+	}
+
+	defer func() { appleRoot = nil }()
+	// env-provided PEM loads
+	appleRoot = nil
+	t.Setenv("ROGERAI_APPLE_ROOT_PEM", string(pemBytes))
+	loadAppleRoot()
+	if appleRoot == nil {
+		t.Error("loadAppleRoot should set the root from ROGERAI_APPLE_ROOT_PEM")
+	}
+	// invalid PEM leaves it unset (fail-closed)
+	appleRoot = nil
+	t.Setenv("ROGERAI_APPLE_ROOT_PEM", "garbage")
+	loadAppleRoot()
+	if appleRoot != nil {
+		t.Error("an invalid root PEM must leave appleRoot nil (fail-closed)")
+	}
+	// with no env override, the EMBEDDED Apple Root CA - G3 is pinned and loads - and it is genuinely
+	// that cert (guards against a wrong/placeholder PEM ever being shipped).
+	appleRoot = nil
+	t.Setenv("ROGERAI_APPLE_ROOT_PEM", "")
+	loadAppleRoot()
+	if appleRoot == nil {
+		t.Fatal("the embedded Apple root should load when no env override is set")
+	}
+	if cn := appleRoot.Subject.CommonName; cn != "Apple Root CA - G3" {
+		t.Errorf("embedded root CN = %q, want \"Apple Root CA - G3\"", cn)
+	}
+}
+
+// TestIAPRequireLiveRefusesSandbox: in require-live mode a Sandbox transaction must not credit.
+func TestIAPRequireLiveRefusesSandbox(t *testing.T) {
+	root, rootKey := genCA(t)
+	leaf, leafKey := genLeaf(t, root, rootKey, time.Now().Add(time.Hour))
+	appleRoot = root
+	defer func() { appleRoot = nil }()
+	t.Setenv("ROGERAI_REQUIRE_LIVE", "1")
+
+	b := &broker{db: store.NewMem(), pubOfUser: map[string]string{}, seedFunds: 0}
+	_, priv, _ := ed25519.GenerateKey(nil)
+	jws := makeJWS(t, leafKey, []*x509.Certificate{leaf, root}, goodTxn(), "ES256") // Environment: Sandbox
+	w := iapPost(t, b, priv, jws, "")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("require-live + Sandbox status %d, want 400", w.Code)
+	}
+}
+
+// --- Stage D: refund notification clawback ---
+
+func notifPost(t *testing.T, b *broker, signedPayload string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"signedPayload": signedPayload})
+	r := httptest.NewRequest(http.MethodPost, "/iap/notifications", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	b.iapNotifications(w, r)
+	return w
+}
+
+// makeNotification builds a signed App Store Server Notification V2 (outer JWS) wrapping a signed
+// transaction (inner JWS) for txn, both over the given chain.
+func makeNotification(t *testing.T, leafKey *ecdsa.PrivateKey, chain []*x509.Certificate, noteType string, txn storeKitTxn) string {
+	t.Helper()
+	inner := makeJWS(t, leafKey, chain, txn, "ES256")
+	payload := map[string]any{
+		"notificationType": noteType,
+		"notificationUUID": "uuid-1",
+		"version":          "2.0",
+		"data": map[string]any{
+			"bundleId":              txn.BundleID,
+			"environment":           txn.Environment,
+			"signedTransactionInfo": inner,
+		},
+	}
+	return makeJWS(t, leafKey, chain, payload, "ES256")
+}
+
+func TestIAPRefundNotification(t *testing.T) {
+	root, rootKey := genCA(t)
+	leaf, leafKey := genLeaf(t, root, rootKey, time.Now().Add(time.Hour))
+	chain := []*x509.Certificate{leaf, root}
+	appleRoot = root
+	defer func() { appleRoot = nil }()
+
+	mem := store.NewMem()
+	b := &broker{db: mem, pubOfUser: map[string]string{}, seedFunds: 0}
+	_, priv, _ := ed25519.GenerateKey(nil)
+
+	// Credit $10 first so a wallet mapping exists to claw back from.
+	txn := goodTxn()
+	if w := iapPost(t, b, priv, makeJWS(t, leafKey, chain, txn, "ES256"), "fyi.rogerai.topup.10"); w.Code != http.StatusOK {
+		t.Fatalf("setup credit failed: %d %s", w.Code, w.Body.String())
+	}
+	wallet, _, _, _ := mem.WalletByCharge("apple:txn-1")
+	if bal, _ := mem.BalanceOf(wallet, 0); bal != 10 {
+		t.Fatalf("pre-refund balance = %v, want 10", bal)
+	}
+
+	// A REFUND notification claws back the $10 once.
+	note := makeNotification(t, leafKey, chain, "REFUND", txn)
+	if w := notifPost(t, b, note); w.Code != http.StatusOK {
+		t.Fatalf("refund status %d: %s", w.Code, w.Body.String())
+	}
+	if bal, _ := mem.BalanceOf(wallet, 0); bal != 0 {
+		t.Errorf("balance after refund = %v, want 0 (clawed back)", bal)
+	}
+
+	// Redelivery (Apple retries) claws back ZERO - idempotent.
+	if w := notifPost(t, b, note); w.Code != http.StatusOK {
+		t.Errorf("refund redelivery status %d, want 200", w.Code)
+	}
+	if bal, _ := mem.BalanceOf(wallet, 0); bal != 0 {
+		t.Errorf("balance after redelivery = %v, want 0 (no double clawback)", bal)
+	}
+
+	// A non-REFUND type is a 200 no-op (so Apple stops retrying).
+	if w := notifPost(t, b, makeNotification(t, leafKey, chain, "DID_RENEW", txn)); w.Code != http.StatusOK {
+		t.Errorf("non-refund notification status %d, want 200 no-op", w.Code)
+	}
+
+	// A refund for a transaction we never credited here is a 200 no-op.
+	unk := txn
+	unk.TransactionID = "txn-unknown"
+	if w := notifPost(t, b, makeNotification(t, leafKey, chain, "REFUND", unk)); w.Code != http.StatusOK {
+		t.Errorf("refund for unknown txn status %d, want 200 no-op", w.Code)
+	}
+
+	// An outer JWS that does not chain to the pinned root is rejected.
+	other, otherKey := genCA(t)
+	otherLeaf, otherLeafKey := genLeaf(t, other, otherKey, time.Now().Add(time.Hour))
+	if w := notifPost(t, b, makeNotification(t, otherLeafKey, []*x509.Certificate{otherLeaf, other}, "REFUND", txn)); w.Code == http.StatusOK {
+		t.Error("a notification not chaining to the pinned root must be rejected")
+	}
+
+	// Wrong bundleId is rejected.
+	wrong := txn
+	wrong.BundleID = "com.evil.app"
+	if w := notifPost(t, b, makeNotification(t, leafKey, chain, "REFUND", wrong)); w.Code == http.StatusOK {
+		t.Error("wrong bundleId notification must be rejected")
+	}
+
+	// A missing signedPayload is a 400.
+	if w := notifPost(t, b, ""); w.Code != http.StatusBadRequest {
+		t.Errorf("empty signedPayload status %d, want 400", w.Code)
+	}
+}
+
+// TestIAPNotificationRequireLiveIgnoresSandbox: in require-live mode a Sandbox refund notification is
+// acknowledged (200) but must NOT claw back real balance - the same fail-closed posture as the credit path.
+func TestIAPNotificationRequireLiveIgnoresSandbox(t *testing.T) {
+	root, rootKey := genCA(t)
+	leaf, leafKey := genLeaf(t, root, rootKey, time.Now().Add(time.Hour))
+	chain := []*x509.Certificate{leaf, root}
+	appleRoot = root
+	defer func() { appleRoot = nil }()
+	t.Setenv("ROGERAI_REQUIRE_LIVE", "1")
+
+	b := &broker{db: store.NewMem(), pubOfUser: map[string]string{}, seedFunds: 0}
+	txn := goodTxn() // Environment: Sandbox
+	if w := notifPost(t, b, makeNotification(t, leafKey, chain, "REFUND", txn)); w.Code != http.StatusOK {
+		t.Errorf("sandbox refund in require-live status %d, want 200 no-op", w.Code)
+	}
+}

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -510,8 +510,8 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		toolsMerged:  map[string]bool{},
 		lastToolMark: map[string]time.Time{},
 		probeSched:   map[string]*probeState{},
-		lastPersist: map[string]time.Time{},
-		priv:        priv, feeRate: fee, seedFunds: seed, lockWin: lock,
+		lastPersist:  map[string]time.Time{},
+		priv:         priv, feeRate: fee, seedFunds: seed, lockWin: lock,
 		ttsMaxChars: audioTTSMaxChars(), audioSem: newAudioSem(),
 		banned:                 map[string]bool{},
 		reportEjectAt:          reportEjectThreshold(),
@@ -555,6 +555,7 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 	// resolve the secret code. Idempotent (a re-run is a no-op) + non-fatal on error.
 	b.remaskExistingBands()
 	b.bill = loadBilling()
+	loadAppleRoot() // StoreKit IAP trust anchor (Apple 3.1.1); /iap/credit is 503 until configured
 	b.conn = loadConnect()
 	b.mod = loadModeration()
 	b.mail = loadMailer()
@@ -664,6 +665,8 @@ func (b *broker) routes() *http.ServeMux {
 	mux.HandleFunc("/billing", b.billing)                              // money-in view: balance + top-up history
 	mux.HandleFunc("/billing/checkout", b.checkout)                    // Stripe top-up -> credits
 	mux.HandleFunc("/billing/webhook", b.webhook)                      // Stripe payment + dispute webhook
+	mux.HandleFunc("/iap/credit", b.iapCredit)                         // StoreKit IAP top-up -> credits (Apple 3.1.1)
+	mux.HandleFunc("/iap/notifications", b.iapNotifications)           // App Store Server Notifications V2 -> refund clawback
 	mux.HandleFunc("/usage", b.usage)                                  // consumer spend by model|day
 	mux.HandleFunc("/connect/onboard", b.connectOnboard)               // Stripe Connect Express onboarding link
 	mux.HandleFunc("/connect/status", b.connectStatus)                 // Connect capability status (KYC gate)


### PR DESCRIPTION
Server side of the App Store 3.1.1 fix: the iOS app buys a StoreKit consumable and the broker verifies + credits the wallet. Companion to the app-side StoreKit flow (separate, build-and-hold).

## Endpoints
- **`POST /iap/credit`** (owner-signed) - verifies the StoreKit JWS **server-side** (the client is never trusted): `ES256` only (alg-confusion defense), x5c chain to a **pinned Apple Root CA - G3**, raw `r||s` signature; enforces `bundleId` / `type=Consumable` / `environment`; maps `productId -> USD` (5/10/20/50, round 1:1); credits via `CreditOnce("apple:"+transactionId)` - **idempotent**, so the purchase POST and the app's `Transaction.updates` re-delivery never double-credit. Reuses the same ledger/`KindTopup` row as Stripe.
- **`POST /iap/notifications`** (Apple-signed) - App Store Server Notifications V2. A `REFUND` is verified (outer + inner JWS to the same pinned root), the wallet + exact credited amount resolved from the persisted mapping, and clawed back through the existing `RefundLineage` engine (idempotent). Non-refunds / unknown txns / sandbox-in-prod are `200` no-ops so Apple stops retrying.

## Security
- No parallel ledger: reuses `CreditOnce` / `LinkCharge` / `WalletByCharge` / `RefundLineage`.
- Credits derive from the **signed transaction**, never client metadata (same posture as the Stripe path).
- Apple Root CA - G3 pinned (verified SHA-256 fingerprint `63:34:3A:BF...`); `ROGERAI_APPLE_ROOT_PEM` overrides. Fail-closed (503) if no root parses.

## Pricing
Round tiers, charge == credit 1:1 ($10 -> $10); RogerAI absorbs Apple's ~30% (offset by the platform token take).

## Tests
Real generated ES256 cert chain + signed JWS (no mocks): credit-once + replay-zero idempotency, refund clawback + redelivery-zero, full rejection matrix (nil/wrong root, non-ES256, tampered, expired, wrong bundle/type/env, unknown product, unsigned). Broker package green, `go build ./...` OK, gofmt clean.

## Founder / deploy
Register the App Store Server Notifications V2 URL (Production + Sandbox): `https://broker.rogerai.fyi/iap/notifications`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)