### PR TITLE
capsule: roger.context.v1 - portable signed context (Stage 1: package + CLI + local handoff)

### DIFF
--- a/cmd/rogerai/context.go
+++ b/cmd/rogerai/context.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/rogerai-fyi/roger/internal/capsule"
+	"github.com/rogerai-fyi/roger/internal/client"
+)
+
+// context.go is the `roger context` verb group: portable signed context capsules
+// (roger.context.v1). It is the FILE interop surface - export signs a capsule with the
+// operator's existing identity, import verifies one (and can append-only merge it into a
+// base thread), so a conversation moves across operators over a .rcap.json file
+// (hermes/opencode) or a same-owner/local handoff. The encrypted stranger broker
+// transport is a follow-on (ruling Q3). tool_calls are rejected at the boundary (Q1).
+
+// contextExportedBy is the producer tag the CLI stamps into meta.exported_by. The app
+// stamps "roger-ios"; the byte-parity golden covers both.
+const contextExportedBy = "roger-cli"
+
+// cmdContext routes `roger context export|import`.
+func cmdContext(cfg config, args []string) error {
+	if len(args) == 0 {
+		contextUsage()
+		return nil
+	}
+	switch args[0] {
+	case "export":
+		return cmdContextExport(args[1:])
+	case "import":
+		return cmdContextImport(args[1:])
+	case "-h", "--help", "help":
+		contextUsage()
+		return nil
+	default:
+		return fmt.Errorf("unknown context command %q (try export|import)", args[0])
+	}
+}
+
+// cmdContextExport signs a draft capsule (read from a file or stdin) into a portable
+// signed .rcap.json (written to -o or stdout), using the operator's existing identity.
+func cmdContextExport(args []string) error {
+	fs := flag.NewFlagSet("context export", flag.ExitOnError)
+	out := fs.String("o", "-", "output file (default: stdout)")
+	fs.Usage = contextExportUsage
+	inPath, rest := leadingPositional(args)
+	fs.Parse(rest)
+	if inPath == "" {
+		inPath = fs.Arg(0)
+	}
+	in, closeIn, err := openIn(inPath)
+	if err != nil {
+		return err
+	}
+	defer closeIn()
+	w, closeOut, err := openOut(*out)
+	if err != nil {
+		return err
+	}
+	defer closeOut()
+	return contextExport(in, w, client.LoadOrCreateUserKey())
+}
+
+// cmdContextImport verifies a capsule (from a file or stdin). With --into it append-only
+// merges the capsule into a base thread and writes the re-signed merged capsule; without
+// it, it prints a one-line summary. A capsule whose signature does not verify is rejected.
+func cmdContextImport(args []string) error {
+	fs := flag.NewFlagSet("context import", flag.ExitOnError)
+	into := fs.String("into", "", "base capsule to append-only merge the imported one into (.rcap.json)")
+	out := fs.String("o", "-", "output file for the merged capsule (default: stdout; --into only)")
+	fs.Usage = contextImportUsage
+	inPath, rest := leadingPositional(args)
+	fs.Parse(rest)
+	if inPath == "" {
+		inPath = fs.Arg(0)
+	}
+	in, closeIn, err := openIn(inPath)
+	if err != nil {
+		return err
+	}
+	defer closeIn()
+
+	if *into == "" {
+		return contextImportSummary(in, os.Stdout)
+	}
+	base, err := os.ReadFile(*into)
+	if err != nil {
+		return err
+	}
+	w, closeOut, err := openOut(*out)
+	if err != nil {
+		return err
+	}
+	defer closeOut()
+	return contextImportMerge(in, base, w, client.LoadOrCreateUserKey())
+}
+
+// contextExport reads a draft capsule JSON from in, signs it with priv (stamping
+// exported_by = the CLI producer, created_at = now), and writes the signed wire JSON.
+func contextExport(in io.Reader, out io.Writer, priv ed25519.PrivateKey) error {
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+	var c capsule.Capsule
+	if err := json.Unmarshal(data, &c); err != nil {
+		return fmt.Errorf("read draft: %w", err)
+	}
+	c.Capsule = capsule.Version // a draft may omit it; export always speaks the current version
+	d := capsule.Draft{
+		ID: c.ID, Thread: c.Thread, Redaction: c.Redaction,
+		Summary: c.Summary, Memory: c.Memory, Messages: c.Messages, ToolsUsed: c.Meta.ToolsUsed,
+	}
+	signed, err := capsule.Export(d, priv, contextExportedBy, nil)
+	if err != nil {
+		return err
+	}
+	return writeCapsule(out, signed)
+}
+
+// contextImportSummary verifies the capsule in in and prints a one-line human summary. It
+// returns an error (nothing written) when the capsule does not verify.
+func contextImportSummary(in io.Reader, out io.Writer) error {
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+	c, err := capsule.Import(data)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "verified capsule %s · %d turns · redaction=%s · owner=%s\n",
+		c.ID, len(c.Messages), c.Redaction, short(c.Meta.OwnerPubkey))
+	return nil
+}
+
+// contextImportMerge verifies the incoming capsule, append-only merges it into base, and
+// writes the re-signed merged capsule. base is not re-verified (it is the operator's own
+// thread); only the incoming capsule is.
+func contextImportMerge(in io.Reader, base []byte, out io.Writer, priv ed25519.PrivateKey) error {
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+	incoming, err := capsule.Import(data)
+	if err != nil {
+		return err
+	}
+	var target capsule.Capsule
+	if err := json.Unmarshal(base, &target); err != nil {
+		return fmt.Errorf("read base: %w", err)
+	}
+	merged, err := capsule.Merge(incoming, target)
+	if err != nil {
+		return err
+	}
+	merged.Meta.ExportedBy = contextExportedBy
+	merged.Sign(priv) // Merge clears the sig; the merged thread is ours, so re-sign it
+	return writeCapsule(out, merged)
+}
+
+// writeCapsule marshals c and writes it with a trailing newline.
+func writeCapsule(out io.Writer, c capsule.Capsule) error {
+	raw, err := c.Marshal()
+	if err != nil {
+		return err
+	}
+	if _, err := out.Write(raw); err != nil {
+		return err
+	}
+	_, err = out.Write([]byte("\n"))
+	return err
+}
+
+// short trims a long hex key to a readable prefix for the summary line.
+func short(hexKey string) string {
+	if len(hexKey) <= 12 {
+		return hexKey
+	}
+	return hexKey[:12] + "…"
+}
+
+// leadingPositional pulls a leading non-flag argument (the input file) out ahead of flag
+// parsing, so `export draft.json -o out` works despite Go's flag stopping at the first
+// positional (mirrors how cmdUse/cmdShare pull their positional first). When the first
+// arg is a flag, the file is left for fs.Arg(0) after parsing (flags-first order).
+func leadingPositional(args []string) (positional string, rest []string) {
+	if len(args) > 0 && args[0] != "" && args[0][0] != '-' {
+		return args[0], args[1:]
+	}
+	return "", args
+}
+
+// openIn opens path for reading, or returns stdin for "" / "-". The returned close is a
+// no-op for stdin.
+func openIn(path string) (io.Reader, func(), error) {
+	if path == "" || path == "-" {
+		return os.Stdin, func() {}, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+// openOut opens path for writing (truncate), or returns stdout for "" / "-". The returned
+// close is a no-op for stdout.
+func openOut(path string) (io.Writer, func(), error) {
+	if path == "" || path == "-" {
+		return os.Stdout, func() {}, nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+func contextExportUsage() {
+	fmt.Print(`roger context export - sign a context capsule with your operator key
+
+  roger context export draft.json -o convo.rcap.json   sign a draft into a portable capsule
+  cat draft.json | roger context export                sign from stdin to stdout
+
+The input is a roger.context.v1 draft (the capsule shape); export stamps exported_by,
+created_at, and your owner_pubkey, then signs. tool_calls are not supported (they are
+rejected at this boundary until their canonical form is pinned cross-language).
+`)
+}
+
+func contextImportUsage() {
+	fmt.Print(`roger context import - verify a context capsule (and optionally merge it)
+
+  roger context import convo.rcap.json                    verify + print a summary
+  roger context import guest.rcap.json --into mine.rcap.json -o merged.rcap.json
+
+Import verifies the owner signature; a capsule that does not verify is rejected. With
+--into, the imported turns are APPENDED (never replace/truncate) to the base thread and
+the merged capsule is re-signed with your key.
+`)
+}
+
+func contextUsage() {
+	fmt.Print(`roger context - carry a conversation across operators (roger.context.v1)
+
+  roger context export draft.json -o convo.rcap.json   sign a portable context capsule
+  roger context import convo.rcap.json                 verify a capsule + print a summary
+  roger context import guest.rcap.json --into mine.rcap.json -o merged.rcap.json
+
+A capsule is a signed, portable snapshot of a thread. Import verifies the owner
+signature and merges APPEND-ONLY (a handoff never erases context).
+`)
+}

--- a/cmd/rogerai/context_bdd_test.go
+++ b/cmd/rogerai/context_bdd_test.go
@@ -1,0 +1,216 @@
+package main
+
+// context_bdd_test.go wires godog for features/capsule/cli.feature: it drives the REAL
+// `roger context` export/import/merge entry points over temp files, with the operator key
+// isolated to a throwaway XDG_CONFIG_HOME (never the developer's real user.key).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/capsule"
+)
+
+type contextCLIBDD struct {
+	dir        string
+	draftPath  string
+	capPath    string
+	basePath   string
+	guestPath  string
+	mergedPath string
+	summary    string
+	exportErr  error
+	importErr  error
+}
+
+// draftJSON builds an unsigned draft (the capsule wire shape) with the given turns.
+func draftJSON(turnsCSV string, withToolCalls bool) []byte {
+	c := capsule.Capsule{
+		Capsule:   capsule.Version,
+		ID:        "cap_cli",
+		Thread:    capsule.Thread{OriginThreadID: "t1", Title: "T"},
+		Redaction: "full",
+		Summary:   capsule.Summary{Text: "s", ProducedBy: "none"},
+	}
+	max := -1
+	for _, p := range strings.Split(turnsCSV, ",") {
+		if p = strings.TrimSpace(p); p == "" {
+			continue
+		}
+		n, _ := strconv.Atoi(p)
+		m := capsule.Message{Role: "user", Content: "c" + p, XRoger: capsule.XRoger{Turn: n, Agent: "user", TS: int64(n)}}
+		if withToolCalls {
+			m.ToolCalls = json.RawMessage(`[{"id":"1"}]`)
+		}
+		c.Messages = append(c.Messages, m)
+		if n > max {
+			max = n
+		}
+	}
+	c.Thread.BaseWatermark = max + 1
+	raw, _ := json.Marshal(c)
+	return raw
+}
+
+func (s *contextCLIBDD) writeDraft(turnsCSV string) error {
+	s.draftPath = filepath.Join(s.dir, "draft.json")
+	return os.WriteFile(s.draftPath, draftJSON(turnsCSV, false), 0o600)
+}
+func (s *contextCLIBDD) writeToolCallDraft() error {
+	s.draftPath = filepath.Join(s.dir, "draft.json")
+	return os.WriteFile(s.draftPath, draftJSON("0", true), 0o600)
+}
+func (s *contextCLIBDD) writeGuestDraft(turnsCSV string) error {
+	s.guestPath = filepath.Join(s.dir, "guest-draft.json")
+	return os.WriteFile(s.guestPath, draftJSON(turnsCSV, false), 0o600)
+}
+
+func (s *contextCLIBDD) exportToCapsule() error {
+	s.capPath = filepath.Join(s.dir, "convo.rcap.json")
+	s.exportErr = cmdContextExport([]string{s.draftPath, "-o", s.capPath})
+	return nil
+}
+func (s *contextCLIBDD) exportAsBase() error {
+	if err := s.exportToCapsule(); err != nil {
+		return err
+	}
+	s.basePath = s.capPath
+	return s.exportErr
+}
+func (s *contextCLIBDD) exportGuest() error {
+	out := filepath.Join(s.dir, "guest.rcap.json")
+	if err := cmdContextExport([]string{s.guestPath, "-o", out}); err != nil {
+		return err
+	}
+	s.guestPath = out
+	return nil
+}
+
+// captureCtxStdout runs fn with os.Stdout redirected to a pipe and returns what it printed.
+func captureCtxStdout(fn func() error) (string, error) {
+	orig := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := fn()
+	_ = w.Close()
+	os.Stdout = orig
+	out, _ := io.ReadAll(r)
+	return string(out), err
+}
+
+func (s *contextCLIBDD) importCapsule() error {
+	s.summary, s.importErr = captureCtxStdout(func() error {
+		return cmdContextImport([]string{s.capPath})
+	})
+	return nil
+}
+func (s *contextCLIBDD) tamperCapsuleOnDisk() error {
+	data, err := os.ReadFile(s.capPath)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.capPath, []byte(strings.Replace(string(data), `"c0"`, `"EVIL"`, 1)), 0o600)
+}
+func (s *contextCLIBDD) importGuestIntoBase() error {
+	s.mergedPath = filepath.Join(s.dir, "merged.rcap.json")
+	s.importErr = cmdContextImport([]string{s.guestPath, "--into", s.basePath, "-o", s.mergedPath})
+	return nil
+}
+
+func (s *contextCLIBDD) importReportsTurns(n int) error {
+	if !strings.Contains(s.summary, strconv.Itoa(n)+" turns") {
+		return bddErrf("summary %q did not report %d turns", s.summary, n)
+	}
+	return nil
+}
+func (s *contextCLIBDD) importReportsVerified() error {
+	if !strings.HasPrefix(s.summary, "verified capsule") {
+		return bddErrf("summary %q did not report verified", s.summary)
+	}
+	return nil
+}
+func (s *contextCLIBDD) importFails() error {
+	if s.importErr == nil {
+		return bddErrf("expected import to fail")
+	}
+	return nil
+}
+func (s *contextCLIBDD) mergedHasTurns(n int) error {
+	if s.importErr != nil {
+		return bddErrf("merge errored: %v", s.importErr)
+	}
+	c := s.readMerged()
+	if len(c.Messages) != n {
+		return bddErrf("merged has %d turns, want %d", len(c.Messages), n)
+	}
+	return nil
+}
+func (s *contextCLIBDD) mergedVerifies() error {
+	if !s.readMerged().Verify() {
+		return bddErrf("merged capsule must verify")
+	}
+	return nil
+}
+func (s *contextCLIBDD) readMerged() capsule.Capsule {
+	data, _ := os.ReadFile(s.mergedPath)
+	var c capsule.Capsule
+	_ = json.Unmarshal(data, &c)
+	return c
+}
+func (s *contextCLIBDD) exportFailsToolCalls() error {
+	if s.exportErr == nil || !strings.Contains(s.exportErr.Error(), "tool_calls") {
+		return bddErrf("expected tool_calls export failure, got %v", s.exportErr)
+	}
+	return nil
+}
+
+// ctxBDDErr is a readable godog assertion failure (mirrors the other packages' bddErr).
+type ctxBDDErr string
+
+func (e ctxBDDErr) Error() string      { return string(e) }
+func bddErrf(f string, a ...any) error { return ctxBDDErr(fmt.Sprintf(f, a...)) }
+
+func TestContextCLIBDD(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // isolate the operator key
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			st := &contextCLIBDD{}
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				*st = contextCLIBDD{dir: t.TempDir()}
+				return ctx, nil
+			})
+			sc.Step(`^a draft with turns "([^"]*)"$`, st.writeDraft)
+			sc.Step(`^a draft carrying tool_calls$`, st.writeToolCallDraft)
+			sc.Step(`^a guest draft with turns "([^"]*)"$`, st.writeGuestDraft)
+			sc.Step(`^I export it to a capsule file$`, st.exportToCapsule)
+			sc.Step(`^I export it to a capsule file as the base thread$`, st.exportAsBase)
+			sc.Step(`^I export the guest draft to a capsule file$`, st.exportGuest)
+			sc.Step(`^I import the capsule file$`, st.importCapsule)
+			sc.Step(`^the capsule file is tampered on disk$`, st.tamperCapsuleOnDisk)
+			sc.Step(`^I import the guest capsule into the base thread$`, st.importGuestIntoBase)
+			sc.Step(`^the import reports (\d+) turns$`, st.importReportsTurns)
+			sc.Step(`^the import reports it verified$`, st.importReportsVerified)
+			sc.Step(`^the import fails$`, st.importFails)
+			sc.Step(`^the merged capsule has (\d+) turns$`, st.mergedHasTurns)
+			sc.Step(`^the merged capsule verifies$`, st.mergedVerifies)
+			sc.Step(`^the export fails as tool_calls-unsupported$`, st.exportFailsToolCalls)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/capsule/cli.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("context CLI behavior scenarios failed (see godog output above)")
+	}
+}

