### PR TITLE
capsule: content-blind one-time-code transport for context handoff

### DIFF
--- a/cmd/rogerai-broker/capsule.go
+++ b/cmd/rogerai-broker/capsule.go
@@ -1,0 +1,143 @@
+package main
+
+// capsule.go is the CONTENT-BLIND one-time-code transport for context-capsule handoff (the app +
+// CLI cross-agent handoff, roger.context.v1). The CLIENT generates a one-time code, derives an
+// encryption key from it, encrypts the (already-redacted, signed) capsule, and stores ONLY the
+// ciphertext here keyed by sha256(code); it shares the code out-of-band. The receiver sends the
+// same sha256(code) to resolve, gets the ciphertext once, and decrypts with its own key(code).
+//
+// The broker never sees the code, the key, or the plaintext - it stores and returns an opaque,
+// expiring, one-time blob. Mirrors the RC link-code posture (rcAttach): the mint is signed (for
+// attribution / rate-limiting), the resolve is authed only by possession of the lookup, and any
+// miss/expired/garbage resolve returns the IDENTICAL 404 so there is no existence oracle. Like the
+// RC live hubs (not the durable roster), the store is per-instance + ephemeral; it is never
+// persisted to the DB.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+const (
+	capsuleTTL         = store.RCCodeTTL    // 10 minutes, the same attach window as an RC link code
+	capsuleMaxBlob     = 1 << 20            // 1 MB hard cap on the stored ciphertext
+	capsuleMaxEntries  = 10000              // bound the in-memory store so a flood of mints cannot grow it unbounded
+	capsuleReadLimit   = capsuleMaxBlob * 2 // base64 expands ~4/3, so allow a just-over-max blob to reach the 413 check
+	capsuleResolveRead = 1 << 14
+)
+
+type capsuleBlob struct {
+	blob    []byte
+	expires int64 // unix seconds
+}
+
+// capsuleStore is a bounded, TTL-swept, per-instance map of lookup-hash -> ciphertext. It holds
+// opaque bytes only (the broker cannot read them), and a blob is consumed on the first successful
+// resolve (one-time).
+type capsuleStore struct {
+	mu sync.Mutex
+	m  map[string]capsuleBlob
+}
+
+func newCapsuleStore() *capsuleStore { return &capsuleStore{m: map[string]capsuleBlob{}} }
+
+// put stores a blob under lookup with a fresh TTL. Returns false when the store is at capacity
+// (shed load rather than grow unbounded). Sweeps expired entries first so capacity self-heals.
+func (c *capsuleStore) put(lookup string, blob []byte, now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sweepLocked(now)
+	if _, exists := c.m[lookup]; !exists && len(c.m) >= capsuleMaxEntries {
+		return false
+	}
+	c.m[lookup] = capsuleBlob{blob: blob, expires: now.Add(capsuleTTL).Unix()}
+	return true
+}
+
+// take returns the blob and REMOVES it (one-time), or false for absent/expired. The work is the
+// same for every outcome so the caller can return a uniform error with no timing/existence oracle.
+func (c *capsuleStore) take(lookup string, now time.Time) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok := c.m[lookup]
+	if ok {
+		delete(c.m, lookup) // consumed whether live or expired: a resolve never leaves it behind
+		if now.Unix() < v.expires {
+			return v.blob, true
+		}
+	}
+	return nil, false
+}
+
+func (c *capsuleStore) sweepLocked(now time.Time) {
+	for k, v := range c.m {
+		if now.Unix() >= v.expires {
+			delete(c.m, k)
+		}
+	}
+}
+
+// capsuleMint handles POST /capsule: store an opaque encrypted blob keyed by the client-supplied
+// lookup (sha256 of the client's one-time code). Requires a VERIFIED signature (any device/owner
+// key) so a mint is attributable and rate-limitable - the plaintext/code/key never reach us.
+func (b *broker) capsuleMint(w http.ResponseWriter, r *http.Request) {
+	if !allow(w, r, http.MethodPost) {
+		return
+	}
+	body, _ := io.ReadAll(io.LimitReader(r.Body, capsuleReadLimit))
+	if _, authed, _ := b.identityOf(r, body); !authed {
+		jsonErr(w, http.StatusUnauthorized, "capsule mint requires a signed request")
+		return
+	}
+	var req struct {
+		Lookup string `json:"lookup"`
+		Blob   string `json:"blob"`
+	}
+	if json.Unmarshal(body, &req) != nil || req.Lookup == "" || req.Blob == "" {
+		jsonErr(w, http.StatusBadRequest, "lookup and blob required")
+		return
+	}
+	blob, err := base64.StdEncoding.DecodeString(req.Blob)
+	if err != nil {
+		jsonErr(w, http.StatusBadRequest, "blob is not base64")
+		return
+	}
+	if len(blob) == 0 || len(blob) > capsuleMaxBlob {
+		jsonErr(w, http.StatusRequestEntityTooLarge, "capsule blob too large")
+		return
+	}
+	now := time.Now()
+	if !b.capsules.put(req.Lookup, blob, now) {
+		jsonErr(w, http.StatusServiceUnavailable, "capsule store is full, retry shortly")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "expires": now.Add(capsuleTTL).Unix()})
+}
+
+// capsuleResolve handles POST /capsule/resolve: return the opaque blob ONCE (delete-on-read).
+// Possession of the lookup is the authorization (no signature). Every miss/expired/garbage returns
+// the IDENTICAL 404 so an attacker cannot probe which lookups exist.
+func (b *broker) capsuleResolve(w http.ResponseWriter, r *http.Request) {
+	if !allow(w, r, http.MethodPost) {
+		return
+	}
+	uniform := func() { writeJSON(w, http.StatusNotFound, map[string]any{"error": "no such capsule"}) }
+	body, _ := io.ReadAll(io.LimitReader(r.Body, capsuleResolveRead))
+	var req struct {
+		Lookup string `json:"lookup"`
+	}
+	_ = json.Unmarshal(body, &req)
+	// Always attempt the take (constant work), even for empty/garbage input.
+	blob, ok := b.capsules.take(req.Lookup, time.Now())
+	if !ok {
+		uniform()
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"blob": base64.StdEncoding.EncodeToString(blob)})
+}