--- a/cmd/rogerai/context_test.go
+++ b/cmd/rogerai/context_test.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/capsule"
+)
+
+func ephemeralKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return priv
+}
+
+// TestCmdContextDispatch covers routing: no args (usage), an unknown verb, and help.
+func TestCmdContextDispatch(t *testing.T) {
+	cfg := config{}
+	if err := cmdContext(cfg, nil); err != nil {
+		t.Errorf("no args should print usage, got %v", err)
+	}
+	if err := cmdContext(cfg, []string{"-h"}); err != nil {
+		t.Errorf("help should return nil, got %v", err)
+	}
+	if err := cmdContext(cfg, []string{"bogus"}); err == nil {
+		t.Error("unknown context verb should error")
+	}
+}
+
+// failIO is a reader+writer that always errors, to exercise the ReadAll/Write error paths.
+type failIO struct{}
+
+func (failIO) Read([]byte) (int, error)  { return 0, os.ErrClosed }
+func (failIO) Write([]byte) (int, error) { return 0, os.ErrClosed }
+
+// TestCmdContextRoutesToExportImport drives the export/import verbs THROUGH cmdContext (not
+// the subcommand funcs directly) so the dispatch arms are covered.
+func TestCmdContextRoutesToExportImport(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir := t.TempDir()
+	draft := filepath.Join(dir, "d.json")
+	cap := filepath.Join(dir, "c.rcap.json")
+	_ = os.WriteFile(draft, []byte(`{"id":"c","messages":[{"role":"user","content":"hi","x_roger":{"turn":0,"agent":"user","ts":1}}]}`), 0o600)
+	if err := cmdContext(config{}, []string{"export", draft, "-o", cap}); err != nil {
+		t.Fatalf("cmdContext export: %v", err)
+	}
+	_, err := captureCtxStdout(func() error { return cmdContext(config{}, []string{"import", cap}) })
+	if err != nil {
+		t.Fatalf("cmdContext import: %v", err)
+	}
+}
+
+// TestContextUsageFuncs runs the help text functions (no panic, non-empty output).
+func TestContextUsageFuncs(t *testing.T) {
+	for _, fn := range []func(){contextUsage, contextExportUsage, contextImportUsage} {
+		if out, _ := captureCtxStdout(func() error { fn(); return nil }); len(out) == 0 {
+			t.Error("usage must print something")
+		}
+	}
+}
+
+// TestContextFailingIO exercises the ReadAll / Write error branches.
+func TestContextFailingIO(t *testing.T) {
+	priv := ephemeralKey(t)
+	if err := contextExport(failIO{}, &bytes.Buffer{}, priv); err == nil {
+		t.Error("export read error must propagate")
+	}
+	if err := contextImportSummary(failIO{}, &bytes.Buffer{}); err == nil {
+		t.Error("import read error must propagate")
+	}
+	if err := contextImportMerge(failIO{}, []byte(`{}`), &bytes.Buffer{}, priv); err == nil {
+		t.Error("merge read error must propagate")
+	}
+	// A valid capsule but a write that fails -> writeCapsule error.
+	var buf bytes.Buffer
+	_ = contextExport(strings.NewReader(`{"id":"c","messages":[]}`), &buf, priv)
+	if err := contextExport(strings.NewReader(`{"id":"c","messages":[]}`), failIO{}, priv); err == nil {
+		t.Error("export write error must propagate")
+	}
+}
+
+// TestContextExportCore: a valid draft signs + verifies (with a real trailing newline);
+// bad JSON errors.
+func TestContextExportCore(t *testing.T) {
+	priv := ephemeralKey(t)
+	draft := `{"id":"cap_u","thread":{"title":"T"},"redaction":"full","messages":[{"role":"user","content":"hi","x_roger":{"turn":0,"agent":"user","ts":1}}]}`
+	var out bytes.Buffer
+	if err := contextExport(strings.NewReader(draft), &out, priv); err != nil {
+		t.Fatalf("contextExport: %v", err)
+	}
+	if !strings.HasSuffix(out.String(), "\n") {
+		t.Error("export must end with a newline")
+	}
+	c, err := capsule.Import(out.Bytes())
+	if err != nil || !c.Verify() {
+		t.Fatalf("exported capsule must import+verify: %v", err)
+	}
+	if c.Meta.ExportedBy != "roger-cli" {
+		t.Errorf("exported_by = %q, want roger-cli", c.Meta.ExportedBy)
+	}
+	if err := contextExport(strings.NewReader("{bad"), &bytes.Buffer{}, priv); err == nil {
+		t.Error("bad draft JSON must error")
+	}
+}
+
+// TestContextImportSummaryVerifyFail: a tampered capsule yields an error and no summary.
+func TestContextImportSummaryVerifyFail(t *testing.T) {
+	priv := ephemeralKey(t)
+	var signedBuf bytes.Buffer
+	_ = contextExport(strings.NewReader(`{"id":"c","messages":[{"role":"user","content":"hi","x_roger":{"turn":0,"agent":"user","ts":1}}]}`), &signedBuf, priv)
+	tampered := strings.Replace(signedBuf.String(), `"hi"`, `"evil"`, 1)
+	if err := contextImportSummary(strings.NewReader(tampered), &bytes.Buffer{}); err == nil {
+		t.Error("tampered capsule must fail import")
+	}
+}
+
+// TestContextImportMergeCore: merges append-only, re-signs, and rejects a bad base.
+func TestContextImportMergeCore(t *testing.T) {
+	priv := ephemeralKey(t)
+	base, _ := capsule.Export(capsule.Draft{ID: "c", Thread: capsule.Thread{BaseWatermark: 1}, Messages: []capsule.Message{{Role: "user", Content: "hi", XRoger: capsule.XRoger{Turn: 0, Agent: "user", TS: 1}}}}, priv, "roger-cli", func() int64 { return 1 })
+	baseRaw, _ := base.Marshal()
+	guest, _ := capsule.Export(capsule.Draft{ID: "c", Thread: capsule.Thread{BaseWatermark: 2}, Messages: []capsule.Message{
+		{Role: "user", Content: "hi", XRoger: capsule.XRoger{Turn: 0, Agent: "user", TS: 1}},
+		{Role: "assistant", Content: "yo", XRoger: capsule.XRoger{Turn: 1, Agent: "opencode", TS: 2}},
+	}}, priv, "roger-cli", func() int64 { return 2 })
+	guestRaw, _ := guest.Marshal()
+
+	var out bytes.Buffer
+	if err := contextImportMerge(bytes.NewReader(guestRaw), baseRaw, &out, priv); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	merged, err := capsule.Import(out.Bytes())
+	if err != nil || !merged.Verify() {
+		t.Fatalf("merged must import+verify: %v", err)
+	}
+	if len(merged.Messages) != 2 {
+		t.Errorf("merged turns = %d, want 2", len(merged.Messages))
+	}
+	// A malformed base is rejected.
+	if err := contextImportMerge(bytes.NewReader(guestRaw), []byte("{bad"), &bytes.Buffer{}, priv); err == nil {
+		t.Error("malformed base must error")
+	}
+	// A forked incoming (turn 0 rewritten) is rejected by the append-only merge.
+	fork, _ := capsule.Export(capsule.Draft{ID: "c", Thread: capsule.Thread{BaseWatermark: 1}, Messages: []capsule.Message{{Role: "user", Content: "REWRITTEN", XRoger: capsule.XRoger{Turn: 0, Agent: "user", TS: 1}}}}, priv, "roger-cli", func() int64 { return 3 })
+	forkRaw, _ := fork.Marshal()
+	if err := contextImportMerge(bytes.NewReader(forkRaw), baseRaw, &bytes.Buffer{}, priv); err == nil {
+		t.Error("forked incoming must error")
+	}
+}
+
+// TestCmdContextExportFileErrors: a missing input file and an unwritable output error out.
+func TestCmdContextExportFileErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := cmdContextExport([]string{filepath.Join(t.TempDir(), "nope.json")}); err == nil {
+		t.Error("missing input file must error")
+	}
+	dir := t.TempDir()
+	draft := filepath.Join(dir, "d.json")
+	_ = os.WriteFile(draft, []byte(`{"id":"c","messages":[]}`), 0o600)
+	// -o points at a directory -> os.Create fails.
+	if err := cmdContextExport([]string{draft, "-o", dir}); err == nil {
+		t.Error("unwritable -o must error")
+	}
+}
+
+// TestCmdContextImportFileErrors: missing input, and --into with a missing base.
+func TestCmdContextImportFileErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := cmdContextImport([]string{filepath.Join(t.TempDir(), "nope.json")}); err == nil {
+		t.Error("missing input file must error")
+	}
+	dir := t.TempDir()
+	cap := filepath.Join(dir, "c.rcap.json")
+	priv := ephemeralKey(t)
+	var b bytes.Buffer
+	_ = contextExport(strings.NewReader(`{"id":"c","messages":[]}`), &b, priv)
+	_ = os.WriteFile(cap, b.Bytes(), 0o600)
+	if err := cmdContextImport([]string{cap, "--into", filepath.Join(dir, "missing-base.json")}); err == nil {
+		t.Error("--into with a missing base must error")
+	}
+}
+
+// TestOpenHelpers covers openIn/openOut for stdin/stdout, files, and the leadingPositional
+// flags-first branch, plus short().
+func TestOpenHelpers(t *testing.T) {
+	if r, c, err := openIn("-"); err != nil || r != os.Stdin {
+		t.Error("openIn - must be stdin")
+	} else {
+		c()
+	}
+	if w, c, err := openOut("-"); err != nil || w != os.Stdout {
+		t.Error("openOut - must be stdout")
+	} else {
+		c()
+	}
+	f := filepath.Join(t.TempDir(), "f")
+	_ = os.WriteFile(f, []byte("x"), 0o600)
+	if _, c, err := openIn(f); err != nil {
+		t.Errorf("openIn file: %v", err)
+	} else {
+		c()
+	}
+	if _, c, err := openOut(f); err != nil {
+		t.Errorf("openOut file: %v", err)
+	} else {
+		c()
+	}
+	if _, _, err := openIn(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Error("openIn missing must error")
+	}
+	if _, _, err := openOut(t.TempDir()); err == nil {
+		t.Error("openOut dir must error")
+	}
+	// flags-first: no leading positional.
+	if p, rest := leadingPositional([]string{"-o", "x", "file"}); p != "" || len(rest) != 3 {
+		t.Errorf("leadingPositional flags-first = %q,%v", p, rest)
+	}
+	if p, _ := leadingPositional([]string{"file", "-o", "x"}); p != "file" {
+		t.Errorf("leadingPositional positional-first = %q, want file", p)
+	}
+	if short("abc") != "abc" {
+		t.Error("short must pass through a short key")
+	}
+	if !strings.HasSuffix(short(strings.Repeat("a", 40)), "…") {
+		t.Error("short must ellipsize a long key")
+	}
+}