--- a/cmd/rogerai-broker/capsule_test.go
+++ b/cmd/rogerai-broker/capsule_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// capsuleBroker builds a broker with an initialized capsule store (buildBroker wires b.capsules).
+func capsuleBroker(t *testing.T) *broker {
+	t.Helper()
+	_, priv, _ := ed25519.GenerateKey(nil)
+	return buildBroker(store.NewMem(), priv, 0.30, 100, time.Hour)
+}
+
+func capsuleMintReq(t *testing.T, b *broker, priv ed25519.PrivateKey, lookup string, blob []byte, sign bool) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"lookup": lookup, "blob": base64.StdEncoding.EncodeToString(blob)})
+	r := httptest.NewRequest(http.MethodPost, "/capsule", bytes.NewReader(body))
+	if sign {
+		signReq(r, priv, body)
+	}
+	w := httptest.NewRecorder()
+	b.capsuleMint(w, r)
+	return w
+}
+
+func capsuleResolveReq(t *testing.T, b *broker, lookup string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"lookup": lookup})
+	r := httptest.NewRequest(http.MethodPost, "/capsule/resolve", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	b.capsuleResolve(w, r)
+	return w
+}
+
+func TestCapsuleMintResolveRoundTrip(t *testing.T) {
+	b := capsuleBroker(t)
+	_, priv, _ := ed25519.GenerateKey(nil)
+	lookup := "abc123" // stands in for hex(sha256(code)); the broker treats it as opaque
+	blob := []byte("this-is-ciphertext-the-broker-cannot-read")
+
+	if w := capsuleMintReq(t, b, priv, lookup, blob, true); w.Code != http.StatusOK {
+		t.Fatalf("mint status %d: %s", w.Code, w.Body.String())
+	}
+
+	// resolve returns the exact blob once
+	w := capsuleResolveReq(t, b, lookup)
+	if w.Code != http.StatusOK {
+		t.Fatalf("resolve status %d: %s", w.Code, w.Body.String())
+	}
+	var out struct {
+		Blob string `json:"blob"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	got, _ := base64.StdEncoding.DecodeString(out.Blob)
+	if !bytes.Equal(got, blob) {
+		t.Fatalf("resolved blob = %q, want %q", got, blob)
+	}
+
+	// ONE-TIME: a second resolve of the same lookup is the uniform 404
+	w2 := capsuleResolveReq(t, b, lookup)
+	if w2.Code != http.StatusNotFound {
+		t.Errorf("second resolve status %d, want 404 (one-time, delete-on-read)", w2.Code)
+	}
+}
+
+func TestCapsuleResolveUniform404(t *testing.T) {
+	b := capsuleBroker(t)
+	miss := capsuleResolveReq(t, b, "does-not-exist")
+	empty := capsuleResolveReq(t, b, "")
+	// an unknown lookup and an empty lookup must produce the IDENTICAL response (no existence oracle)
+	if miss.Code != http.StatusNotFound || empty.Code != http.StatusNotFound {
+		t.Fatalf("miss=%d empty=%d, both want 404", miss.Code, empty.Code)
+	}
+	if miss.Body.String() != empty.Body.String() {
+		t.Errorf("unknown vs empty lookup gave different bodies (%q vs %q) - that is an oracle", miss.Body.String(), empty.Body.String())
+	}
+}
+
+func TestCapsuleExpired(t *testing.T) {
+	b := capsuleBroker(t)
+	// store a blob that expired in the past (put with a `now` two TTLs ago -> expires one TTL ago)
+	b.capsules.put("stale", []byte("old"), time.Now().Add(-2*capsuleTTL))
+	if w := capsuleResolveReq(t, b, "stale"); w.Code != http.StatusNotFound {
+		t.Errorf("expired blob resolve status %d, want 404", w.Code)
+	}
+}
+
+func TestCapsuleOversize(t *testing.T) {
+	b := capsuleBroker(t)
+	_, priv, _ := ed25519.GenerateKey(nil)
+	big := bytes.Repeat([]byte{0x41}, capsuleMaxBlob+1)
+	if w := capsuleMintReq(t, b, priv, "toobig", big, true); w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("oversize mint status %d, want 413", w.Code)
+	}
+}
+
+func TestCapsuleUnsignedMintRejected(t *testing.T) {
+	b := capsuleBroker(t)
+	_, priv, _ := ed25519.GenerateKey(nil)
+	if w := capsuleMintReq(t, b, priv, "nosig", []byte("x"), false); w.Code != http.StatusUnauthorized {
+		t.Errorf("unsigned mint status %d, want 401", w.Code)
+	}
+	// and it must NOT have stored anything (content-blind + no unsigned writes)
+	if w := capsuleResolveReq(t, b, "nosig"); w.Code != http.StatusNotFound {
+		t.Errorf("an unsigned mint must store nothing, got resolve status %d", w.Code)
+	}
+}
+
+// TestCapsuleStoreBounded: the in-memory store sheds load at capacity rather than growing unbounded.
+func TestCapsuleStoreBounded(t *testing.T) {
+	c := newCapsuleStore()
+	now := time.Now()
+	exp := now.Add(capsuleTTL).Unix()
+	for i := 0; i < capsuleMaxEntries; i++ {
+		c.m[string(rune(i))+"-k"] = capsuleBlob{blob: []byte("v"), expires: exp} // fill to capacity (all live)
+	}
+	if c.put("one-too-many", []byte("v"), now) {
+		t.Error("put past capacity should be refused, not grow unbounded")
+	}
+}

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -149,6 +149,7 @@ type broker struct {
 	// host inbound channel, viewer fan-out, a bounded replay ring). See rc.go.
 	rcMu        sync.Mutex
 	rcHubs      map[string]*rcHub
+	capsules    *capsuleStore // content-blind one-time-code capsule handoff blobs (capsule.go); per-instance, ephemeral
 	bill        billing
 	conn        connect
 	mod         moderation
@@ -503,6 +504,7 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		private: map[string]bool{}, bandOf: map[string]string{}, tps: map[string]float64{},
 		attestedAt: map[string]time.Time{}, localRegAt: map[string]time.Time{}, localPollAt: map[string]time.Time{}, attest: loadAttestRegistry(),
 		quotes: map[string]priceQuote{}, streams: map[string]*streamSink{}, db: db,
+		capsules:  newCapsuleStore(),
 		pubOfUser: map[string]string{},
 		inflight:  map[string]int{}, success: map[string]float64{}, trust: map[string]trustState{},
 		successCount: map[string]int{}, concurrentTPS: map[string]float64{},
@@ -510,8 +512,8 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		toolsMerged:  map[string]bool{},
 		lastToolMark: map[string]time.Time{},
 		probeSched:   map[string]*probeState{},
-		lastPersist: map[string]time.Time{},
-		priv:        priv, feeRate: fee, seedFunds: seed, lockWin: lock,
+		lastPersist:  map[string]time.Time{},
+		priv:         priv, feeRate: fee, seedFunds: seed, lockWin: lock,
 		ttsMaxChars: audioTTSMaxChars(), audioSem: newAudioSem(),
 		banned:                 map[string]bool{},
 		reportEjectAt:          reportEjectThreshold(),
@@ -697,6 +699,8 @@ func (b *broker) routes() *http.ServeMux {
 	mux.HandleFunc("/rc/attach", b.rcAttach)                                                          // remote surface: attach with the link code (uniform-404)
 	mux.HandleFunc("/rc/revoke-all", b.rcRevokeAll)                                                   // owner: end every remote-control session
 	mux.HandleFunc("/rc/", b.rcSubtree)                                                               // /rc/{sid}/{poll|events|send|stream|code|disable}
+	mux.HandleFunc("/capsule", b.capsuleMint)                                                         // signed: store an encrypted context-capsule blob under a one-time-code hash (content-blind)
+	mux.HandleFunc("/capsule/resolve", b.capsuleResolve)                                              // code-authed: fetch the blob ONCE (uniform-404, delete-on-read)
 	mux.HandleFunc("/admin/csam", b.adminCSAMQueue)                                                   // admin-authed: the CyberTipline drain queue (metadata only) + backlog stats
 	mux.HandleFunc("/admin/csam/submit", b.adminCSAMSubmit)                                           // admin-authed: mark an incident submitted with its CyberTipline report id
 	mux.HandleFunc("/admin/live", b.adminLive)                                                        // admin-authed: LIVE in-memory ops (health, marketplace, dispatch, seed/fee/stripe) the private roger-admin portal merges with its own Postgres rollups


### PR DESCRIPTION
Broker transport for the cross-agent **context capsule** (`roger.context.v1`) - a conversation can be handed off cross-device or to an operator via a one-time code. Companion to the app-side capsule (Stages 1-3, build-and-hold) and the CLI/TUI parity brief.

## Content-blind
The broker stores only `{lookup = sha256(code), blob = ciphertext}` and does **zero crypto**. The code, the HKDF-derived key, and the plaintext capsule are all client-side. A leaked `lookup` yields only the undecryptable blob. `lookup` and `key` are independent one-way derivations of a 128-bit random code, so the lookup can't yield the key.

## Endpoints
- **`POST /capsule`** (owner-signed, for attribution/rate-limiting): `{lookup, blob}` stored with a 10-min TTL (`store.RCCodeTTL`), one-time, size-capped (empty or >1MB -> 413).
- **`POST /capsule/resolve`** (code-authed by possession of the lookup, no signature): always runs `take()` (constant work) and returns a **byte-identical 404** for miss/expired/garbage (no existence oracle); **delete-on-read**, so a second resolve is a 404.

## Store
A per-instance, bounded (10k), TTL-swept map on the broker instance (like the RC live hubs) - the blob is ephemeral content-blind ciphertext. **Multi-instance** (a shared valkey TTL store, mirroring how RC does cross-instance attach) is a flagged follow-up.

## Tests
Real payloads, no mocks: mint->resolve round-trip; second resolve -> 404 (one-time); unknown vs empty lookup -> identical 404 (no oracle); expired -> 404; oversize -> 413; unsigned mint -> 401 and stores nothing; store refuses puts past capacity. Broker package green, `go build ./...` OK, `go vet` + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)