--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -761,6 +761,8 @@ func dispatch(cfg config, args []string) error {
 		return cmdPayout(cfg, args[1:])
 	case "grant":
 		return cmdGrant(cfg, args[1:])
+	case "context":
+		return cmdContext(cfg, args[1:])
 	case "onboard", "setup":
 		return cmdOnboard(cfg, args[1:])
 	case "config":

--- a/features/capsule/canonical.feature
+++ b/features/capsule/canonical.feature
@@ -1,0 +1,30 @@
+Feature: roger.context.v1 canonical signing bytes
+  The ONE load-bearing interop contract: the Go canonical() must reproduce the app's
+  canonical bytes token-for-token, so an app-signed capsule verifies in Go and vice-versa.
+  Byte-parity is pinned by the golden vector (both producers); a signature is asserted to
+  VERIFY, never pinned to a fixed value (CryptoKit randomizes the ed25519 nonce).
+
+  Scenario: the golden vector reproduces the brief's bytes for the roger-cli producer
+    Given the golden fixture capsule exported by "roger-cli"
+    When I compute its canonical bytes
+    Then they equal the golden canonical string for "roger-cli"
+
+  Scenario: the golden vector reproduces the brief's bytes for the roger-ios producer
+    Given the golden fixture capsule exported by "roger-ios"
+    When I compute its canonical bytes
+    Then they equal the golden canonical string for "roger-ios"
+
+  Scenario: the two producers differ only in exported_by
+    Given the golden fixture capsule exported by "roger-cli"
+    And the golden fixture capsule exported by "roger-ios"
+    Then their canonical bytes differ only in the exported_by value
+
+  Scenario: a nil model and provider emit the literal null, not an omitted key
+    Given the golden fixture capsule exported by "roger-cli"
+    When I compute its canonical bytes
+    Then the canonical bytes carry a literal null model and provider
+
+  Scenario: the signature field is never part of the canonical bytes
+    Given the golden fixture capsule exported by "roger-cli"
+    When I set the signature to "deadbeef"
+    Then the canonical bytes are unchanged

--- a/features/capsule/cli.feature
+++ b/features/capsule/cli.feature
@@ -1,0 +1,32 @@
+Feature: the `roger context` CLI
+  export signs a draft into a portable .rcap.json with the operator's own key; import
+  verifies it (and can append-only merge it into a base thread). This is the file interop
+  surface for hermes/opencode and a same-owner/local handoff.
+
+  Scenario: export then import round-trips and verifies
+    Given a draft with turns "0,1"
+    When I export it to a capsule file
+    And I import the capsule file
+    Then the import reports 2 turns
+    And the import reports it verified
+
+  Scenario: a tampered capsule file is rejected on import
+    Given a draft with turns "0,1"
+    And I export it to a capsule file
+    When the capsule file is tampered on disk
+    And I import the capsule file
+    Then the import fails
+
+  Scenario: import --into merges a guest capsule append-only
+    Given a draft with turns "0,1"
+    And I export it to a capsule file as the base thread
+    And a guest draft with turns "0,1,2"
+    And I export the guest draft to a capsule file
+    When I import the guest capsule into the base thread
+    Then the merged capsule has 3 turns
+    And the merged capsule verifies
+
+  Scenario: export refuses a draft carrying tool_calls
+    Given a draft carrying tool_calls
+    When I export it to a capsule file
+    Then the export fails as tool_calls-unsupported

--- a/features/capsule/handoff.feature
+++ b/features/capsule/handoff.feature
@@ -1,0 +1,41 @@
+Feature: carry the conversation through an operator handoff
+  The TUI records each completed turn into a minimal per-turn ring (ruling Q4). On a
+  same-owner/local operator handoff it EXPORTS the conversation as a signed capsule the
+  guest can import, and on recall MERGES the guest's return capsule back append-only. The
+  flat transcript stays the render source; the stranger encrypted transport is a follow-on.
+
+  Scenario: completed turns accumulate in the ring in order
+    Given a fresh session
+    When the user says "hello" and the station replies "hi there"
+    Then the ring has 2 turns
+    And the ring turn indexes are "0,1"
+
+  Scenario: an exported capsule is signed by the operator and carries the transcript
+    Given a fresh session
+    And the user says "hello" and the station replies "hi there"
+    When I export the context capsule
+    Then the exported capsule verifies
+    And the exported capsule has 2 turns
+    And the exported capsule owner is the operator key
+
+  Scenario: a guest's return capsule merges back append-only
+    Given a fresh session
+    And the user says "hello" and the station replies "hi there"
+    And I write the handoff capsule to the guest workdir
+    When the guest appends a turn and leaves a return capsule
+    And the DJ reads the return capsule
+    Then the ring has 3 turns
+    And the ring turn indexes are "0,1,2"
+
+  Scenario: a stranger export is summary-only (no full transcript)
+    Given a fresh session
+    And the user says "secret one" and the station replies "secret two"
+    When I export the context capsule for a stranger
+    Then the exported capsule redaction is "summary"
+    And the exported capsule has 1 turns
+
+  Scenario: no return capsule is a clean no-op
+    Given a fresh session
+    And the user says "hello" and the station replies "hi there"
+    When the DJ reads the return capsule from an empty workdir
+    Then the recall added 0 turns

--- a/features/capsule/merge.feature
+++ b/features/capsule/merge.feature
@@ -1,0 +1,73 @@
+Feature: append-only capsule merge
+  A returning capsule may only ADD turns; a handoff never erases context. Merge verifies
+  the incoming signature FIRST, rejects a forked turn or an unknown version or tool_calls,
+  then appends only the turns at/after the target's watermark that are not already present.
+
+  Background:
+    Given a fresh operator keypair
+
+  Scenario: merging a full capsule into an empty thread reproduces the transcript
+    Given a signed capsule with watermark 3 and turns
+      | turn | role      | content |
+      | 0    | user      | hi      |
+      | 1    | assistant | yo      |
+      | 2    | user      | more    |
+    When I merge it into an empty thread
+    Then the merge succeeds
+    And the merged thread has turns "0,1,2"
+    And the merged watermark is 3
+    And the merged signature is cleared
+
+  Scenario: a second merge of the same capsule is idempotent
+    Given a signed capsule with watermark 2 and turns
+      | turn | role      | content |
+      | 0    | user      | hi      |
+      | 1    | assistant | yo      |
+    When I merge it into an empty thread
+    And I merge it again into the result
+    Then the merge succeeds
+    And the merged thread has turns "0,1"
+
+  Scenario: a smaller incoming capsule never truncates the target
+    Given a signed capsule with watermark 3 and turns
+      | turn | role      | content |
+      | 0    | user      | hi      |
+      | 1    | assistant | yo      |
+      | 2    | user      | more    |
+    When I merge it into an empty thread
+    And a signed capsule with watermark 1 and turns
+      | turn | role | content |
+      | 0    | user | hi      |
+    And I merge it into the result
+    Then the merge succeeds
+    And the merged thread has turns "0,1,2"
+
+  Scenario: an unverified capsule is rejected and the target is unchanged
+    Given the target thread has turns "0" at watermark 1
+    And a signed capsule with watermark 2 and turns
+      | turn | role      | content |
+      | 0    | user      | hi      |
+      | 1    | assistant | yo      |
+    And the incoming capsule is tampered after signing
+    When I merge it into the target
+    Then the merge is rejected as unverified
+    And the merged thread has turns "0"
+
+  Scenario: a forked turn rejects the whole capsule and the target is unchanged
+    Given the target thread has turns "0,1" at watermark 2
+    And a signed capsule with watermark 2 and turns
+      | turn | role      | content |
+      | 0    | user      | hi      |
+      | 1    | assistant | FORKED  |
+      | 2    | user      | new     |
+    When I merge it into the target
+    Then the merge is rejected as forked
+    And the merged thread has turns "0,1"
+
+  Scenario: an unknown capsule version is rejected
+    Given a signed capsule with watermark 1 and turns
+      | turn | role | content |
+      | 0    | user | hi      |
+    And the incoming capsule version is changed and re-signed to "roger.context.v2"
+    When I merge it into an empty thread
+    Then the merge is rejected as unknown-version

--- a/features/capsule/merge.feature
+++ b/features/capsule/merge.feature
@@ -64,6 +64,15 @@ Feature: append-only capsule merge
     Then the merge is rejected as forked
     And the merged thread has turns "0,1"
 
+  Scenario: an incoming capsule that forks a turn within itself is rejected
+    Given a signed capsule with watermark 3 and turns
+      | turn | role      | content     |
+      | 0    | user      | hi          |
+      | 1    | assistant | yo          |
+      | 1    | assistant | REWRITTEN   |
+    When I merge it into an empty thread
+    Then the merge is rejected as forked
+
   Scenario: an unknown capsule version is rejected
     Given a signed capsule with watermark 1 and turns
       | turn | role | content |

--- a/features/capsule/security.feature
+++ b/features/capsule/security.feature
@@ -1,0 +1,46 @@
+Feature: capsule security invariants
+  The owner ed25519 signature covers every field except sig (over the canonical bytes, so
+  it also covers redaction). Verify-before-merge, append-only, and summary-only redaction
+  for strangers are enforced. tool_calls are rejected at the boundary (ruling Q1).
+
+  Background:
+    Given a fresh operator keypair
+
+  Scenario: a stranger cannot escalate a summary-only capsule to full
+    Given a signed summary-only capsule
+    Then the capsule redaction is "summary"
+    When I flip the redaction to "full" without the key
+    Then the capsule no longer verifies
+
+  Scenario Outline: any tampered field breaks verification
+    Given a signed summary-only capsule
+    When I tamper the field "<field>"
+    Then the capsule no longer verifies
+
+    Examples:
+      | field       |
+      | content     |
+      | role        |
+      | title       |
+      | summary     |
+      | created_at  |
+      | exported_by |
+      | watermark   |
+
+  Scenario: a capsule carrying tool_calls is rejected at import
+    Given a signed capsule carrying tool_calls
+    When I import it
+    Then the import is rejected as tool_calls-unsupported
+
+  Scenario: exporting a draft that carries tool_calls is refused
+    Given a draft carrying tool_calls
+    When I export it
+    Then the export is refused as tool_calls-unsupported
+
+  Scenario: an importable capsule round-trips through marshal and verifies
+    Given a signed capsule with watermark 1 and turns
+      | turn | role | content |
+      | 0    | user | hi      |
+    When I marshal and import it
+    Then the import succeeds
+    And the imported capsule verifies

--- a/internal/capsule/canonical_test.go
+++ b/internal/capsule/canonical_test.go
@@ -1,0 +1,39 @@
+package capsule
+
+import "testing"
+
+// goldenInput builds the brief's golden fixture capsule (unsigned). exportedBy is the
+// only value that differs by producer ("roger-cli" vs "roger-ios"); everything else is
+// identical. The owner_pubkey is a literal "aa" in the vector (not derived from a key)
+// because this test pins the CANONICAL BYTES, not a signature.
+func goldenInput(exportedBy string) Capsule {
+	return Capsule{
+		Capsule:   Version,
+		ID:        "cap_x",
+		Thread:    Thread{OriginThreadID: "t1", Title: "Hi", BaseWatermark: 1},
+		Redaction: "full",
+		Summary:   Summary{Text: "hi", ProducedBy: "none", AsOfTurn: 1},
+		Memory:    Memory{Notes: "", Facts: nil},
+		Messages: []Message{{
+			Role:    "user",
+			Content: "hi",
+			XRoger:  XRoger{Turn: 0, Agent: "user", Model: nil, Provider: nil, TS: 100},
+		}},
+		Meta: Meta{ToolsUsed: nil, ExportedBy: exportedBy, CreatedAt: 100, OwnerPubkey: "aa"},
+	}
+}
+
+// TestGoldenVector is the ONE load-bearing interop contract: canonical() must reproduce
+// the brief's golden bytes byte-for-byte, for BOTH producers. An app-signed capsule can
+// only verify in Go if these bytes match token-for-token (RogerAI/Services/CapsuleWire.swift).
+func TestGoldenVector(t *testing.T) {
+	const cliGolden = `{"capsule":"roger.context.v1","id":"cap_x","thread":{"origin_thread_id":"t1","title":"Hi","base_watermark":1},"redaction":"full","summary":{"text":"hi","produced_by":"none","as_of_turn":1},"memory":{"notes":"","facts":[]},"messages":[{"role":"user","content":"hi","x_roger":{"turn":0,"agent":"user","model":null,"provider":null,"ts":100}}],"meta":{"tools_used":[],"exported_by":"roger-cli","created_at":100,"owner_pubkey":"aa"}}`
+	const iosGolden = `{"capsule":"roger.context.v1","id":"cap_x","thread":{"origin_thread_id":"t1","title":"Hi","base_watermark":1},"redaction":"full","summary":{"text":"hi","produced_by":"none","as_of_turn":1},"memory":{"notes":"","facts":[]},"messages":[{"role":"user","content":"hi","x_roger":{"turn":0,"agent":"user","model":null,"provider":null,"ts":100}}],"meta":{"tools_used":[],"exported_by":"roger-ios","created_at":100,"owner_pubkey":"aa"}}`
+
+	if got := string(goldenInput("roger-cli").canonical()); got != cliGolden {
+		t.Errorf("roger-cli canonical mismatch\n got: %s\nwant: %s", got, cliGolden)
+	}
+	if got := string(goldenInput("roger-ios").canonical()); got != iosGolden {
+		t.Errorf("roger-ios canonical mismatch\n got: %s\nwant: %s", got, iosGolden)
+	}
+}

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -1,0 +1,228 @@
+// Package capsule implements roger.context.v1, the portable signed context capsule
+// that carries a conversation across operators (CLI/TUI <-> iOS <-> guest agents).
+//
+// The format is defined authoritatively by the iOS app
+// (RogerAI/Services/CapsuleWire.swift). The ONE load-bearing interop contract is that
+// canonical() reproduces the app's canonical signing bytes token-for-token, so an
+// app-signed capsule verifies in Go and vice-versa. That parity is pinned by the
+// golden vector in canonical_test.go, exactly like the share-receipt / IAP JWS goldens.
+//
+// Stage 1 scope (founder-approved): the capsule package + the `roger context` CLI +
+// SAME-OWNER / LOCAL handoff only. The encrypted stranger broker transport is a
+// follow-on (ruling Q3). tool_calls are REJECTED at the app<->CLI boundary (ruling
+// Q1): a canonical form for them is not yet pinned cross-language, so no capsule
+// carrying them may cross until it is.
+package capsule
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+)
+
+// Version is the only capsule format this package speaks. Merge/Import reject any other.
+const Version = "roger.context.v1"
+
+// Capsule is a single signed roger.context.v1 object. The owner ed25519 sig covers
+// every field except sig (over the canonical bytes, so it also covers redaction - a
+// stranger cannot flip a summary-only capsule to full and re-sign).
+type Capsule struct {
+	Capsule   string    `json:"capsule"`
+	ID        string    `json:"id"`
+	Thread    Thread    `json:"thread"`
+	Redaction string    `json:"redaction"` // full | summary | minimal
+	Summary   Summary   `json:"summary"`
+	Memory    Memory    `json:"memory"`
+	Messages  []Message `json:"messages"`
+	Meta      Meta      `json:"meta"`
+	Sig       string    `json:"sig"`
+}
+
+// Thread is the origin-thread provenance. BaseWatermark is the count of turns the
+// holder had at export time (= the next-expected turn index): a turn index t is
+// "already present" iff t < BaseWatermark. Merge appends only turns at/after it.
+type Thread struct {
+	OriginThreadID string `json:"origin_thread_id"`
+	Title          string `json:"title"`
+	BaseWatermark  int    `json:"base_watermark"`
+}
+
+// Summary is the optional condensed context (Stage 2 fills it; Stage 1 carries it
+// verbatim). ProducedBy is "none" | "on-device" | "operator:<model>".
+type Summary struct {
+	Text       string `json:"text"`
+	ProducedBy string `json:"produced_by"`
+	AsOfTurn   int    `json:"as_of_turn"`
+}
+
+// Memory is durable notes/facts carried with the thread (empty in Stage 1 exports).
+type Memory struct {
+	Notes string   `json:"notes"`
+	Facts []string `json:"facts"`
+}
+
+// Message is one turn in plain OpenAI shape so any agent can read it; RogerAI
+// provenance lives under the ignore-unknown x_roger namespace. ToolCalls is carried
+// as raw JSON and is REJECTED at the boundary (ruling Q1) until its canonical form is
+// pinned cross-language; it appears in canonical() only to keep the fixed field order.
+type Message struct {
+	Role      string          `json:"role"`
+	Content   string          `json:"content"`
+	ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
+	XRoger    XRoger          `json:"x_roger"`
+}
+
+// XRoger is the RogerAI provenance for a message. Model/Provider are pointers so a nil
+// emits the literal null in canonical() (NOT omitted) - the format distinguishes
+// "no model" from an empty string.
+type XRoger struct {
+	Turn     int     `json:"turn"`
+	Agent    string  `json:"agent"`
+	Model    *string `json:"model"`
+	Provider *string `json:"provider"`
+	TS       int64   `json:"ts"`
+}
+
+// Meta is capsule-level provenance. OwnerPubkey is the hex ed25519 key the sig
+// verifies against; Sign sets it from the signing key.
+type Meta struct {
+	ToolsUsed   []string `json:"tools_used"`
+	ExportedBy  string   `json:"exported_by"`
+	CreatedAt   int64    `json:"created_at"`
+	OwnerPubkey string   `json:"owner_pubkey"`
+}
+
+// goString encodes a string exactly as Go's encoding/json does (HTML-escaping < > &),
+// matching the app's goString so byte-parity holds. json.Marshal of a string never
+// errors, so the error is discarded.
+func goString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// canonical builds the exact bytes signed: the capsule with sig cleared, emitted in a
+// FIXED field order (never runtime-sorted), each string via goString, numbers in plain
+// decimal, nil model/provider as literal null, tool_calls only when present. It is
+// HAND-BUILT (not json.Marshal of a struct) because the format needs literal null for
+// nil pointers and a conditional tool_calls slot that struct tags cannot express, and
+// because the byte order must be pinned against the app rather than left to a marshaler.
+func (c Capsule) canonical() []byte {
+	var b []byte
+	b = append(b, '{')
+	b = append(b, `"capsule":`...)
+	b = append(b, goString(c.Capsule)...)
+	b = append(b, `,"id":`...)
+	b = append(b, goString(c.ID)...)
+
+	b = append(b, `,"thread":{"origin_thread_id":`...)
+	b = append(b, goString(c.Thread.OriginThreadID)...)
+	b = append(b, `,"title":`...)
+	b = append(b, goString(c.Thread.Title)...)
+	b = append(b, `,"base_watermark":`...)
+	b = strconv.AppendInt(b, int64(c.Thread.BaseWatermark), 10)
+	b = append(b, '}')
+
+	b = append(b, `,"redaction":`...)
+	b = append(b, goString(c.Redaction)...)
+
+	b = append(b, `,"summary":{"text":`...)
+	b = append(b, goString(c.Summary.Text)...)
+	b = append(b, `,"produced_by":`...)
+	b = append(b, goString(c.Summary.ProducedBy)...)
+	b = append(b, `,"as_of_turn":`...)
+	b = strconv.AppendInt(b, int64(c.Summary.AsOfTurn), 10)
+	b = append(b, '}')
+
+	b = append(b, `,"memory":{"notes":`...)
+	b = append(b, goString(c.Memory.Notes)...)
+	b = append(b, `,"facts":`...)
+	b = appendStringArray(b, c.Memory.Facts)
+	b = append(b, '}')
+
+	b = append(b, `,"messages":[`...)
+	for i, m := range c.Messages {
+		if i > 0 {
+			b = append(b, ',')
+		}
+		b = append(b, `{"role":`...)
+		b = append(b, goString(m.Role)...)
+		b = append(b, `,"content":`...)
+		b = append(b, goString(m.Content)...)
+		if len(m.ToolCalls) > 0 {
+			b = append(b, `,"tool_calls":`...)
+			b = append(b, m.ToolCalls...)
+		}
+		b = append(b, `,"x_roger":{"turn":`...)
+		b = strconv.AppendInt(b, int64(m.XRoger.Turn), 10)
+		b = append(b, `,"agent":`...)
+		b = append(b, goString(m.XRoger.Agent)...)
+		b = append(b, `,"model":`...)
+		b = appendNullableString(b, m.XRoger.Model)
+		b = append(b, `,"provider":`...)
+		b = appendNullableString(b, m.XRoger.Provider)
+		b = append(b, `,"ts":`...)
+		b = strconv.AppendInt(b, m.XRoger.TS, 10)
+		b = append(b, '}', '}')
+	}
+	b = append(b, ']')
+
+	b = append(b, `,"meta":{"tools_used":`...)
+	b = appendStringArray(b, c.Meta.ToolsUsed)
+	b = append(b, `,"exported_by":`...)
+	b = append(b, goString(c.Meta.ExportedBy)...)
+	b = append(b, `,"created_at":`...)
+	b = strconv.AppendInt(b, c.Meta.CreatedAt, 10)
+	b = append(b, `,"owner_pubkey":`...)
+	b = append(b, goString(c.Meta.OwnerPubkey)...)
+	b = append(b, '}')
+
+	b = append(b, '}')
+	return b
+}
+
+// appendStringArray emits a JSON array of goString-encoded strings with no spaces
+// (an empty or nil slice emits []), matching the app's canonical array form.
+func appendStringArray(b []byte, ss []string) []byte {
+	b = append(b, '[')
+	for i, s := range ss {
+		if i > 0 {
+			b = append(b, ',')
+		}
+		b = append(b, goString(s)...)
+	}
+	return append(b, ']')
+}
+
+// appendNullableString emits the literal null for a nil pointer, else the goString of
+// the pointed-to value. The format distinguishes an absent model/provider (null) from
+// an empty string ("").
+func appendNullableString(b []byte, s *string) []byte {
+	if s == nil {
+		return append(b, "null"...)
+	}
+	return append(b, goString(*s)...)
+}
+
+// Sign sets Meta.OwnerPubkey from priv and Sig to the hex ed25519 signature over the
+// canonical bytes (sig cleared). Deterministic per RFC-8032, but callers must assert
+// the BYTES + that a sig VERIFIES, never a fixed sig value (CryptoKit randomizes).
+func (c *Capsule) Sign(priv ed25519.PrivateKey) {
+	c.Meta.OwnerPubkey = hex.EncodeToString(priv.Public().(ed25519.PublicKey))
+	// canonical() never emits sig, so the signature is inherently over sig-cleared bytes.
+	c.Sig = hex.EncodeToString(ed25519.Sign(priv, c.canonical()))
+}
+
+// Verify reports whether Sig is a valid ed25519 signature over the canonical bytes for
+// Meta.OwnerPubkey. Malformed hex / wrong-length inputs are rejected, never panicked.
+func (c Capsule) Verify() bool {
+	pub, err := hex.DecodeString(c.Meta.OwnerPubkey)
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return false
+	}
+	sig, err := hex.DecodeString(c.Sig)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return false
+	}
+	return ed25519.Verify(ed25519.PublicKey(pub), c.canonical(), sig)
+}

--- a/internal/capsule/capsule_bdd_test.go
+++ b/internal/capsule/capsule_bdd_test.go
@@ -1,0 +1,425 @@
+package capsule
+
+// capsule_bdd_test.go wires godog so the roger.context.v1 behavior specs
+// (features/capsule/{canonical,merge,security}.feature) are EXECUTABLE Cucumber tests
+// over REAL ed25519 (no mocks), mirroring the proven relay-auth BDD pattern.
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+)
+
+// The golden canonical strings from the brief (the app-verified vector). The two
+// producers differ ONLY in the exported_by value.
+const (
+	goldenCLI = `{"capsule":"roger.context.v1","id":"cap_x","thread":{"origin_thread_id":"t1","title":"Hi","base_watermark":1},"redaction":"full","summary":{"text":"hi","produced_by":"none","as_of_turn":1},"memory":{"notes":"","facts":[]},"messages":[{"role":"user","content":"hi","x_roger":{"turn":0,"agent":"user","model":null,"provider":null,"ts":100}}],"meta":{"tools_used":[],"exported_by":"roger-cli","created_at":100,"owner_pubkey":"aa"}}`
+	goldenIOS = `{"capsule":"roger.context.v1","id":"cap_x","thread":{"origin_thread_id":"t1","title":"Hi","base_watermark":1},"redaction":"full","summary":{"text":"hi","produced_by":"none","as_of_turn":1},"memory":{"notes":"","facts":[]},"messages":[{"role":"user","content":"hi","x_roger":{"turn":0,"agent":"user","model":null,"provider":null,"ts":100}}],"meta":{"tools_used":[],"exported_by":"roger-ios","created_at":100,"owner_pubkey":"aa"}}`
+)
+
+type capsuleBDD struct {
+	priv      ed25519.PrivateKey
+	fixtures  []Capsule // for the two-producer scenario
+	subject   Capsule   // the capsule under test
+	canon     string
+	incoming  Capsule
+	target    Capsule
+	merged    Capsule
+	mergeErr  error
+	importErr error
+	imported  bool
+}
+
+func fixedNow() int64 { return 100 }
+
+func (s *capsuleBDD) freshKeypair() error {
+	_, priv, err := ed25519.GenerateKey(nil)
+	s.priv = priv
+	return err
+}
+
+func (s *capsuleBDD) goldenFixture(producer string) error {
+	s.subject = goldenInput(producer)
+	s.fixtures = append(s.fixtures, s.subject)
+	return nil
+}
+
+func (s *capsuleBDD) computeCanonical() error {
+	s.canon = string(s.subject.canonical())
+	return nil
+}
+
+func (s *capsuleBDD) canonEquals(producer string) error {
+	want := goldenCLI
+	if producer == "roger-ios" {
+		want = goldenIOS
+	}
+	if s.canon != want {
+		return bddErrf("canonical mismatch\n got: %s\nwant: %s", s.canon, want)
+	}
+	return nil
+}
+
+func (s *capsuleBDD) producersDifferOnlyInExportedBy() error {
+	if len(s.fixtures) != 2 {
+		return bddErrf("need both producer fixtures")
+	}
+	a := string(s.fixtures[0].canonical())
+	b := string(s.fixtures[1].canonical())
+	// Normalize the exported_by value and the bytes must be identical.
+	an := strings.Replace(a, `"exported_by":"roger-cli"`, `"exported_by":"X"`, 1)
+	an = strings.Replace(an, `"exported_by":"roger-ios"`, `"exported_by":"X"`, 1)
+	bn := strings.Replace(b, `"exported_by":"roger-cli"`, `"exported_by":"X"`, 1)
+	bn = strings.Replace(bn, `"exported_by":"roger-ios"`, `"exported_by":"X"`, 1)
+	if an != bn {
+		return bddErrf("producers differ beyond exported_by:\n%s\n%s", a, b)
+	}
+	if a == b {
+		return bddErrf("producers must differ in exported_by")
+	}
+	return nil
+}
+
+func (s *capsuleBDD) canonLiteralNull() error {
+	if !strings.Contains(s.canon, `"model":null,"provider":null`) {
+		return bddErrf("canonical must carry literal null model+provider: %s", s.canon)
+	}
+	return nil
+}
+
+func (s *capsuleBDD) setSig(v string) error {
+	s.canon = string(s.subject.canonical()) // baseline BEFORE the sig is set
+	s.subject.Sig = v
+	return nil
+}
+
+func (s *capsuleBDD) canonUnchanged() error {
+	if got := string(s.subject.canonical()); got != s.canon {
+		return bddErrf("canonical changed after sig set:\n before: %s\n after: %s", s.canon, got)
+	}
+	return nil
+}
+
+// --- merge steps ---
+
+func (s *capsuleBDD) signedCapsuleWithTurns(watermark int, table *godog.Table) error {
+	msgs, err := rowsToMessages(table)
+	if err != nil {
+		return err
+	}
+	c := Capsule{Capsule: Version, ID: "cap", Thread: Thread{OriginThreadID: "t1", Title: "T", BaseWatermark: watermark}, Messages: msgs, Meta: Meta{ToolsUsed: []string{}}}
+	c.Sign(s.priv)
+	s.incoming = c
+	return nil
+}
+
+// contentForTurn is the fixed content convention the tables use (turn 0 "hi", 1 "yo",
+// 2 "more"), so a synthetic target and a table-built incoming agree on the content of an
+// overlapping turn (otherwise every overlap would look like a fork).
+func contentForTurn(t int) string {
+	switch t {
+	case 0:
+		return "hi"
+	case 1:
+		return "yo"
+	case 2:
+		return "more"
+	default:
+		return "t" + strconv.Itoa(t)
+	}
+}
+
+func (s *capsuleBDD) targetWithTurns(csv string, watermark int) error {
+	c := Capsule{Capsule: Version, Thread: Thread{BaseWatermark: watermark}}
+	for _, t := range parseCSVInts(csv) {
+		role := "user"
+		if t%2 == 1 {
+			role = "assistant"
+		}
+		c.Messages = append(c.Messages, Message{Role: role, Content: contentForTurn(t), XRoger: XRoger{Turn: t, Agent: "user", TS: int64(t)}})
+	}
+	s.target = c
+	return nil
+}
+
+func (s *capsuleBDD) mergeIntoEmpty() error {
+	s.merged, s.mergeErr = Merge(s.incoming, Capsule{Capsule: Version})
+	return nil
+}
+func (s *capsuleBDD) mergeIntoTarget() error {
+	s.merged, s.mergeErr = Merge(s.incoming, s.target)
+	return nil
+}
+
+// mergeIntoResult merges the current incoming into the previous merge result - used both
+// for the idempotent "merge again" case and the "merge a smaller capsule" case.
+func (s *capsuleBDD) mergeIntoResult() error {
+	s.merged, s.mergeErr = Merge(s.incoming, s.merged)
+	return nil
+}
+
+func (s *capsuleBDD) mergeSucceeds() error {
+	if s.mergeErr != nil {
+		return bddErrf("expected merge success, got %v", s.mergeErr)
+	}
+	return nil
+}
+func (s *capsuleBDD) mergeRejected(kind string) error {
+	var want error
+	switch kind {
+	case "unverified":
+		want = ErrUnverified
+	case "forked":
+		want = ErrForkedTurn
+	case "unknown-version":
+		want = ErrUnknownVersion
+	default:
+		return bddErrf("unknown rejection kind %q", kind)
+	}
+	if !errors.Is(s.mergeErr, want) {
+		return bddErrf("expected %v, got %v", want, s.mergeErr)
+	}
+	return nil
+}
+
+func (s *capsuleBDD) mergedTurns(csv string) error {
+	got := mergedTurnCSV(s.merged)
+	if got != csv {
+		return bddErrf("merged turns = %q, want %q", got, csv)
+	}
+	return nil
+}
+func (s *capsuleBDD) mergedWatermark(n int) error {
+	if s.merged.Thread.BaseWatermark != n {
+		return bddErrf("merged watermark = %d, want %d", s.merged.Thread.BaseWatermark, n)
+	}
+	return nil
+}
+func (s *capsuleBDD) mergedSigCleared() error {
+	if s.merged.Sig != "" {
+		return bddErrf("merged sig must be cleared, got %q", s.merged.Sig)
+	}
+	return nil
+}
+func (s *capsuleBDD) tamperIncomingAfterSigning() error {
+	if len(s.incoming.Messages) == 0 {
+		return bddErrf("no message to tamper")
+	}
+	s.incoming.Messages[len(s.incoming.Messages)-1].Content = "evil"
+	return nil
+}
+func (s *capsuleBDD) changeVersionResign(v string) error {
+	s.incoming.Capsule = v
+	s.incoming.Sign(s.priv)
+	return nil
+}
+
+// --- security steps ---
+
+func (s *capsuleBDD) signedSummaryOnly() error {
+	c, err := Export(SummaryOnly(Draft{
+		ID:       "cap_s",
+		Thread:   Thread{OriginThreadID: "t1", Title: "T", BaseWatermark: 3},
+		Summary:  Summary{Text: "so far", ProducedBy: "operator:m", AsOfTurn: 2},
+		Memory:   Memory{Notes: "secret", Facts: []string{"private"}},
+		Messages: []Message{{Role: "user", Content: "current", XRoger: XRoger{Turn: 2, Agent: "user", TS: 9}}},
+	}), s.priv, "roger-cli", fixedNow)
+	s.subject = c
+	return err
+}
+func (s *capsuleBDD) redactionIs(v string) error {
+	if s.subject.Redaction != v {
+		return bddErrf("redaction = %q, want %q", s.subject.Redaction, v)
+	}
+	return nil
+}
+func (s *capsuleBDD) flipRedaction(v string) error { s.subject.Redaction = v; return nil }
+func (s *capsuleBDD) noLongerVerifies() error {
+	if s.subject.Verify() {
+		return bddErrf("capsule must not verify after tamper")
+	}
+	return nil
+}
+func (s *capsuleBDD) tamperField(field string) error {
+	switch field {
+	case "content":
+		s.subject.Messages[0].Content = "evil"
+	case "role":
+		s.subject.Messages[0].Role = "system"
+	case "title":
+		s.subject.Thread.Title = "other"
+	case "summary":
+		s.subject.Summary.Text = "rewritten"
+	case "created_at":
+		s.subject.Meta.CreatedAt = 200
+	case "exported_by":
+		s.subject.Meta.ExportedBy = "roger-ios"
+	case "watermark":
+		s.subject.Thread.BaseWatermark = 99
+	default:
+		return bddErrf("unknown field %q", field)
+	}
+	return nil
+}
+func (s *capsuleBDD) signedCapsuleWithToolCalls() error {
+	c := Capsule{Capsule: Version, ID: "cap_tc", Thread: Thread{BaseWatermark: 1}, Messages: []Message{{Role: "assistant", Content: "c", ToolCalls: json.RawMessage(`[{"id":"1"}]`), XRoger: XRoger{Turn: 0, Agent: "roger:m", TS: 1}}}, Meta: Meta{ToolsUsed: []string{}}}
+	c.Sign(s.priv)
+	s.incoming = c
+	return nil
+}
+func (s *capsuleBDD) importIncoming() error {
+	raw, _ := s.incoming.Marshal()
+	_, s.importErr = Import(raw)
+	return nil
+}
+func (s *capsuleBDD) importRejectedToolCalls() error {
+	if !errors.Is(s.importErr, ErrToolCalls) {
+		return bddErrf("expected ErrToolCalls, got %v", s.importErr)
+	}
+	return nil
+}
+func (s *capsuleBDD) draftWithToolCalls() error {
+	s.subject = Capsule{} // reuse subject as a marker; the draft is built in exportDraft
+	return nil
+}
+func (s *capsuleBDD) exportDraft() error {
+	_, s.importErr = Export(Draft{ID: "cap_d", Messages: []Message{{Role: "assistant", Content: "c", ToolCalls: json.RawMessage(`[{"id":"1"}]`), XRoger: XRoger{Turn: 0, Agent: "roger:m"}}}}, s.priv, "roger-cli", fixedNow)
+	return nil
+}
+func (s *capsuleBDD) exportRefusedToolCalls() error {
+	if !errors.Is(s.importErr, ErrToolCalls) {
+		return bddErrf("expected ErrToolCalls, got %v", s.importErr)
+	}
+	return nil
+}
+func (s *capsuleBDD) marshalAndImport() error {
+	raw, _ := s.incoming.Marshal()
+	c, err := Import(raw)
+	s.importErr = err
+	s.imported = err == nil
+	s.subject = c
+	return nil
+}
+func (s *capsuleBDD) importSucceeds() error {
+	if !s.imported {
+		return bddErrf("expected import success, got %v", s.importErr)
+	}
+	return nil
+}
+func (s *capsuleBDD) importedVerifies() error {
+	if !s.subject.Verify() {
+		return bddErrf("imported capsule must verify")
+	}
+	return nil
+}
+
+// --- helpers ---
+
+func rowsToMessages(table *godog.Table) ([]Message, error) {
+	var msgs []Message
+	for i, row := range table.Rows {
+		if i == 0 {
+			continue // header
+		}
+		turn, err := strconv.Atoi(strings.TrimSpace(row.Cells[0].Value))
+		if err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, Message{
+			Role:    strings.TrimSpace(row.Cells[1].Value),
+			Content: strings.TrimSpace(row.Cells[2].Value),
+			XRoger:  XRoger{Turn: turn, Agent: "user", TS: int64(turn)},
+		})
+	}
+	return msgs, nil
+}
+
+func parseCSVInts(csv string) []int {
+	var out []int
+	for _, p := range strings.Split(csv, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			n, _ := strconv.Atoi(p)
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func mergedTurnCSV(c Capsule) string {
+	var parts []string
+	for _, m := range c.Messages {
+		parts = append(parts, strconv.Itoa(m.XRoger.Turn))
+	}
+	return strings.Join(parts, ",")
+}
+
+type bddError string
+
+func (e bddError) Error() string            { return string(e) }
+func bddErrf(format string, a ...any) error { return bddError(fmt.Sprintf(format, a...)) }
+
+func TestCapsuleBDD(t *testing.T) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			st := &capsuleBDD{}
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				*st = capsuleBDD{}
+				return ctx, nil
+			})
+			// canonical
+			sc.Step(`^the golden fixture capsule exported by "([^"]*)"$`, st.goldenFixture)
+			sc.Step(`^I compute its canonical bytes$`, st.computeCanonical)
+			sc.Step(`^they equal the golden canonical string for "([^"]*)"$`, st.canonEquals)
+			sc.Step(`^their canonical bytes differ only in the exported_by value$`, st.producersDifferOnlyInExportedBy)
+			sc.Step(`^the canonical bytes carry a literal null model and provider$`, st.canonLiteralNull)
+			sc.Step(`^I set the signature to "([^"]*)"$`, st.setSig)
+			sc.Step(`^the canonical bytes are unchanged$`, st.canonUnchanged)
+			// merge
+			sc.Step(`^a fresh operator keypair$`, st.freshKeypair)
+			sc.Step(`^a signed capsule with watermark (\d+) and turns$`, st.signedCapsuleWithTurns)
+			sc.Step(`^the target thread has turns "([^"]*)" at watermark (\d+)$`, st.targetWithTurns)
+			sc.Step(`^I merge it into an empty thread$`, st.mergeIntoEmpty)
+			sc.Step(`^I merge it into the target$`, st.mergeIntoTarget)
+			sc.Step(`^I merge it again into the result$`, st.mergeIntoResult)
+			sc.Step(`^I merge it into the result$`, st.mergeIntoResult)
+			sc.Step(`^the merge succeeds$`, st.mergeSucceeds)
+			sc.Step(`^the merge is rejected as (unverified|forked|unknown-version)$`, st.mergeRejected)
+			sc.Step(`^the merged thread has turns "([^"]*)"$`, st.mergedTurns)
+			sc.Step(`^the merged watermark is (\d+)$`, st.mergedWatermark)
+			sc.Step(`^the merged signature is cleared$`, st.mergedSigCleared)
+			sc.Step(`^the incoming capsule is tampered after signing$`, st.tamperIncomingAfterSigning)
+			sc.Step(`^the incoming capsule version is changed and re-signed to "([^"]*)"$`, st.changeVersionResign)
+			// security
+			sc.Step(`^a signed summary-only capsule$`, st.signedSummaryOnly)
+			sc.Step(`^the capsule redaction is "([^"]*)"$`, st.redactionIs)
+			sc.Step(`^I flip the redaction to "([^"]*)" without the key$`, st.flipRedaction)
+			sc.Step(`^the capsule no longer verifies$`, st.noLongerVerifies)
+			sc.Step(`^I tamper the field "([^"]*)"$`, st.tamperField)
+			sc.Step(`^a signed capsule carrying tool_calls$`, st.signedCapsuleWithToolCalls)
+			sc.Step(`^I import it$`, st.importIncoming)
+			sc.Step(`^the import is rejected as tool_calls-unsupported$`, st.importRejectedToolCalls)
+			sc.Step(`^a draft carrying tool_calls$`, st.draftWithToolCalls)
+			sc.Step(`^I export it$`, st.exportDraft)
+			sc.Step(`^the export is refused as tool_calls-unsupported$`, st.exportRefusedToolCalls)
+			sc.Step(`^I marshal and import it$`, st.marshalAndImport)
+			sc.Step(`^the import succeeds$`, st.importSucceeds)
+			sc.Step(`^the imported capsule verifies$`, st.importedVerifies)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/capsule/canonical.feature", "../../features/capsule/merge.feature", "../../features/capsule/security.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("capsule behavior scenarios failed (see godog output above)")
+	}
+}

--- a/internal/capsule/capsule_more_test.go
+++ b/internal/capsule/capsule_more_test.go
@@ -1,0 +1,222 @@
+package capsule
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func strp(s string) *string { return &s }
+
+// keypair returns an ephemeral ed25519 keypair for a test. The unit tests deliberately
+// use throwaway keys (never the CLI identity) so a passing test can never depend on, or
+// mint, the on-disk user.key.
+func keypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+// TestCanonicalFieldOrderAndForm exhaustively pins the canonical shape: fixed field
+// order, goString escaping of < > &, literal null (not omit) for nil model/provider, a
+// real model/provider string, plain-decimal numbers (incl negative), non-empty
+// facts/tools arrays, and the conditional tool_calls slot present vs absent.
+func TestCanonicalFieldOrderAndForm(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Capsule
+		want string
+	}{
+		{
+			name: "real model/provider strings + non-empty arrays",
+			in: Capsule{
+				Capsule:   Version,
+				ID:        "cap_1",
+				Thread:    Thread{OriginThreadID: "t1", Title: "a b", BaseWatermark: 2},
+				Redaction: "full",
+				Summary:   Summary{Text: "xy", ProducedBy: "operator:m", AsOfTurn: 2},
+				Memory:    Memory{Notes: "n", Facts: []string{"f1", "f2"}},
+				Messages: []Message{{
+					Role: "user", Content: "hey",
+					XRoger: XRoger{Turn: 1, Agent: "user", Model: strp("gpt"), Provider: strp("openai"), TS: 100},
+				}},
+				Meta: Meta{ToolsUsed: []string{"bash", "read"}, ExportedBy: "roger-cli", CreatedAt: 100, OwnerPubkey: "aa"},
+			},
+			want: `{"capsule":"roger.context.v1","id":"cap_1","thread":{"origin_thread_id":"t1","title":"a b","base_watermark":2},"redaction":"full","summary":{"text":"xy","produced_by":"operator:m","as_of_turn":2},"memory":{"notes":"n","facts":["f1","f2"]},"messages":[{"role":"user","content":"hey","x_roger":{"turn":1,"agent":"user","model":"gpt","provider":"openai","ts":100}}],"meta":{"tools_used":["bash","read"],"exported_by":"roger-cli","created_at":100,"owner_pubkey":"aa"}}`,
+		},
+		{
+			name: "negative numbers + empty everything + null model/provider",
+			in: Capsule{
+				Capsule:  Version,
+				ID:       "cap_2",
+				Thread:   Thread{BaseWatermark: -1},
+				Summary:  Summary{AsOfTurn: -5},
+				Messages: []Message{{Role: "assistant", Content: "", XRoger: XRoger{Turn: -2, Agent: "roger:m", TS: -9}}},
+				Meta:     Meta{},
+			},
+			want: `{"capsule":"roger.context.v1","id":"cap_2","thread":{"origin_thread_id":"","title":"","base_watermark":-1},"redaction":"","summary":{"text":"","produced_by":"","as_of_turn":-5},"memory":{"notes":"","facts":[]},"messages":[{"role":"assistant","content":"","x_roger":{"turn":-2,"agent":"roger:m","model":null,"provider":null,"ts":-9}}],"meta":{"tools_used":[],"exported_by":"","created_at":0,"owner_pubkey":""}}`,
+		},
+		{
+			name: "conditional tool_calls slot present (verbatim raw)",
+			in: Capsule{
+				Capsule:  Version,
+				ID:       "cap_3",
+				Messages: []Message{{Role: "assistant", Content: "c", ToolCalls: json.RawMessage(`[{"id":"1"}]`), XRoger: XRoger{Turn: 0, Agent: "roger:m", TS: 1}}},
+				Meta:     Meta{OwnerPubkey: "bb"},
+			},
+			want: `{"capsule":"roger.context.v1","id":"cap_3","thread":{"origin_thread_id":"","title":"","base_watermark":0},"redaction":"","summary":{"text":"","produced_by":"","as_of_turn":0},"memory":{"notes":"","facts":[]},"messages":[{"role":"assistant","content":"c","tool_calls":[{"id":"1"}],"x_roger":{"turn":0,"agent":"roger:m","model":null,"provider":null,"ts":1}}],"meta":{"tools_used":[],"exported_by":"","created_at":0,"owner_pubkey":"bb"}}`,
+		},
+		{
+			name: "multiple messages join with a comma, no trailing space",
+			in: Capsule{
+				Capsule: Version, ID: "cap_4",
+				Messages: []Message{
+					{Role: "user", Content: "a", XRoger: XRoger{Turn: 0, Agent: "user", TS: 1}},
+					{Role: "assistant", Content: "b", XRoger: XRoger{Turn: 1, Agent: "roger:m", TS: 2}},
+				},
+				Meta: Meta{OwnerPubkey: "cc"},
+			},
+			want: `{"capsule":"roger.context.v1","id":"cap_4","thread":{"origin_thread_id":"","title":"","base_watermark":0},"redaction":"","summary":{"text":"","produced_by":"","as_of_turn":0},"memory":{"notes":"","facts":[]},"messages":[{"role":"user","content":"a","x_roger":{"turn":0,"agent":"user","model":null,"provider":null,"ts":1}},{"role":"assistant","content":"b","x_roger":{"turn":1,"agent":"roger:m","model":null,"provider":null,"ts":2}}],"meta":{"tools_used":[],"exported_by":"","created_at":0,"owner_pubkey":"cc"}}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string(tc.in.canonical()); got != tc.want {
+				t.Errorf("canonical mismatch\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCanonicalExcludesSig proves the signature field is never part of the canonical
+// bytes: setting Sig cannot change canonical() (so a sig can sign over sig-cleared bytes).
+func TestCanonicalExcludesSig(t *testing.T) {
+	c := goldenInput("roger-cli")
+	before := string(c.canonical())
+	c.Sig = "deadbeef"
+	if after := string(c.canonical()); after != before {
+		t.Errorf("Sig leaked into canonical bytes:\n before: %s\n after:  %s", before, after)
+	}
+}
+
+// TestSignVerifyRoundtrip: a freshly signed capsule verifies, sets owner_pubkey from the
+// key, and is deterministic per RFC-8032 (same key + bytes -> same sig) - but the test
+// asserts the sig VERIFIES, it does not pin a fixed sig value.
+func TestSignVerifyRoundtrip(t *testing.T) {
+	pub, priv := keypair(t)
+	c := goldenInput("roger-cli")
+	if c.Verify() {
+		t.Fatal("unsigned capsule must not verify")
+	}
+	c.Sign(priv)
+	if c.Meta.OwnerPubkey != hex.EncodeToString(pub) {
+		t.Errorf("Sign must set owner_pubkey to the signing key")
+	}
+	if !c.Verify() {
+		t.Error("signed capsule must verify with its own key")
+	}
+	// A different key must not verify.
+	otherPub, _ := keypair(t)
+	c.Meta.OwnerPubkey = hex.EncodeToString(otherPub)
+	if c.Verify() {
+		t.Error("capsule must not verify under a different owner_pubkey")
+	}
+}
+
+// TestVerifyMalformedInputs: garbage pubkey/sig are rejected, never panic.
+func TestVerifyMalformedInputs(t *testing.T) {
+	_, priv := keypair(t)
+	c := goldenInput("roger-cli")
+	c.Sign(priv)
+	for _, bad := range []struct {
+		name, pub, sig string
+	}{
+		{"non-hex pubkey", "zz", c.Sig},
+		{"short pubkey", "aa", c.Sig},
+		{"non-hex sig", c.Meta.OwnerPubkey, "zz"},
+		{"short sig", c.Meta.OwnerPubkey, "aa"},
+		{"empty sig", c.Meta.OwnerPubkey, ""},
+	} {
+		t.Run(bad.name, func(t *testing.T) {
+			tc := c
+			tc.Meta.OwnerPubkey, tc.Sig = bad.pub, bad.sig
+			if tc.Verify() {
+				t.Error("malformed input must not verify")
+			}
+		})
+	}
+}
+
+// TestTamperMatrix: every mutation of a signed capsule breaks verification, because the
+// sig covers the canonical bytes of every field. This includes the STRANGER escalation:
+// flipping a summary-only capsule's redaction to "full" cannot re-verify without the key.
+func TestTamperMatrix(t *testing.T) {
+	_, priv := keypair(t)
+	base, err := Export(SummaryOnly(Draft{
+		ID:       "cap_s",
+		Thread:   Thread{OriginThreadID: "t1", Title: "T", BaseWatermark: 3},
+		Summary:  Summary{Text: "so far", ProducedBy: "operator:m", AsOfTurn: 2},
+		Memory:   Memory{Notes: "secret", Facts: []string{"private"}},
+		Messages: []Message{{Role: "user", Content: "current", XRoger: XRoger{Turn: 2, Agent: "user", TS: 9}}},
+	}), priv, "roger-cli", func() int64 { return 100 })
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if !base.Verify() {
+		t.Fatal("base summary-only capsule must verify")
+	}
+	if base.Redaction != "summary" {
+		t.Fatalf("SummaryOnly must set redaction=summary, got %q", base.Redaction)
+	}
+
+	tampers := map[string]func(*Capsule){
+		"escalate redaction summary->full": func(c *Capsule) { c.Redaction = "full" },
+		"flip a message content":           func(c *Capsule) { c.Messages[0].Content = "evil" },
+		"flip a message role":              func(c *Capsule) { c.Messages[0].Role = "system" },
+		"append a forged turn":             func(c *Capsule) { c.Messages = append(c.Messages, Message{Role: "assistant", Content: "forged", XRoger: XRoger{Turn: 3, Agent: "roger:m", TS: 10}}) },
+		"change the title":                 func(c *Capsule) { c.Thread.Title = "other" },
+		"change the summary text":          func(c *Capsule) { c.Summary.Text = "rewritten" },
+		"change created_at":                func(c *Capsule) { c.Meta.CreatedAt = 200 },
+		"change exported_by":               func(c *Capsule) { c.Meta.ExportedBy = "roger-ios" },
+		"change base_watermark":            func(c *Capsule) { c.Thread.BaseWatermark = 99 },
+	}
+	for name, mut := range tampers {
+		t.Run(name, func(t *testing.T) {
+			tc := base
+			// deep-copy the message slice so a mutation does not bleed across subtests
+			tc.Messages = append([]Message(nil), base.Messages...)
+			mut(&tc)
+			if tc.Verify() {
+				t.Errorf("tampered capsule (%s) must not verify", name)
+			}
+		})
+	}
+}
+
+// TestCanonicalHTMLEscapes proves goString HTML-escapes < > & (matching the app's
+// goString / the share receipts). A field carrying those runes must emit NO raw < > &
+// in the canonical bytes (each is escaped to a \u00XX sequence), and the escaping
+// backslash must appear. This is checked on runes so no fragile \u literal is needed.
+func TestCanonicalHTMLEscapes(t *testing.T) {
+	c := Capsule{Capsule: Version, Thread: Thread{Title: "<a & b>"}}
+	got := string(c.canonical())
+	for _, raw := range []rune{'<', '>', '&'} {
+		if strings.ContainsRune(got, raw) {
+			t.Errorf("canonical must not contain a RAW %q (must be HTML-escaped): %s", raw, got)
+		}
+	}
+	if !strings.ContainsRune(got, '\\') {
+		t.Errorf("canonical must contain a \\u escape for the escaped runes: %s", got)
+	}
+	// The exact escape must equal encoding/json's (the app's goString is json.Marshal),
+	// built from the marshaler itself rather than a hand-typed literal.
+	jm, _ := json.Marshal(c.Thread.Title)
+	if !strings.Contains(got, string(jm)) {
+		t.Errorf("canonical title must equal json.Marshal(title)=%s: %s", jm, got)
+	}
+}

--- a/internal/capsule/capsule_more_test.go
+++ b/internal/capsule/capsule_more_test.go
@@ -178,12 +178,14 @@ func TestTamperMatrix(t *testing.T) {
 		"escalate redaction summary->full": func(c *Capsule) { c.Redaction = "full" },
 		"flip a message content":           func(c *Capsule) { c.Messages[0].Content = "evil" },
 		"flip a message role":              func(c *Capsule) { c.Messages[0].Role = "system" },
-		"append a forged turn":             func(c *Capsule) { c.Messages = append(c.Messages, Message{Role: "assistant", Content: "forged", XRoger: XRoger{Turn: 3, Agent: "roger:m", TS: 10}}) },
-		"change the title":                 func(c *Capsule) { c.Thread.Title = "other" },
-		"change the summary text":          func(c *Capsule) { c.Summary.Text = "rewritten" },
-		"change created_at":                func(c *Capsule) { c.Meta.CreatedAt = 200 },
-		"change exported_by":               func(c *Capsule) { c.Meta.ExportedBy = "roger-ios" },
-		"change base_watermark":            func(c *Capsule) { c.Thread.BaseWatermark = 99 },
+		"append a forged turn": func(c *Capsule) {
+			c.Messages = append(c.Messages, Message{Role: "assistant", Content: "forged", XRoger: XRoger{Turn: 3, Agent: "roger:m", TS: 10}})
+		},
+		"change the title":        func(c *Capsule) { c.Thread.Title = "other" },
+		"change the summary text": func(c *Capsule) { c.Summary.Text = "rewritten" },
+		"change created_at":       func(c *Capsule) { c.Meta.CreatedAt = 200 },
+		"change exported_by":      func(c *Capsule) { c.Meta.ExportedBy = "roger-ios" },
+		"change base_watermark":   func(c *Capsule) { c.Thread.BaseWatermark = 99 },
 	}
 	for name, mut := range tampers {
 		t.Run(name, func(t *testing.T) {

--- a/internal/capsule/merge.go
+++ b/internal/capsule/merge.go
@@ -1,0 +1,188 @@
+package capsule
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Boundary errors. These are the rejections the app<->CLI/guest boundary enforces; the
+// copy is deliberately terse (a public repo does not narrate the escalation each guards).
+var (
+	// ErrUnverified rejects a capsule whose sig does not verify against meta.owner_pubkey.
+	ErrUnverified = errors.New("capsule: signature does not verify")
+	// ErrUnknownVersion rejects a capsule whose format is not Version.
+	ErrUnknownVersion = errors.New("capsule: unknown version")
+	// ErrToolCalls rejects a capsule carrying tool_calls (ruling Q1): the canonical form
+	// for tool_calls is not yet pinned cross-language, so none may cross the boundary.
+	ErrToolCalls = errors.New("capsule: tool_calls not supported at this boundary")
+	// ErrForkedTurn rejects a merge where an incoming turn collides with a present turn of
+	// the same index but different content (ruling Q2): the whole capsule is rejected and
+	// the target is left unchanged - a returning capsule may never rewrite history.
+	ErrForkedTurn = errors.New("capsule: forked turn (same turn index, different content)")
+)
+
+// turnHash is the dedup/fork identity of a message: sha256 over role and content with a
+// NUL separator (so "a"+"b" and "ab" can never collide). Turn index + this hash is a
+// message's identity for append-only merge.
+func turnHash(m Message) string {
+	h := sha256.Sum256([]byte(m.Role + "\x00" + m.Content))
+	return hex.EncodeToString(h[:])
+}
+
+// validateBoundary runs the version + tool_calls checks every crossing capsule must
+// pass. It does NOT verify the signature (callers that need verification call Verify or
+// Merge, which does both) - Export produces boundary-valid capsules, Merge/Import
+// consume them.
+func validateBoundary(c Capsule) error {
+	if c.Capsule != Version {
+		return ErrUnknownVersion
+	}
+	for i := range c.Messages {
+		if len(c.Messages[i].ToolCalls) > 0 {
+			return ErrToolCalls
+		}
+	}
+	return nil
+}
+
+// Merge appends the turns in incoming that into does not already have, append-only. It
+// (1) rejects an incoming capsule that fails validateBoundary (version / tool_calls),
+// (2) rejects one whose sig does not verify (verify-before-merge), (3) rejects the whole
+// capsule if any incoming turn forks a present turn (ruling Q2), then (4) appends only
+// incoming messages at/after into's base_watermark that are not already present (dedup by
+// turn index + turnHash). It NEVER truncates or replaces - a handoff can only add context.
+//
+// The returned capsule is into with the new turns appended, base_watermark advanced, and
+// Sig cleared: the merged thread is the holder's own local state and must be re-signed
+// (Export) before it crosses a boundary again. into is trusted local state and is not
+// re-verified; only incoming is.
+func Merge(incoming, into Capsule) (Capsule, error) {
+	if err := validateBoundary(incoming); err != nil {
+		return into, err
+	}
+	if !incoming.Verify() {
+		return into, ErrUnverified
+	}
+
+	// Identity index of the target: turn index -> content hash. A present turn is one at
+	// index t < base_watermark OR any turn already in Messages.
+	present := make(map[int]string, len(into.Messages))
+	for _, m := range into.Messages {
+		present[m.XRoger.Turn] = turnHash(m)
+	}
+
+	// Fork check FIRST, across the whole incoming set, so a rejection leaves into fully
+	// unchanged (ruling Q2): any incoming turn that collides with a present turn of the
+	// same index but a different hash rejects the entire capsule.
+	for _, m := range incoming.Messages {
+		if h, ok := present[m.XRoger.Turn]; ok && h != turnHash(m) {
+			return into, ErrForkedTurn
+		}
+	}
+
+	// Append-only: add incoming turns at/after the watermark that are not already present.
+	out := into
+	out.Sig = "" // messages change; the old signature no longer covers them
+	maxTurn := into.Thread.BaseWatermark - 1
+	for _, m := range incoming.Messages {
+		if m.XRoger.Turn < into.Thread.BaseWatermark {
+			continue // the holder already had this turn (or an earlier one); never backdate-insert
+		}
+		if h, ok := present[m.XRoger.Turn]; ok && h == turnHash(m) {
+			continue // exact duplicate already appended - idempotent
+		}
+		out.Messages = append(out.Messages, m)
+		present[m.XRoger.Turn] = turnHash(m)
+		if m.XRoger.Turn > maxTurn {
+			maxTurn = m.XRoger.Turn
+		}
+	}
+	if maxTurn+1 > out.Thread.BaseWatermark {
+		out.Thread.BaseWatermark = maxTurn + 1
+	}
+	return out, nil
+}
+
+// Import decodes and verifies a capsule from raw JSON (a .rcap.json file / stdin). It
+// enforces the same boundary as Merge: valid JSON, known version, no tool_calls, and a
+// signature that verifies. The receiving side of the file interop.
+func Import(data []byte) (Capsule, error) {
+	var c Capsule
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Capsule{}, err
+	}
+	if err := validateBoundary(c); err != nil {
+		return Capsule{}, err
+	}
+	if !c.Verify() {
+		return Capsule{}, ErrUnverified
+	}
+	return c, nil
+}
+
+// Draft is the unsigned content Export signs into a capsule: everything except the
+// producer-stamped meta (exported_by / created_at / owner_pubkey) and the sig, which
+// Export fills. Turns carries the ordered messages (the TUI ring feeds these).
+type Draft struct {
+	ID        string
+	Thread    Thread
+	Redaction string
+	Summary   Summary
+	Memory    Memory
+	Messages  []Message
+	ToolsUsed []string
+}
+
+// Export builds a signed roger.context.v1 capsule from d, stamping meta.exported_by =
+// exportedBy (e.g. "roger-cli"), created_at = now, and signing with priv (which also
+// sets owner_pubkey). It REJECTS a draft carrying tool_calls (ruling Q1) before signing,
+// so a capsule that crosses the boundary can never contain them. now is injectable for
+// deterministic tests; pass nil to use time.Now.
+func Export(d Draft, priv ed25519.PrivateKey, exportedBy string, now func() int64) (Capsule, error) {
+	ts := time.Now().Unix
+	if now != nil {
+		ts = now
+	}
+	c := Capsule{
+		Capsule:   Version,
+		ID:        d.ID,
+		Thread:    d.Thread,
+		Redaction: d.Redaction,
+		Summary:   d.Summary,
+		Memory:    d.Memory,
+		Messages:  d.Messages,
+		Meta: Meta{
+			ToolsUsed:  d.ToolsUsed,
+			ExportedBy: exportedBy,
+			CreatedAt:  ts(),
+		},
+	}
+	if err := validateBoundary(c); err != nil {
+		return Capsule{}, err
+	}
+	c.Sign(priv)
+	return c, nil
+}
+
+// Marshal serializes a signed capsule to its wire JSON (a .rcap.json file). It is the
+// standard encoding/json form (the sig-bearing at-rest object), distinct from the
+// canonical signing bytes.
+func (c Capsule) Marshal() ([]byte, error) { return json.Marshal(c) }
+
+// SummaryOnly returns the redacted draft the CLI hands to a MARKETPLACE/STRANGER
+// operator: redaction="summary", memory dropped, and only the CURRENT (last) turn kept -
+// no full transcript. The redaction level is signed (it is in canonical()), so a stranger
+// cannot silently upgrade a summary-only capsule to full and re-sign. Same-owner/trusted
+// targets get the full draft; the encrypted stranger transport itself is a follow-on (Q3).
+func SummaryOnly(d Draft) Draft {
+	d.Redaction = "summary"
+	d.Memory = Memory{}
+	if n := len(d.Messages); n > 0 {
+		d.Messages = d.Messages[n-1:]
+	}
+	return d
+}

--- a/internal/capsule/merge.go
+++ b/internal/capsule/merge.go
@@ -75,13 +75,20 @@ func Merge(incoming, into Capsule) (Capsule, error) {
 		present[m.XRoger.Turn] = turnHash(m)
 	}
 
-	// Fork check FIRST, across the whole incoming set, so a rejection leaves into fully
-	// unchanged (ruling Q2): any incoming turn that collides with a present turn of the
-	// same index but a different hash rejects the entire capsule.
+	// Fork check FIRST, so a rejection leaves into fully unchanged (ruling Q2). A fork is
+	// any two turns sharing an index but differing in content - checked both against the
+	// TARGET and WITHIN the incoming set itself (an incoming capsule that carries turn 2
+	// twice with different content is a rewrite too, and must not slip through).
+	seen := make(map[int]string, len(incoming.Messages))
 	for _, m := range incoming.Messages {
-		if h, ok := present[m.XRoger.Turn]; ok && h != turnHash(m) {
+		h := turnHash(m)
+		if e, ok := present[m.XRoger.Turn]; ok && e != h {
 			return into, ErrForkedTurn
 		}
+		if e, ok := seen[m.XRoger.Turn]; ok && e != h {
+			return into, ErrForkedTurn
+		}
+		seen[m.XRoger.Turn] = h
 	}
 
 	// Append-only: add incoming turns at/after the watermark that are not already present.

--- a/internal/capsule/merge_test.go
+++ b/internal/capsule/merge_test.go
@@ -177,6 +177,31 @@ func TestMergeRejectsForkedTurn(t *testing.T) {
 	}
 }
 
+// TestMergeRejectsIntraIncomingFork is a regression for the reviewer's Q2 gap: an incoming
+// capsule that carries the SAME turn index twice with different content is a rewrite too,
+// and must reject the whole capsule (not silently append both). into is left unchanged.
+func TestMergeRejectsIntraIncomingFork(t *testing.T) {
+	_, priv := keypair(t)
+	into := signed(t, priv, 0)
+	incoming := signed(t, priv, 3,
+		msg(0, "user", "a", "user"),
+		msg(1, "assistant", "b", "roger:m"),
+		msg(1, "assistant", "b-REWRITTEN", "roger:m"), // turn 1 again, different content
+	)
+	out, err := Merge(incoming, into)
+	if !errors.Is(err, ErrForkedTurn) {
+		t.Errorf("err = %v, want ErrForkedTurn", err)
+	}
+	if len(out.Messages) != 0 {
+		t.Errorf("into must be unchanged on intra-incoming fork, got %v", turns(out))
+	}
+	// An exact-duplicate turn (same index AND content) is NOT a fork - it dedups.
+	dup := signed(t, priv, 2, msg(0, "user", "a", "user"), msg(0, "user", "a", "user"))
+	if _, err := Merge(dup, into); err != nil {
+		t.Errorf("exact-duplicate turn must dedup, not fork: %v", err)
+	}
+}
+
 // TestMergeRejectsUnknownVersion + tool_calls at the boundary.
 func TestMergeRejectsBoundary(t *testing.T) {
 	_, priv := keypair(t)

--- a/internal/capsule/merge_test.go
+++ b/internal/capsule/merge_test.go
@@ -1,0 +1,309 @@
+package capsule
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func msg(turn int, role, content, agent string) Message {
+	return Message{Role: role, Content: content, XRoger: XRoger{Turn: turn, Agent: agent, TS: int64(turn)}}
+}
+
+// signed builds a signed capsule with the given watermark + messages under priv.
+func signed(t *testing.T, priv ed25519.PrivateKey, watermark int, msgs ...Message) Capsule {
+	t.Helper()
+	c := Capsule{
+		Capsule:  Version,
+		ID:       "cap",
+		Thread:   Thread{OriginThreadID: "t1", Title: "T", BaseWatermark: watermark},
+		Messages: msgs,
+		Meta:     Meta{ToolsUsed: []string{}},
+	}
+	c.Sign(priv)
+	return c
+}
+
+func turns(c Capsule) []int {
+	var out []int
+	for _, m := range c.Messages {
+		out = append(out, m.XRoger.Turn)
+	}
+	return out
+}
+
+func eqInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestMergeIntoEmptyReproducesTranscript: merging a full capsule into an empty thread
+// yields every turn in order (the golden turn 0 is NOT dropped by the watermark).
+func TestMergeIntoEmptyReproducesTranscript(t *testing.T) {
+	_, priv := keypair(t)
+	incoming := signed(t, priv, 3, msg(0, "user", "hi", "user"), msg(1, "assistant", "yo", "roger:m"), msg(2, "user", "more", "user"))
+	empty := Capsule{Capsule: Version, Thread: Thread{BaseWatermark: 0}}
+	out, err := Merge(incoming, empty)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if !eqInts(turns(out), []int{0, 1, 2}) {
+		t.Errorf("turns = %v, want [0 1 2]", turns(out))
+	}
+	if out.Thread.BaseWatermark != 3 {
+		t.Errorf("watermark = %d, want 3", out.Thread.BaseWatermark)
+	}
+	if out.Sig != "" {
+		t.Error("merged capsule must clear Sig (re-sign on export)")
+	}
+}
+
+// TestMergeAppendOnlyWatermark: only turns at/after into's watermark are appended, and a
+// backdated turn below the watermark that into does not have is NOT inserted (append-only).
+func TestMergeAppendOnlyWatermark(t *testing.T) {
+	_, priv := keypair(t)
+	into := signed(t, priv, 2, msg(0, "user", "a", "user"), msg(1, "assistant", "b", "roger:m"))
+	// incoming has the DJ's 0,1 plus new 2,3 (guest turns) and a sneaky backdated -1.
+	incoming := signed(t, priv, 2,
+		msg(-1, "system", "backdated", "user"),
+		msg(0, "user", "a", "user"),
+		msg(1, "assistant", "b", "roger:m"),
+		msg(2, "user", "c", "opencode"),
+		msg(3, "assistant", "d", "opencode"),
+	)
+	out, err := Merge(incoming, into)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if !eqInts(turns(out), []int{0, 1, 2, 3}) {
+		t.Errorf("turns = %v, want [0 1 2 3] (backdated -1 rejected, 2/3 appended)", turns(out))
+	}
+	if out.Thread.BaseWatermark != 4 {
+		t.Errorf("watermark = %d, want 4", out.Thread.BaseWatermark)
+	}
+}
+
+// TestMergeDoubleDedups: merging the same capsule twice is idempotent.
+func TestMergeDoubleDedups(t *testing.T) {
+	_, priv := keypair(t)
+	into := signed(t, priv, 0)
+	incoming := signed(t, priv, 3, msg(0, "user", "a", "user"), msg(1, "assistant", "b", "roger:m"), msg(2, "user", "c", "opencode"))
+	once, err := Merge(incoming, into)
+	if err != nil {
+		t.Fatalf("first Merge: %v", err)
+	}
+	twice, err := Merge(incoming, once)
+	if err != nil {
+		t.Fatalf("second Merge: %v", err)
+	}
+	if !eqInts(turns(twice), []int{0, 1, 2}) {
+		t.Errorf("double-merge turns = %v, want [0 1 2]", turns(twice))
+	}
+}
+
+// TestMergeDedupsWithinIncoming: an incoming capsule that repeats the SAME turn (same
+// index + content) at/after the watermark appends it once (intra-set dedup).
+func TestMergeDedupsWithinIncoming(t *testing.T) {
+	_, priv := keypair(t)
+	into := Capsule{Capsule: Version, Thread: Thread{BaseWatermark: 0}}
+	incoming := signed(t, priv, 2,
+		msg(0, "user", "a", "user"),
+		msg(0, "user", "a", "user"), // exact duplicate of turn 0
+		msg(1, "assistant", "b", "roger:m"),
+	)
+	out, err := Merge(incoming, into)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if !eqInts(turns(out), []int{0, 1}) {
+		t.Errorf("turns = %v, want [0 1] (duplicate turn 0 collapsed)", turns(out))
+	}
+}
+
+// TestMergeNeverTruncates: an incoming capsule with FEWER turns than into never shrinks it.
+func TestMergeNeverTruncates(t *testing.T) {
+	_, priv := keypair(t)
+	into := signed(t, priv, 3, msg(0, "user", "a", "user"), msg(1, "assistant", "b", "roger:m"), msg(2, "user", "c", "user"))
+	incoming := signed(t, priv, 1, msg(0, "user", "a", "user")) // only the first turn
+	out, err := Merge(incoming, into)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if !eqInts(turns(out), []int{0, 1, 2}) {
+		t.Errorf("turns = %v, want [0 1 2] (never truncated)", turns(out))
+	}
+}
+
+// TestMergeRejectsUnverified: a capsule whose sig does not verify is rejected and into is
+// left unchanged.
+func TestMergeRejectsUnverified(t *testing.T) {
+	_, priv := keypair(t)
+	into := signed(t, priv, 1, msg(0, "user", "a", "user"))
+	incoming := signed(t, priv, 2, msg(0, "user", "a", "user"), msg(1, "assistant", "TAMPERED", "roger:m"))
+	incoming.Messages[1].Content = "evil" // break the sig without re-signing
+	out, err := Merge(incoming, into)
+	if !errors.Is(err, ErrUnverified) {
+		t.Errorf("err = %v, want ErrUnverified", err)
+	}
+	if !eqInts(turns(out), []int{0}) {
+		t.Errorf("into must be unchanged on reject, got %v", turns(out))
+	}
+}
+
+// TestMergeRejectsForkedTurn: an incoming turn that collides with a present turn index but
+// carries different content rejects the WHOLE capsule (ruling Q2); into is unchanged.
+func TestMergeRejectsForkedTurn(t *testing.T) {
+	_, priv := keypair(t)
+	into := signed(t, priv, 2, msg(0, "user", "a", "user"), msg(1, "assistant", "b", "roger:m"))
+	incoming := signed(t, priv, 2,
+		msg(0, "user", "a", "user"),
+		msg(1, "assistant", "FORKED", "roger:m"), // same turn 1, different content
+		msg(2, "user", "c", "opencode"),          // a valid new turn that must NOT land
+	)
+	out, err := Merge(incoming, into)
+	if !errors.Is(err, ErrForkedTurn) {
+		t.Errorf("err = %v, want ErrForkedTurn", err)
+	}
+	if !eqInts(turns(out), []int{0, 1}) {
+		t.Errorf("into must be unchanged on fork-reject, got %v", turns(out))
+	}
+}
+
+// TestMergeRejectsUnknownVersion + tool_calls at the boundary.
+func TestMergeRejectsBoundary(t *testing.T) {
+	_, priv := keypair(t)
+	into := signed(t, priv, 0)
+
+	badVer := signed(t, priv, 1, msg(0, "user", "a", "user"))
+	badVer.Capsule = "roger.context.v2"
+	badVer.Sign(priv) // re-sign so it is a VALID sig of an UNKNOWN version
+	if _, err := Merge(badVer, into); !errors.Is(err, ErrUnknownVersion) {
+		t.Errorf("unknown version: err = %v, want ErrUnknownVersion", err)
+	}
+
+	withTools := signed(t, priv, 0)
+	withTools.Messages = []Message{{Role: "assistant", Content: "c", ToolCalls: json.RawMessage(`[{"id":"1"}]`), XRoger: XRoger{Turn: 0, Agent: "roger:m", TS: 1}}}
+	withTools.Thread.BaseWatermark = 1
+	withTools.Sign(priv)
+	if _, err := Merge(withTools, into); !errors.Is(err, ErrToolCalls) {
+		t.Errorf("tool_calls: err = %v, want ErrToolCalls", err)
+	}
+}
+
+// TestExportRoundtrip: Export -> Marshal -> Import reproduces a verifying capsule, stamps
+// the producer meta, and Merge into an empty thread reproduces the transcript.
+func TestExportRoundtrip(t *testing.T) {
+	_, priv := keypair(t)
+	d := Draft{
+		ID:       "cap_e",
+		Thread:   Thread{OriginThreadID: "t1", Title: "T", BaseWatermark: 2},
+		Summary:  Summary{Text: "s", ProducedBy: "none", AsOfTurn: 1},
+		Messages: []Message{msg(0, "user", "hi", "user"), msg(1, "assistant", "yo", "roger:m")},
+	}
+	c, err := Export(d, priv, "roger-cli", func() int64 { return 100 })
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if c.Meta.ExportedBy != "roger-cli" || c.Meta.CreatedAt != 100 || c.Meta.OwnerPubkey == "" {
+		t.Errorf("Export meta not stamped: %+v", c.Meta)
+	}
+	if !c.Verify() {
+		t.Fatal("exported capsule must verify")
+	}
+	raw, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	imported, err := Import(raw)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	out, err := Merge(imported, Capsule{Capsule: Version})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if !eqInts(turns(out), []int{0, 1}) {
+		t.Errorf("round-trip turns = %v, want [0 1]", turns(out))
+	}
+}
+
+// TestExportRejectsToolCalls: Export refuses a draft carrying tool_calls (ruling Q1) so a
+// capsule that crosses the boundary can never contain them.
+func TestExportRejectsToolCalls(t *testing.T) {
+	_, priv := keypair(t)
+	d := Draft{ID: "cap_t", Messages: []Message{{Role: "assistant", Content: "c", ToolCalls: json.RawMessage(`[{"id":"1"}]`), XRoger: XRoger{Turn: 0, Agent: "roger:m"}}}}
+	if _, err := Export(d, priv, "roger-cli", nil); !errors.Is(err, ErrToolCalls) {
+		t.Errorf("err = %v, want ErrToolCalls", err)
+	}
+}
+
+// TestExportUsesTimeNowWhenNil: Export with a nil now stamps a real (non-zero) created_at.
+func TestExportUsesTimeNowWhenNil(t *testing.T) {
+	_, priv := keypair(t)
+	c, err := Export(Draft{ID: "cap_n"}, priv, "roger-cli", nil)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if c.Meta.CreatedAt == 0 {
+		t.Error("nil now must stamp a real created_at")
+	}
+}
+
+// TestImportErrors: malformed JSON, unknown version, tool_calls, and a bad signature are
+// each rejected by Import.
+func TestImportErrors(t *testing.T) {
+	_, priv := keypair(t)
+	good, _ := Export(Draft{ID: "cap_i", Thread: Thread{BaseWatermark: 1}, Messages: []Message{msg(0, "user", "hi", "user")}}, priv, "roger-cli", func() int64 { return 1 })
+	goodRaw, _ := good.Marshal()
+
+	if _, err := Import([]byte("{not json")); err == nil {
+		t.Error("malformed JSON must be rejected")
+	}
+
+	var badVer Capsule
+	_ = json.Unmarshal(goodRaw, &badVer)
+	badVer.Capsule = "vX"
+	raw, _ := json.Marshal(badVer)
+	if _, err := Import(raw); !errors.Is(err, ErrUnknownVersion) {
+		t.Errorf("err = %v, want ErrUnknownVersion", err)
+	}
+
+	var tampered Capsule
+	_ = json.Unmarshal(goodRaw, &tampered)
+	tampered.Messages[0].Content = "evil"
+	raw2, _ := json.Marshal(tampered)
+	if _, err := Import(raw2); !errors.Is(err, ErrUnverified) {
+		t.Errorf("err = %v, want ErrUnverified", err)
+	}
+}
+
+// TestSummaryOnly: drops memory, sets redaction=summary, keeps only the current (last)
+// turn; and is a no-op on an empty message set (no panic).
+func TestSummaryOnly(t *testing.T) {
+	d := Draft{
+		Redaction: "full",
+		Memory:    Memory{Notes: "secret", Facts: []string{"x"}},
+		Messages:  []Message{msg(0, "user", "old", "user"), msg(1, "assistant", "mid", "roger:m"), msg(2, "user", "current", "user")},
+	}
+	got := SummaryOnly(d)
+	if got.Redaction != "summary" {
+		t.Errorf("redaction = %q, want summary", got.Redaction)
+	}
+	if got.Memory.Notes != "" || len(got.Memory.Facts) != 0 {
+		t.Errorf("memory must be dropped, got %+v", got.Memory)
+	}
+	if len(got.Messages) != 1 || got.Messages[0].Content != "current" {
+		t.Errorf("must keep only the current turn, got %+v", got.Messages)
+	}
+	if n := len(SummaryOnly(Draft{}).Messages); n != 0 {
+		t.Errorf("empty draft must stay empty, got %d messages", n)
+	}
+}

--- a/internal/tui/context_capsule.go
+++ b/internal/tui/context_capsule.go
@@ -1,0 +1,176 @@
+package tui
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/capsule"
+	"github.com/rogerai-fyi/roger/internal/client"
+)
+
+// context_capsule.go is the TUI side of roger.context.v1: a MINIMAL per-turn ring (ruling
+// Q4) that records each completed turn so a conversation can be EXPORTED into a signed,
+// portable capsule on an operator handoff, and a returning capsule MERGED back append-only
+// on recall. The flat transcript/agentLines slices stay the render source (no render
+// rewrite); this ring exists only to feed export/merge.
+//
+// Stage 1 handoff is SAME-OWNER / LOCAL only: the capsule is written to a file the local
+// guest process can read, and its return capsule is merged back. The encrypted broker
+// transport for a MARKETPLACE/STRANGER guest is a follow-on (ruling Q3); a stranger export
+// is summary-only by default (redaction invariant) and gated here with a clear message.
+
+// contextRingCap bounds the per-turn ring: the capsule carries at most the most recent N
+// completed turns (older turns age out, but their turn INDEX is preserved so a later merge
+// still dedups correctly).
+const contextRingCap = 400
+
+// handoffCapsuleFile / recallCapsuleFile are the local same-owner rendezvous under the
+// guest's workdir: the DJ writes the outbound context, the guest writes its return.
+const (
+	handoffDir         = ".roger"
+	handoffCapsuleFile = "context.rcap.json"
+	recallCapsuleFile  = "return.rcap.json"
+)
+
+// recordTurn appends one completed turn to the per-turn ring (Q4), assigning the next
+// sequential turn index. mdl/provider are pointers so an unknown value carries as a literal
+// null in the capsule (distinct from an empty string). It is a no-op for an empty
+// role+content. The ring is bounded to contextRingCap (oldest ages out).
+func (m *model) recordTurn(role, content, agent string, mdl, provider *string) {
+	if role == "" && content == "" {
+		return
+	}
+	msg := capsule.Message{Role: role, Content: content, XRoger: capsule.XRoger{
+		Turn: m.ringTurn, Agent: agent, Model: mdl, Provider: provider, TS: time.Now().Unix(),
+	}}
+	m.ringTurn++
+	m.ring = append(m.ring, msg)
+	if len(m.ring) > contextRingCap {
+		m.ring = m.ring[len(m.ring)-contextRingCap:]
+	}
+}
+
+// contextThreadID returns this session's stable origin thread id, minting one on first use.
+func (m *model) contextThreadID() string {
+	if m.threadID == "" {
+		m.threadID = "th_" + randHex(8)
+	}
+	return m.threadID
+}
+
+// exportContextCapsule builds a signed roger.context.v1 capsule from the ring using the
+// operator's EXISTING identity (client.LoadOrCreateUserKey - no new key is minted). When
+// summaryOnly is set (the STRANGER default), the capsule carries only the summary + the
+// current turn, no full transcript or memory (redaction invariant).
+func (m *model) exportContextCapsule(summaryOnly bool) (capsule.Capsule, error) {
+	title := ""
+	if m.connected != nil {
+		title = m.connected.Model
+	}
+	d := capsule.Draft{
+		ID:        "cap_" + randHex(8),
+		Thread:    capsule.Thread{OriginThreadID: m.contextThreadID(), Title: title, BaseWatermark: m.ringTurn},
+		Redaction: "full",
+		Messages:  append([]capsule.Message(nil), m.ring...),
+	}
+	if summaryOnly {
+		d = capsule.SummaryOnly(d)
+	}
+	return capsule.Export(d, client.LoadOrCreateUserKey(), "roger-cli", nil)
+}
+
+// mergeReturnCapsule verifies a returning capsule and append-only merges its turns into the
+// ring (never truncate/replace). It returns the number of NEW turns added.
+func (m *model) mergeReturnCapsule(raw []byte) (int, error) {
+	incoming, err := capsule.Import(raw)
+	if err != nil {
+		return 0, err
+	}
+	base := capsule.Capsule{Capsule: capsule.Version, Thread: capsule.Thread{BaseWatermark: m.ringTurn}, Messages: m.ring}
+	merged, err := capsule.Merge(incoming, base)
+	if err != nil {
+		return 0, err
+	}
+	added := len(merged.Messages) - len(m.ring)
+	m.ring = merged.Messages
+	m.ringTurn = merged.Thread.BaseWatermark
+	return added, nil
+}
+
+// writeHandoffCapsule exports the current conversation and writes it under the guest's
+// workdir so a SAME-OWNER local guest can import it (the reference the guest reads, not
+// bytes inline on a frame). Best-effort: it returns the path written, or an error the
+// caller narrates without aborting the handoff. An empty ring writes nothing.
+func (m *model) writeHandoffCapsule(workdir string) (string, error) {
+	if len(m.ring) == 0 {
+		return "", nil
+	}
+	c, err := m.exportContextCapsule(false) // same-owner local guest gets the full transcript
+	if err != nil {
+		return "", err
+	}
+	raw, err := c.Marshal()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(workdir, handoffDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, handoffCapsuleFile)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// readRecallCapsule merges a guest's return capsule (if it left one under the workdir) back
+// into the ring append-only. It returns the number of turns added (0 when no return file
+// exists - the common case), or an error the caller narrates. A missing file is not an
+// error.
+func (m *model) readRecallCapsule(workdir string) (int, error) {
+	path := filepath.Join(workdir, handoffDir, recallCapsuleFile)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return m.mergeReturnCapsule(raw)
+}
+
+// channelAgent is the x_roger.agent for a CHANNEL assistant turn: "roger:<model>" when a
+// band is tuned, else "roger".
+func (m *model) channelAgent() string {
+	if m.connected != nil && m.connected.Model != "" {
+		return "roger:" + m.connected.Model
+	}
+	return "roger"
+}
+
+// channelModelProvider returns the model + provider pointers for a CHANNEL assistant turn:
+// the tuned band's public model (nil if none) and the broker-reported provider (nil if
+// empty). Nil pointers become a literal null in the capsule (distinct from "").
+func (m *model) channelModelProvider(provider string) (mdl, prov *string) {
+	if m.connected != nil && m.connected.Model != "" {
+		mm := m.connected.Model
+		mdl = &mm
+	}
+	if provider != "" {
+		pp := provider
+		prov = &pp
+	}
+	return mdl, prov
+}
+
+// randHex returns n random bytes hex-encoded (2n chars). Used for opaque capsule/thread
+// ids; rand.Read from crypto/rand does not fail in practice, and a short id is cosmetic.
+func randHex(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/tui/context_capsule_bdd_test.go
+++ b/internal/tui/context_capsule_bdd_test.go
@@ -1,0 +1,178 @@
+package tui
+
+// context_capsule_bdd_test.go wires godog for features/capsule/handoff.feature: it drives
+// the per-turn ring + export/merge model methods over REAL ed25519 (the operator key,
+// isolated to a throwaway XDG_CONFIG_HOME), mirroring the proven BDD pattern.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/capsule"
+	"github.com/rogerai-fyi/roger/internal/client"
+)
+
+type handoffBDD struct {
+	m         model
+	workdir   string
+	exported  capsule.Capsule
+	exportErr error
+	recall    int
+}
+
+func (s *handoffBDD) freshSession() error {
+	s.m = model{connected: &offer{Model: "test-model"}}
+	s.workdir = ""
+	return nil
+}
+
+// userSaysStationReplies records a user turn then an assistant turn, mirroring the two
+// CHANNEL feed points (the send path + the chatMsg handler).
+func (s *handoffBDD) userSaysStationReplies(user, reply string) error {
+	s.m.recordTurn("user", user, "user", nil, nil)
+	mdl, prov := s.m.channelModelProvider("test-provider")
+	s.m.recordTurn("assistant", reply, s.m.channelAgent(), mdl, prov)
+	return nil
+}
+
+func (s *handoffBDD) ringHasTurns(n int) error {
+	if len(s.m.ring) != n {
+		return hbErr(fmt.Sprintf("ring has %d turns, want %d", len(s.m.ring), n))
+	}
+	return nil
+}
+func (s *handoffBDD) ringTurnIndexes(csv string) error {
+	var got []string
+	for _, msg := range s.m.ring {
+		got = append(got, strconv.Itoa(msg.XRoger.Turn))
+	}
+	if j := strings.Join(got, ","); j != csv {
+		return hbErr("ring indexes = " + j + ", want " + csv)
+	}
+	return nil
+}
+
+func (s *handoffBDD) exportCapsule() error {
+	s.exported, s.exportErr = s.m.exportContextCapsule(false)
+	return s.exportErr
+}
+func (s *handoffBDD) exportCapsuleStranger() error {
+	s.exported, s.exportErr = s.m.exportContextCapsule(true)
+	return s.exportErr
+}
+func (s *handoffBDD) exportedVerifies() error {
+	if !s.exported.Verify() {
+		return hbErr("exported capsule must verify")
+	}
+	return nil
+}
+func (s *handoffBDD) exportedHasTurns(n int) error {
+	if len(s.exported.Messages) != n {
+		return hbErr(fmt.Sprintf("exported has %d turns, want %d", len(s.exported.Messages), n))
+	}
+	return nil
+}
+func (s *handoffBDD) exportedOwnerIsOperator() error {
+	if s.exported.Meta.OwnerPubkey != client.UserPubHex() {
+		return hbErr("exported owner is not the operator key")
+	}
+	return nil
+}
+func (s *handoffBDD) exportedRedaction(v string) error {
+	if s.exported.Redaction != v {
+		return hbErr("redaction = " + s.exported.Redaction + ", want " + v)
+	}
+	return nil
+}
+
+func (s *handoffBDD) writeHandoff() error {
+	s.workdir = handoffTestDir()
+	_, err := s.m.writeHandoffCapsule(s.workdir)
+	return err
+}
+
+// guestAppendsReturnCapsule simulates the guest: it imports the handoff capsule, appends a
+// turn signed with the SAME owner key (a same-owner local guest), and leaves a return file.
+func (s *handoffBDD) guestAppendsReturnCapsule() error {
+	raw, err := os.ReadFile(filepath.Join(s.workdir, handoffDir, handoffCapsuleFile))
+	if err != nil {
+		return err
+	}
+	base, err := capsule.Import(raw)
+	if err != nil {
+		return err
+	}
+	base.Messages = append(base.Messages, capsule.Message{Role: "assistant", Content: "guest turn", XRoger: capsule.XRoger{Turn: base.Thread.BaseWatermark, Agent: "opencode", TS: 9}})
+	base.Thread.BaseWatermark++
+	base.Meta.ExportedBy = "opencode"
+	base.Sign(client.LoadOrCreateUserKey())
+	out, _ := base.Marshal()
+	return os.WriteFile(filepath.Join(s.workdir, handoffDir, recallCapsuleFile), out, 0o600)
+}
+func (s *handoffBDD) djReadsReturn() error {
+	s.recall, s.exportErr = s.m.readRecallCapsule(s.workdir)
+	return s.exportErr
+}
+func (s *handoffBDD) djReadsEmptyWorkdir() error {
+	s.recall, s.exportErr = s.m.readRecallCapsule(handoffTestDir())
+	return s.exportErr
+}
+func (s *handoffBDD) recallAdded(n int) error {
+	if s.recall != n {
+		return hbErr(fmt.Sprintf("recall added %d turns, want %d", s.recall, n))
+	}
+	return nil
+}
+
+type handoffBDDErr string
+
+func (e handoffBDDErr) Error() string { return string(e) }
+func hbErr(s string) error            { return handoffBDDErr(s) }
+
+var handoffTestDirFn func() string
+
+func handoffTestDir() string { return handoffTestDirFn() }
+
+func TestHandoffBDD(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // isolate the operator key
+	handoffTestDirFn = t.TempDir
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			st := &handoffBDD{}
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				*st = handoffBDD{}
+				return ctx, nil
+			})
+			sc.Step(`^a fresh session$`, st.freshSession)
+			sc.Step(`^the user says "([^"]*)" and the station replies "([^"]*)"$`, st.userSaysStationReplies)
+			sc.Step(`^the ring has (\d+) turns$`, st.ringHasTurns)
+			sc.Step(`^the ring turn indexes are "([^"]*)"$`, st.ringTurnIndexes)
+			sc.Step(`^I export the context capsule$`, st.exportCapsule)
+			sc.Step(`^I export the context capsule for a stranger$`, st.exportCapsuleStranger)
+			sc.Step(`^the exported capsule verifies$`, st.exportedVerifies)
+			sc.Step(`^the exported capsule has (\d+) turns$`, st.exportedHasTurns)
+			sc.Step(`^the exported capsule owner is the operator key$`, st.exportedOwnerIsOperator)
+			sc.Step(`^the exported capsule redaction is "([^"]*)"$`, st.exportedRedaction)
+			sc.Step(`^I write the handoff capsule to the guest workdir$`, st.writeHandoff)
+			sc.Step(`^the guest appends a turn and leaves a return capsule$`, st.guestAppendsReturnCapsule)
+			sc.Step(`^the DJ reads the return capsule$`, st.djReadsReturn)
+			sc.Step(`^the DJ reads the return capsule from an empty workdir$`, st.djReadsEmptyWorkdir)
+			sc.Step(`^the recall added (\d+) turns$`, st.recallAdded)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/capsule/handoff.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("handoff behavior scenarios failed (see godog output above)")
+	}
+}

--- a/internal/tui/context_capsule_test.go
+++ b/internal/tui/context_capsule_test.go
@@ -1,0 +1,214 @@
+package tui
+
+import (
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rogerai-fyi/roger/internal/capsule"
+	"github.com/rogerai-fyi/roger/internal/client"
+)
+
+// capsuleForkFixture is a signed return capsule that rewrites turn 0 with different content
+// (a fork), for the append-only rejection path. It is signed by an ephemeral key so the
+// signature verifies and Merge reaches the fork check.
+func capsuleForkFixture(t *testing.T) []byte {
+	t.Helper()
+	_, priv, _ := ed25519.GenerateKey(nil)
+	c := capsule.Capsule{
+		Capsule:  capsule.Version,
+		Thread:   capsule.Thread{BaseWatermark: 1},
+		Messages: []capsule.Message{{Role: "user", Content: "DIFFERENT", XRoger: capsule.XRoger{Turn: 0, Agent: "user", TS: 1}}},
+	}
+	c.Sign(priv)
+	raw, _ := c.Marshal()
+	return raw
+}
+
+// TestRecordTurnBoundedAndSkipsEmpty: empty turns are skipped; the ring is bounded to
+// contextRingCap with monotonically increasing turn indexes preserved.
+func TestRecordTurnBoundedAndSkipsEmpty(t *testing.T) {
+	var m model
+	m.recordTurn("", "", "user", nil, nil) // no-op
+	if len(m.ring) != 0 || m.ringTurn != 0 {
+		t.Fatal("empty turn must be a no-op")
+	}
+	for i := 0; i < contextRingCap+50; i++ {
+		m.recordTurn("user", "t", "user", nil, nil)
+	}
+	if len(m.ring) != contextRingCap {
+		t.Errorf("ring len = %d, want %d (bounded)", len(m.ring), contextRingCap)
+	}
+	if m.ringTurn != contextRingCap+50 {
+		t.Errorf("ringTurn = %d, want %d (index preserved past the cap)", m.ringTurn, contextRingCap+50)
+	}
+	// The oldest turn aged out; the first retained turn's index is (total - cap).
+	if got := m.ring[0].XRoger.Turn; got != 50 {
+		t.Errorf("oldest retained turn index = %d, want 50", got)
+	}
+}
+
+// TestChannelProvenance: channelAgent + channelModelProvider reflect the tuned band, and
+// carry nil pointers (null in the capsule) when unknown.
+func TestChannelProvenance(t *testing.T) {
+	var m model
+	if m.channelAgent() != "roger" {
+		t.Error("untuned agent must be 'roger'")
+	}
+	if mdl, prov := m.channelModelProvider(""); mdl != nil || prov != nil {
+		t.Error("untuned + no provider must be nil pointers")
+	}
+	m.connected = &offer{Model: "m1"}
+	if m.channelAgent() != "roger:m1" {
+		t.Errorf("tuned agent = %q, want roger:m1", m.channelAgent())
+	}
+	mdl, prov := m.channelModelProvider("openai")
+	if mdl == nil || *mdl != "m1" || prov == nil || *prov != "openai" {
+		t.Errorf("model/provider = %v/%v, want m1/openai", mdl, prov)
+	}
+}
+
+// TestContextThreadIDStable: the thread id is minted once and stays stable.
+func TestContextThreadIDStable(t *testing.T) {
+	var m model
+	a := m.contextThreadID()
+	if a == "" || a != m.contextThreadID() {
+		t.Error("thread id must be non-empty and stable")
+	}
+}
+
+// TestWriteHandoffEmptyRingNoFile: an empty ring writes no capsule (nothing to hand off).
+func TestWriteHandoffEmptyRingNoFile(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	var m model
+	dir := t.TempDir()
+	path, err := m.writeHandoffCapsule(dir)
+	if err != nil || path != "" {
+		t.Errorf("empty ring: path=%q err=%v, want no file", path, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, handoffDir)); !os.IsNotExist(err) {
+		t.Error("empty ring must not create the handoff dir")
+	}
+}
+
+// TestWriteHandoffMkdirError: an unwritable workdir surfaces an error (best-effort caller
+// narrates it).
+func TestWriteHandoffMkdirError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	var m model
+	m.recordTurn("user", "hi", "user", nil, nil)
+	// A regular file as the "workdir" makes MkdirAll(<file>/.roger) fail.
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	_ = os.WriteFile(f, []byte("x"), 0o600)
+	if _, err := m.writeHandoffCapsule(f); err == nil {
+		t.Error("mkdir under a file must error")
+	}
+}
+
+// TestReadRecallErrors: a missing file is a clean 0; a malformed return capsule errors.
+func TestReadRecallErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	var m model
+	dir := t.TempDir()
+	if n, err := m.readRecallCapsule(dir); n != 0 || err != nil {
+		t.Errorf("missing return: n=%d err=%v, want 0/nil", n, err)
+	}
+	rdir := filepath.Join(dir, handoffDir)
+	_ = os.MkdirAll(rdir, 0o700)
+	_ = os.WriteFile(filepath.Join(rdir, recallCapsuleFile), []byte("{bad"), 0o600)
+	if _, err := m.readRecallCapsule(dir); err == nil {
+		t.Error("malformed return capsule must error")
+	}
+}
+
+// TestRandHex: returns 2n hex chars.
+func TestRandHex(t *testing.T) {
+	if got := randHex(8); len(got) != 16 {
+		t.Errorf("randHex(8) len = %d, want 16", len(got))
+	}
+}
+
+// TestMergeReturnForked: a return capsule that forks an existing turn is rejected.
+func TestMergeReturnForked(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	var m model
+	m.recordTurn("user", "hi", "user", nil, nil) // ring: turn 0 = user/hi
+	// Build a signed return capsule that rewrites turn 0 with different content.
+	fork := capsuleForkFixture(t)
+	if _, err := m.mergeReturnCapsule(fork); err == nil {
+		t.Error("forked return capsule must be rejected")
+	}
+}
+
+// TestWriteHandoffWriteFileError: a pre-existing directory at the capsule path makes the
+// WriteFile fail after the dir is created.
+func TestWriteHandoffWriteFileError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	var m model
+	m.recordTurn("user", "hi", "user", nil, nil)
+	wd := t.TempDir()
+	blocking := filepath.Join(wd, handoffDir, handoffCapsuleFile)
+	_ = os.MkdirAll(blocking, 0o700) // the capsule path is a directory -> WriteFile errors
+	if _, err := m.writeHandoffCapsule(wd); err == nil {
+		t.Error("WriteFile onto a directory must error")
+	}
+}
+
+// TestReadRecallReadError: a directory at the return path yields a non-NotExist read error.
+func TestReadRecallReadError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	var m model
+	wd := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(wd, handoffDir, recallCapsuleFile), 0o700)
+	if _, err := m.readRecallCapsule(wd); err == nil {
+		t.Error("reading a directory as the return file must error")
+	}
+}
+
+// TestOperatorHandoffCarriesCapsuleE2E drives a real local handoff through onOperatorExec /
+// onOperatorDone and proves the conversation is carried: onOperatorExec writes the signed
+// handoff capsule to the guest workdir, and onOperatorDone merges the guest's return
+// capsule back into the ring append-only. This is the "live E2E" for Task B.
+func TestOperatorHandoffCarriesCapsuleE2E(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	wd := t.TempDir()
+	saveWd := operatorWorkdir
+	operatorWorkdir = func() string { return wd }
+	t.Cleanup(func() { operatorWorkdir = saveWd })
+
+	m, _, _ := opRegressionSeed(t)
+	m.recordTurn("user", "hello", "user", nil, nil)
+	m.recordTurn("assistant", "hi there", "roger:m", nil, nil)
+
+	var tm tea.Model = m
+	tm, _ = tm.(model).runAgentCommand("/operator opencode")
+	tm, _ = tm.Update(keyMsg("y")) // accept the plate -> staged
+	tm, _ = tm.Update(operatorExecMsg{})
+
+	// onOperatorExec wrote the handoff capsule for the guest.
+	handoffPath := filepath.Join(wd, handoffDir, handoffCapsuleFile)
+	raw, err := os.ReadFile(handoffPath)
+	if err != nil {
+		t.Fatalf("handoff capsule not written: %v", err)
+	}
+	c, err := capsule.Import(raw)
+	if err != nil || !c.Verify() || len(c.Messages) != 2 {
+		t.Fatalf("handoff capsule bad: err=%v turns=%d", err, len(c.Messages))
+	}
+
+	// The guest appends a turn and leaves a return capsule (same-owner: signed with the
+	// operator key, which the sandboxed user.key is).
+	c.Messages = append(c.Messages, capsule.Message{Role: "assistant", Content: "guest work", XRoger: capsule.XRoger{Turn: c.Thread.BaseWatermark, Agent: "opencode", TS: 9}})
+	c.Thread.BaseWatermark++
+	c.Sign(client.LoadOrCreateUserKey())
+	retRaw, _ := c.Marshal()
+	_ = os.WriteFile(filepath.Join(wd, handoffDir, recallCapsuleFile), retRaw, 0o600)
+
+	tm, _ = tm.Update(operatorDoneMsg{})
+	if got := len(tm.(model).ring); got != 3 {
+		t.Fatalf("after recall the ring has %d turns, want 3 (guest turn merged append-only)", got)
+	}
+}

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -907,6 +907,15 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 		m.rcEmit(client.OperatorStatusFrame(h.det.Guest.Name, opts.Model, m.proxyHolder.Spent()))
 		m.rcBridge.Park(h.det.Guest.Name, m.agentTranscriptText(), opts.Model, m.proxyHolder.Spent)
 	}
+	// Same-owner LOCAL handoff (Stage 1): drop the conversation as a signed roger.context
+	// capsule the guest can import from its workdir (a REFERENCE it reads, not bytes on a
+	// frame). Best-effort - a write failure narrates but never aborts the handoff. The
+	// encrypted stranger transport is a follow-on (ruling Q3).
+	if path, err := m.writeHandoffCapsule(wd); err != nil {
+		m.rcNote("context capsule not handed off: " + err.Error())
+	} else if path != "" {
+		m.rcNote(fmt.Sprintf("handed the conversation to %s · %d turns", h.det.Guest.Name, m.ringTurn))
+	}
 	c := operator.Command(launch, h.det.Path, sess.Workdir, os.Environ())
 	return m, operatorExec(c, func(err error) tea.Msg { return operatorDoneMsg{err: err} })
 }
@@ -933,6 +942,14 @@ func (m model) onOperatorDone(msg operatorDoneMsg) (tea.Model, tea.Cmd) {
 		m.rcEmitDJBack()
 	}
 	guest := h.det.Guest.Name
+	// Merge any return capsule the guest left under its workdir back into the context ring
+	// (append-only; a handoff never truncates the thread). Best-effort - a missing file is
+	// the common case (0 turns), a bad one narrates.
+	if n, err := m.readRecallCapsule(h.workdir); err != nil {
+		m.rcNote("return capsule not merged: " + err.Error())
+	} else if n > 0 {
+		m.rcNote(fmt.Sprintf("merged %d turns back from %s", n, guest))
+	}
 	// The defensive reset just wrote ESC[?2004l AFTER bubbletea's RestoreTerminal had
 	// re-enabled paste, so bracketed paste must be re-armed here or it stays dead for
 	// the rest of the radio session (iteration-1 finding #2). The radio always runs

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -32,6 +32,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-isatty"
 	"github.com/rogerai-fyi/roger/internal/agent"
+	"github.com/rogerai-fyi/roger/internal/capsule"
 	"github.com/rogerai-fyi/roger/internal/client"
 	"github.com/rogerai-fyi/roger/internal/detect"
 	"github.com/rogerai-fyi/roger/internal/glyphs"
@@ -664,6 +665,15 @@ type model struct {
 	// history.go.
 	chatHist   *inputHistory
 	transcript []string
+	// ring is the MINIMAL per-turn context ring (ruling Q4): one capsule.Message per
+	// completed turn (role/content/turn/model/provider/agent/ts), fed from the chatMsg
+	// before it is discarded. It is NOT a render source (the flat transcript stays that);
+	// it exists only to EXPORT a portable roger.context.v1 capsule on an operator handoff
+	// and MERGE a returning one append-only. ringTurn is the next turn index; threadID is
+	// the session's stable origin thread id. See context_capsule.go.
+	ring     []capsule.Message
+	ringTurn int
+	threadID string
 	// lastReply is the RAW (unstyled) text of the most recent station reply, kept so
 	// ctrl+y / `/copy` yank clean text to the clipboard (the transcript holds styled lines).
 	lastReply string
@@ -1456,6 +1466,11 @@ func (m model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.lastReply = msg.reply // raw text, for ctrl+y / /copy
 			reply = stLive.Render("◂ ") + reply
+			// Record the assistant turn into the per-turn context ring (Q4). The tuned
+			// band's model is public; the provider (if the broker reported one) rides the
+			// x_roger provenance. Only real content is recorded (a no-text turn is skipped).
+			mdl, prov := m.channelModelProvider(msg.provider)
+			m.recordTurn("assistant", msg.reply, m.channelAgent(), mdl, prov)
 		}
 		m.msgInFrom, m.msgInFrame = len(m.transcript), m.frame // mark this block for the settle-in
 		m.transcript = append(m.transcript, reply)
@@ -1866,6 +1881,10 @@ func (m model) onKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.relaying = true
 			m.relayStart = time.Now()
+			// Record the user turn into the per-turn context ring (Q4) before it is sent,
+			// so an operator handoff can carry the conversation. The flat transcript above
+			// stays the render source.
+			m.recordTurn("user", p, "user", nil, nil)
 			// Carry the user's explicit out-price cap for this model (0 -> the default
 			// consumer cap applies broker-side); keeps the in-channel chat bounded like use.
 			return m, sendChat(m.broker, m.user, m.connected.Model, turn, m.confidentialOnly, m.limits.resolve(m.connected.Model).MaxOut)


### PR DESCRIPTION
## capsule: roger.context.v1 - portable signed context (Stage 1)

**BUILD-AND-HOLD - please review, do not merge.** The encrypted stranger/marketplace transport is a deliberate follow-on (ruling Q3); Stage 1 is the capsule package + the `roger context` CLI + a SAME-OWNER / LOCAL operator handoff only.

Brings the iOS app's portable context capsule to the Go CLI/TUI so a conversation moves *with* an operator handoff. Spec-first TDD, RED -> GREEN.

### The load-bearing gate: golden byte-parity
`canonical()` is HAND-BUILT in a fixed field order (nil model/provider emit literal `null`, tool_calls only when present, strings via `json.Marshal` HTML-escaping). `TestGoldenVector` pins it against the brief's exact bytes for BOTH producers (`roger-cli` and `roger-ios`, differing only in `exported_by`), so an app-signed capsule verifies in Go and vice-versa. The Go bytes matched the brief's golden **exactly on the first GREEN**.

### Invariants
- **Append-only merge** - a returning capsule may only ADD turns (dedup by turn index + hash(role+content)); it never truncates or replaces the live thread.
- **Verify-first** - a capsule whose sig does not verify against `meta.owner_pubkey` is rejected before any merge. The sig covers the canonical bytes of every field incl `redaction`, so a stranger cannot flip a summary-only capsule to full and re-sign.
- **Summary-only for strangers** - the redacted export carries summary + current turn only (no full transcript, no memory); redaction is signed and honored, never silently upgraded.
- **Reuses the operator's existing ed25519 identity** (`client.LoadOrCreateUserKey`); NO new key material is minted.

### Founder rulings applied
- **Q1** tool_calls: rejected at the app<->CLI boundary (export refuses, import rejects); the canonical form is not yet pinned cross-language, so none may cross.
- **Q2** forked turn on merge: rejects the WHOLE capsule, target unchanged - across the target AND within the incoming set (a capsule that carries one turn index twice with different content is a rewrite too).
- **Q3** stranger encrypted broker transport: out of this PR (follow-on). Stage 1 stranger handoff is local / summary-only.
- **Q4** turn buffer: a MINIMAL per-turn ring captures role/content/turn/model/provider/agent/ts per completed turn (fed from the chatMsg before it is discarded); the flat transcript stays the render source (no TUI render rewrite).

### What ships
- `internal/capsule`: the roger.context.v1 model, hand-built `canonical()`, Sign/Verify, Export/Import, append-only Merge, summary-only redaction. **100% coverage.**
- `roger context export|import` (file / stdin-stdout, `--into` append-only merge).
- The per-turn ring + a same-owner/local operator handoff: `onOperatorExec` writes the signed capsule to the guest workdir; `onOperatorDone` merges the guest's return capsule back append-only, narrated via the existing RCKindStatus path.

### Tests (RED -> GREEN, real ed25519, no mocks)
- The golden vector (both producers) - RED (compile) then GREEN, byte-exact on first pass.
- Table tests: canonical field-order / escaping / null-not-omit / numbers / tool_calls present+absent; sign-verify roundtrip; the tamper matrix (each mutation fails verify, incl the stranger summary->full escalation); merge append-only / dedup / watermark / no-truncate / reject-unverified / reject-forked (incl intra-incoming) / unknown-version.
- godog specs: `features/capsule/{canonical,merge,security,cli,handoff}.feature`.
- A live E2E drives a real desk handoff and asserts the conversation is carried both ways.

### Gates
`make cover-gate` PASS: internal/capsule 100.0%, cmd/rogerai 92.1%, internal/tui 92.5%, module total 92.4%, every package >=90%. Pre-push `claude-audit` VERDICT=PASS (high, build pass).

### Acknowledged Stage-1 items (by design; not blockers)
- Merge verifies the sig against the capsule's OWN embedded `owner_pubkey`, not a bound operator key. Safe under the same-owner/local + append-only + fork-safe model; the owner-binding check lands with the encrypted stranger transport (Q3).
- The exported-capsule `summaryOnly=true` path is the stranger default; exercised by tests, wired for the Q3 follow-on.

### Merge block
Holding for founder review. The encrypted stranger transport (Q3) is the next stage.
