### PR TITLE
capsule: encrypted stranger transport (Stage 3) - content-blind one-time-code handoff

### DIFF
--- a/cmd/rogerai-broker/capsule.go
+++ b/cmd/rogerai-broker/capsule.go
@@ -9,9 +9,14 @@ package main
 // The broker never sees the code, the key, or the plaintext - it stores and returns an opaque,
 // expiring, one-time blob. Mirrors the RC link-code posture (rcAttach): the mint is signed (for
 // attribution / rate-limiting), the resolve is authed only by possession of the lookup, and any
-// miss/expired/garbage resolve returns the IDENTICAL 404 so there is no existence oracle. Like the
-// RC live hubs (not the durable roster), the store is per-instance + ephemeral; it is never
-// persisted to the DB.
+// miss/expired/garbage resolve returns the IDENTICAL 404 so there is no existence oracle.
+//
+// MULTI-INSTANCE: the blob store is SHARED-first (b.shared.putCapsule / takeCapsule, a Valkey
+// SET + one-time GETDEL keyed on rogerai:cap:<lookup>), so a mint on instance A resolves on
+// instance B and exactly one of N concurrent resolves wins (atomic single-use across
+// instances). When no shared backend is wired (single-instance / no-Valkey), it falls back to
+// the bounded, TTL-swept, per-instance capsuleStore map below. Either way it is ephemeral
+// ciphertext, never persisted to the money DB.
 
 import (
 	"encoding/base64"
@@ -83,6 +88,43 @@ func (c *capsuleStore) sweepLocked(now time.Time) {
 	}
 }
 
+// putCapsuleBlob stores a mint SHARED-first (so a mint on one instance resolves on another),
+// falling back to the per-instance map when no shared backend is wired (single-instance /
+// no-Valkey). A shared backend that is present but ERRORING sheds the mint (returns false ->
+// 503) rather than writing it locally where a peer could never see it. errNoSharedStore (the
+// inert memStore) routes to the local map. Content-blind: only {lookup, ciphertext} at rest.
+func (b *broker) putCapsuleBlob(lookup string, blob []byte, now time.Time) bool {
+	if b.shared != nil {
+		err := b.shared.putCapsule(lookup, blob, capsuleTTL)
+		if err == nil {
+			return true
+		}
+		if err != errNoSharedStore {
+			return false // real backend error: shed (retry), never split-brain to local
+		}
+		// errNoSharedStore: no shared backend (memStore) -> use the per-instance map.
+	}
+	return b.capsules.put(lookup, blob, now)
+}
+
+// takeCapsuleBlob consumes a blob SHARED-first (atomic one-time GETDEL across instances),
+// falling back to the per-instance map when no shared backend is wired. A shared backend
+// that is present but ERRORING yields a uniform miss (the handler 404s) rather than probing
+// the local map for a blob a peer minted. errNoSharedStore routes to the local map.
+func (b *broker) takeCapsuleBlob(lookup string, now time.Time) ([]byte, bool) {
+	if b.shared != nil {
+		blob, found, err := b.shared.takeCapsule(lookup)
+		if err == nil {
+			return blob, found // authoritative: a hit or a clean miss
+		}
+		if err != errNoSharedStore {
+			return nil, false // real backend error: uniform miss
+		}
+		// errNoSharedStore: no shared backend -> use the per-instance map.
+	}
+	return b.capsules.take(lookup, now)
+}
+
 // capsuleMint handles POST /capsule: store an opaque encrypted blob keyed by the client-supplied
 // lookup (sha256 of the client's one-time code). Requires a VERIFIED signature (any device/owner
 // key) so a mint is attributable and rate-limitable - the plaintext/code/key never reach us.
@@ -113,7 +155,7 @@ func (b *broker) capsuleMint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := time.Now()
-	if !b.capsules.put(req.Lookup, blob, now) {
+	if !b.putCapsuleBlob(req.Lookup, blob, now) {
 		jsonErr(w, http.StatusServiceUnavailable, "capsule store is full, retry shortly")
 		return
 	}
@@ -134,7 +176,7 @@ func (b *broker) capsuleResolve(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = json.Unmarshal(body, &req)
 	// Always attempt the take (constant work), even for empty/garbage input.
-	blob, ok := b.capsules.take(req.Lookup, time.Now())
+	blob, ok := b.takeCapsuleBlob(req.Lookup, time.Now())
 	if !ok {
 		uniform()
 		return

--- a/cmd/rogerai-broker/capsule.go
+++ b/cmd/rogerai-broker/capsule.go
@@ -1,0 +1,143 @@
+package main
+
+// capsule.go is the CONTENT-BLIND one-time-code transport for context-capsule handoff (the app +
+// CLI cross-agent handoff, roger.context.v1). The CLIENT generates a one-time code, derives an
+// encryption key from it, encrypts the (already-redacted, signed) capsule, and stores ONLY the
+// ciphertext here keyed by sha256(code); it shares the code out-of-band. The receiver sends the
+// same sha256(code) to resolve, gets the ciphertext once, and decrypts with its own key(code).
+//
+// The broker never sees the code, the key, or the plaintext - it stores and returns an opaque,
+// expiring, one-time blob. Mirrors the RC link-code posture (rcAttach): the mint is signed (for
+// attribution / rate-limiting), the resolve is authed only by possession of the lookup, and any
+// miss/expired/garbage resolve returns the IDENTICAL 404 so there is no existence oracle. Like the
+// RC live hubs (not the durable roster), the store is per-instance + ephemeral; it is never
+// persisted to the DB.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+const (
+	capsuleTTL         = store.RCCodeTTL    // 10 minutes, the same attach window as an RC link code
+	capsuleMaxBlob     = 1 << 20            // 1 MB hard cap on the stored ciphertext
+	capsuleMaxEntries  = 10000              // bound the in-memory store so a flood of mints cannot grow it unbounded
+	capsuleReadLimit   = capsuleMaxBlob * 2 // base64 expands ~4/3, so allow a just-over-max blob to reach the 413 check
+	capsuleResolveRead = 1 << 14
+)
+
+type capsuleBlob struct {
+	blob    []byte
+	expires int64 // unix seconds
+}
+
+// capsuleStore is a bounded, TTL-swept, per-instance map of lookup-hash -> ciphertext. It holds
+// opaque bytes only (the broker cannot read them), and a blob is consumed on the first successful
+// resolve (one-time).
+type capsuleStore struct {
+	mu sync.Mutex
+	m  map[string]capsuleBlob
+}
+
+func newCapsuleStore() *capsuleStore { return &capsuleStore{m: map[string]capsuleBlob{}} }
+
+// put stores a blob under lookup with a fresh TTL. Returns false when the store is at capacity
+// (shed load rather than grow unbounded). Sweeps expired entries first so capacity self-heals.
+func (c *capsuleStore) put(lookup string, blob []byte, now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sweepLocked(now)
+	if _, exists := c.m[lookup]; !exists && len(c.m) >= capsuleMaxEntries {
+		return false
+	}
+	c.m[lookup] = capsuleBlob{blob: blob, expires: now.Add(capsuleTTL).Unix()}
+	return true
+}
+
+// take returns the blob and REMOVES it (one-time), or false for absent/expired. The work is the
+// same for every outcome so the caller can return a uniform error with no timing/existence oracle.
+func (c *capsuleStore) take(lookup string, now time.Time) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok := c.m[lookup]
+	if ok {
+		delete(c.m, lookup) // consumed whether live or expired: a resolve never leaves it behind
+		if now.Unix() < v.expires {
+			return v.blob, true
+		}
+	}
+	return nil, false
+}
+
+func (c *capsuleStore) sweepLocked(now time.Time) {
+	for k, v := range c.m {
+		if now.Unix() >= v.expires {
+			delete(c.m, k)
+		}
+	}
+}
+
+// capsuleMint handles POST /capsule: store an opaque encrypted blob keyed by the client-supplied
+// lookup (sha256 of the client's one-time code). Requires a VERIFIED signature (any device/owner
+// key) so a mint is attributable and rate-limitable - the plaintext/code/key never reach us.
+func (b *broker) capsuleMint(w http.ResponseWriter, r *http.Request) {
+	if !allow(w, r, http.MethodPost) {
+		return
+	}
+	body, _ := io.ReadAll(io.LimitReader(r.Body, capsuleReadLimit))
+	if _, authed, _ := b.identityOf(r, body); !authed {
+		jsonErr(w, http.StatusUnauthorized, "capsule mint requires a signed request")
+		return
+	}
+	var req struct {
+		Lookup string `json:"lookup"`
+		Blob   string `json:"blob"`
+	}
+	if json.Unmarshal(body, &req) != nil || req.Lookup == "" || req.Blob == "" {
+		jsonErr(w, http.StatusBadRequest, "lookup and blob required")
+		return
+	}
+	blob, err := base64.StdEncoding.DecodeString(req.Blob)
+	if err != nil {
+		jsonErr(w, http.StatusBadRequest, "blob is not base64")
+		return
+	}
+	if len(blob) == 0 || len(blob) > capsuleMaxBlob {
+		jsonErr(w, http.StatusRequestEntityTooLarge, "capsule blob too large")
+		return
+	}
+	now := time.Now()
+	if !b.capsules.put(req.Lookup, blob, now) {
+		jsonErr(w, http.StatusServiceUnavailable, "capsule store is full, retry shortly")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "expires": now.Add(capsuleTTL).Unix()})
+}
+
+// capsuleResolve handles POST /capsule/resolve: return the opaque blob ONCE (delete-on-read).
+// Possession of the lookup is the authorization (no signature). Every miss/expired/garbage returns
+// the IDENTICAL 404 so an attacker cannot probe which lookups exist.
+func (b *broker) capsuleResolve(w http.ResponseWriter, r *http.Request) {
+	if !allow(w, r, http.MethodPost) {
+		return
+	}
+	uniform := func() { writeJSON(w, http.StatusNotFound, map[string]any{"error": "no such capsule"}) }
+	body, _ := io.ReadAll(io.LimitReader(r.Body, capsuleResolveRead))
+	var req struct {
+		Lookup string `json:"lookup"`
+	}
+	_ = json.Unmarshal(body, &req)
+	// Always attempt the take (constant work), even for empty/garbage input.
+	blob, ok := b.capsules.take(req.Lookup, time.Now())
+	if !ok {
+		uniform()
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"blob": base64.StdEncoding.EncodeToString(blob)})
+}

--- a/cmd/rogerai-broker/capsule_multiinstance_test.go
+++ b/cmd/rogerai-broker/capsule_multiinstance_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -107,6 +108,44 @@ func TestCapsuleMultiInstanceRaceOneWinner(t *testing.T) {
 	if wins != 1 || misses != 1 {
 		t.Fatalf("race must yield exactly one winner: wins=%d misses=%d", wins, misses)
 	}
+}
+
+// TestCapsuleInertSharedFallsBackToLocalMap: with an INERT memStore (errNoSharedStore), the
+// handlers use the per-instance map (single-instance / no-Valkey) and still round-trip.
+func TestCapsuleInertSharedFallsBackToLocalMap(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	b := buildBroker(store.NewMem(), priv, 0.30, 100, time.Hour)
+	b.shared = newMemStore() // non-nil but inert
+	lookup, blob := "lk-inert", []byte("via-local-map")
+	if w := capsuleMintReq(t, b, priv, lookup, blob, true); w.Code != http.StatusOK {
+		t.Fatalf("mint status %d", w.Code)
+	}
+	w := capsuleResolveReq(t, b, lookup)
+	if w.Code != http.StatusOK || string(decodeBlobMI(w)) != string(blob) {
+		t.Fatalf("inert-shared resolve status %d blob %q", w.Code, decodeBlobMI(w))
+	}
+}
+
+// TestCapsuleDownedSharedShedsAndMisses: a PRESENT-but-erroring shared backend must NOT
+// split-brain to the local map - a mint sheds (503) and a resolve is a uniform 404.
+func TestCapsuleDownedSharedShedsAndMisses(t *testing.T) {
+	url := xiRedisURL(t)
+	b := sharedBroker(t, url)
+	_, priv, _ := ed25519.GenerateKey(nil)
+	b.shared.(*valkeyStore).rdb.Close() // kill the backend
+	if w := capsuleMintReq(t, b, priv, "lk-down", []byte("x"), true); w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("mint on a downed shared backend status %d, want 503", w.Code)
+	}
+	if w := capsuleResolveReq(t, b, "lk-down"); w.Code != http.StatusNotFound {
+		t.Fatalf("resolve on a downed shared backend status %d, want 404", w.Code)
+	}
+}
+
+func decodeBlobMI(w *httptest.ResponseRecorder) []byte {
+	var out struct{ Blob string }
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	b, _ := base64.StdEncoding.DecodeString(out.Blob)
+	return b
 }
 
 // TestCapsuleBrokerContentBlind proves the broker cannot decrypt what it stores: after a

--- a/cmd/rogerai-broker/capsule_multiinstance_test.go
+++ b/cmd/rogerai-broker/capsule_multiinstance_test.go
@@ -1,0 +1,156 @@
+package main
+
+// capsule_multiinstance_test.go pins the SHARED-store, multi-instance behavior of the
+// content-blind capsule rendezvous (the prod gap #64 left: a per-instance map does not
+// resolve across instances). Two brokers share one Valkey (miniredis, or a real
+// ROGERAI_TEST_REDIS_URL): a mint on A resolves on B, and two concurrent resolves race to
+// exactly one winner (atomic single-use across instances). Also proves the broker is
+// content-blind by INSPECTING what it stores: only {lookup, ciphertext}, never the code/key/
+// plaintext.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/capsule"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// sharedBroker builds a broker whose capsule rendezvous is backed by the shared store at url.
+func sharedBroker(t *testing.T, url string) *broker {
+	t.Helper()
+	_, priv, _ := ed25519.GenerateKey(nil)
+	b := buildBroker(store.NewMem(), priv, 0.30, 100, time.Hour)
+	vs, err := newValkeyStore(url)
+	if err != nil {
+		t.Fatalf("valkey: %v", err)
+	}
+	t.Cleanup(func() { _ = vs.Close() })
+	b.shared = vs
+	return b
+}
+
+func TestCapsuleMultiInstanceMintAResolveB(t *testing.T) {
+	url := xiRedisURL(t)
+	a := sharedBroker(t, url)
+	b := sharedBroker(t, url) // a SECOND instance sharing the same store
+	_, priv, _ := ed25519.GenerateKey(nil)
+
+	lookup := "lk-cross-instance"
+	blob := []byte("opaque-ciphertext-A-minted")
+
+	if w := capsuleMintReq(t, a, priv, lookup, blob, true); w.Code != http.StatusOK {
+		t.Fatalf("mint on A status %d: %s", w.Code, w.Body.String())
+	}
+	// resolve on the OTHER instance must return the exact blob (the #64 gap).
+	w := capsuleResolveReq(t, b, lookup)
+	if w.Code != http.StatusOK {
+		t.Fatalf("resolve on B status %d, want 200 (mint on A must resolve on B): %s", w.Code, w.Body.String())
+	}
+	var out struct{ Blob string }
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	got, _ := base64.StdEncoding.DecodeString(out.Blob)
+	if string(got) != string(blob) {
+		t.Fatalf("resolved blob = %q, want %q", got, blob)
+	}
+	// one-time across instances: a second resolve on A (the minter) is now a 404 too.
+	if w2 := capsuleResolveReq(t, a, lookup); w2.Code != http.StatusNotFound {
+		t.Errorf("second resolve on A status %d, want 404 (one-time across instances)", w2.Code)
+	}
+}
+
+func TestCapsuleMultiInstanceRaceOneWinner(t *testing.T) {
+	url := xiRedisURL(t)
+	a := sharedBroker(t, url)
+	b := sharedBroker(t, url)
+	_, priv, _ := ed25519.GenerateKey(nil)
+
+	lookup := "lk-race"
+	blob := []byte("exactly-one-resolver-wins")
+	if w := capsuleMintReq(t, a, priv, lookup, blob, true); w.Code != http.StatusOK {
+		t.Fatalf("mint status %d", w.Code)
+	}
+
+	// Two instances resolve the SAME lookup concurrently: exactly one 200, one 404.
+	var wg sync.WaitGroup
+	codes := make([]int, 2)
+	brokers := []*broker{a, b}
+	wg.Add(2)
+	for i := range brokers {
+		i := i
+		go func() {
+			defer wg.Done()
+			codes[i] = capsuleResolveReq(t, brokers[i], lookup).Code
+		}()
+	}
+	wg.Wait()
+
+	wins, misses := 0, 0
+	for _, c := range codes {
+		switch c {
+		case http.StatusOK:
+			wins++
+		case http.StatusNotFound:
+			misses++
+		default:
+			t.Fatalf("unexpected resolve status %d", c)
+		}
+	}
+	if wins != 1 || misses != 1 {
+		t.Fatalf("race must yield exactly one winner: wins=%d misses=%d", wins, misses)
+	}
+}
+
+// TestCapsuleBrokerContentBlind proves the broker cannot decrypt what it stores: after a
+// mint, the shared store holds ONLY the ciphertext under the lookup - not the plaintext, the
+// raw code, or the derived key. The plaintext is recoverable ONLY with the raw code.
+func TestCapsuleBrokerContentBlind(t *testing.T) {
+	url := xiRedisURL(t)
+	a := sharedBroker(t, url)
+	_, priv, _ := ed25519.GenerateKey(nil)
+
+	code, _, _ := protocol.NewRCLinkCode()
+	plaintext := []byte(`{"capsule":"roger.context.v1","messages":[{"content":"SENSITIVE-SECRET-BODY"}]}`)
+	sealed, err := capsule.SealForCode(plaintext, code)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	lookup := capsule.TransportLookup(code)
+
+	if w := capsuleMintReq(t, a, priv, lookup, sealed, true); w.Code != http.StatusOK {
+		t.Fatalf("mint status %d", w.Code)
+	}
+
+	// Inspect the raw stored value: it must equal the ciphertext and contain NEITHER the
+	// plaintext NOR the code/tail.
+	vs := a.shared.(*valkeyStore)
+	raw, err := vs.rdb.Get(context.Background(), capsuleKeyPrefix+lookup).Bytes()
+	if err != nil {
+		t.Fatalf("read stored blob: %v", err)
+	}
+	if string(raw) != string(sealed) {
+		t.Fatal("stored value must be exactly the ciphertext")
+	}
+	if bytes.Contains(raw, plaintext) {
+		t.Fatal("the stored blob must NOT contain the plaintext (content-blind)")
+	}
+	if bytes.Contains(raw, []byte(code)) {
+		t.Fatal("the stored blob must NOT contain the raw code")
+	}
+	// The broker holds no code/key field: the ONLY way back to plaintext is the raw code.
+	if _, err := capsule.OpenWithCode(raw, lookup); err == nil {
+		t.Fatal("the lookup (all the broker has) must not decrypt the blob")
+	}
+	got, err := capsule.OpenWithCode(raw, code)
+	if err != nil || string(got) != string(plaintext) {
+		t.Fatalf("only the raw code recovers the plaintext: err=%v", err)
+	}
+}

--- a/cmd/rogerai-broker/capsule_rendezvous_bdd_test.go
+++ b/cmd/rogerai-broker/capsule_rendezvous_bdd_test.go
@@ -1,0 +1,363 @@
+package main
+
+// capsule_rendezvous_bdd_test.go makes features/capsule/broker_rendezvous.feature EXECUTABLE
+// under godog: the content-blind, one-time, multi-instance broker rendezvous over a real
+// shared store (miniredis, or ROGERAI_TEST_REDIS_URL) and REAL seal/open crypto. No mocks.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/capsule"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+func bddErrf(format string, a ...any) error { return fmt.Errorf(format, a...) }
+
+type rvBDD struct {
+	t         *testing.T
+	url       string
+	a, b      *broker // two instances sharing one store
+	local     *broker // per-instance-map broker (no shared) for the expiry path
+	priv      ed25519.PrivateKey
+	lookup    string
+	blob      []byte
+	code      string
+	plaintext []byte
+	res       *httptest.ResponseRecorder
+	resB      *httptest.ResponseRecorder
+	unknown   *httptest.ResponseRecorder
+	empty     *httptest.ResponseRecorder
+	mintCode  int
+}
+
+func (s *rvBDD) shared() *broker {
+	if s.a == nil {
+		s.a = sharedBroker(s.t, s.url)
+		s.b = sharedBroker(s.t, s.url)
+	}
+	return s.a
+}
+
+// --- Given ---------------------------------------------------------------
+
+func (s *rvBDD) signedMintUnderLookup() error {
+	s.shared()
+	s.lookup = "lk-" + protocol.BandCodeHash("rendezvous-fixture")
+	s.blob = []byte("opaque-ciphertext-the-broker-cannot-read")
+	if w := capsuleMintReq(s.t, s.a, s.priv, s.lookup, s.blob, true); w.Code != http.StatusOK {
+		return bddErrf("mint status %d", w.Code)
+	}
+	return nil
+}
+
+func (s *rvBDD) sealedAndMinted() error {
+	s.shared()
+	s.code, _, _ = protocol.NewRCLinkCode()
+	s.plaintext = []byte(`{"capsule":"roger.context.v1","messages":[{"content":"SENSITIVE-SECRET-BODY"}]}`)
+	sealed, err := capsule.SealForCode(s.plaintext, s.code)
+	if err != nil {
+		return err
+	}
+	s.blob = sealed
+	s.lookup = capsule.TransportLookup(s.code)
+	// capture the log to prove nothing sensitive is written during the mint.
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	w := capsuleMintReq(s.t, s.a, s.priv, s.lookup, sealed, true)
+	log.SetOutput(old)
+	if w.Code != http.StatusOK {
+		return bddErrf("mint status %d", w.Code)
+	}
+	if bytes.Contains(buf.Bytes(), []byte(s.code)) || bytes.Contains(buf.Bytes(), s.plaintext) {
+		return bddErrf("a log line leaked the code or plaintext")
+	}
+	return nil
+}
+
+func (s *rvBDD) expiredMint() error {
+	s.local = capsuleBroker(s.t) // per-instance map, no shared
+	s.lookup = "stale"
+	s.blob = []byte("old-ciphertext")
+	s.local.capsules.put(s.lookup, s.blob, time.Now().Add(-2*capsuleTTL))
+	return nil
+}
+
+func (s *rvBDD) oversizeMint() error {
+	s.shared()
+	s.lookup = "toobig"
+	big := bytes.Repeat([]byte{0x41}, capsuleMaxBlob+1)
+	s.mintCode = capsuleMintReq(s.t, s.a, s.priv, s.lookup, big, true).Code
+	return nil
+}
+
+func (s *rvBDD) unsignedMint() error {
+	s.shared()
+	s.lookup = "nosig"
+	s.mintCode = capsuleMintReq(s.t, s.a, s.priv, s.lookup, []byte("x"), false).Code
+	return nil
+}
+
+func (s *rvBDD) twoInstances() error { s.shared(); return nil }
+
+func (s *rvBDD) mintOnAUnderLookup() error {
+	s.lookup = "lk-A-to-B"
+	s.blob = []byte("A-minted-ciphertext")
+	if w := capsuleMintReq(s.t, s.a, s.priv, s.lookup, s.blob, true); w.Code != http.StatusOK {
+		return bddErrf("mint on A status %d", w.Code)
+	}
+	return nil
+}
+
+func (s *rvBDD) minted() error { return s.mintOnAUnderLookup() }
+
+// --- When ----------------------------------------------------------------
+
+func (s *rvBDD) resolveLookup() error {
+	s.res = capsuleResolveReq(s.t, s.a, s.lookup)
+	return nil
+}
+
+func (s *rvBDD) resolveExpired() error {
+	s.res = capsuleResolveReq(s.t, s.local, s.lookup)
+	return nil
+}
+
+func (s *rvBDD) resolveUnknown() error {
+	s.unknown = capsuleResolveReq(s.t, s.shared(), "does-not-exist")
+	return nil
+}
+
+func (s *rvBDD) resolveEmpty() error {
+	s.empty = capsuleResolveReq(s.t, s.shared(), "")
+	return nil
+}
+
+func (s *rvBDD) resolveOnB() error {
+	s.resB = capsuleResolveReq(s.t, s.b, s.lookup)
+	return nil
+}
+
+func (s *rvBDD) resolveConcurrently() error {
+	var wg sync.WaitGroup
+	out := make([]*httptest.ResponseRecorder, 2)
+	brs := []*broker{s.a, s.b}
+	wg.Add(2)
+	for i := range brs {
+		i := i
+		go func() { defer wg.Done(); out[i] = capsuleResolveReq(s.t, brs[i], s.lookup) }()
+	}
+	wg.Wait()
+	s.res, s.resB = out[0], out[1]
+	return nil
+}
+
+// --- Then ----------------------------------------------------------------
+
+func (s *rvBDD) resolveReturnsExact() error {
+	if s.res.Code != http.StatusOK {
+		return bddErrf("resolve status %d, want 200", s.res.Code)
+	}
+	got := decodeBlob(s.res)
+	if !bytes.Equal(got, s.blob) {
+		return bddErrf("resolved blob %q, want %q", got, s.blob)
+	}
+	return nil
+}
+
+func (s *rvBDD) secondResolveUniform404() error {
+	if w := capsuleResolveReq(s.t, s.a, s.lookup); w.Code != http.StatusNotFound {
+		return bddErrf("second resolve status %d, want 404 (one-time)", w.Code)
+	}
+	return nil
+}
+
+func (s *rvBDD) holdsOnlyLookupAndCiphertext() error {
+	vs := s.a.shared.(*valkeyStore)
+	raw, err := vs.rdb.Get(context.Background(), capsuleKeyPrefix+s.lookup).Bytes()
+	if err != nil {
+		return bddErrf("read stored blob: %v", err)
+	}
+	if !bytes.Equal(raw, s.blob) {
+		return bddErrf("stored value is not exactly the ciphertext")
+	}
+	if bytes.Contains(raw, s.plaintext) {
+		return bddErrf("the stored blob contains the plaintext")
+	}
+	return nil
+}
+
+func (s *rvBDD) hasNeitherCodeNorKey() error {
+	vs := s.a.shared.(*valkeyStore)
+	raw, _ := vs.rdb.Get(context.Background(), capsuleKeyPrefix+s.lookup).Bytes()
+	if bytes.Contains(raw, []byte(s.code)) {
+		return bddErrf("the stored blob contains the raw code")
+	}
+	// The lookup is all the broker holds; it must not derive the key/plaintext.
+	if _, err := capsule.OpenWithCode(raw, s.lookup); err == nil {
+		return bddErrf("the lookup decrypted the blob (key not domain-separated)")
+	}
+	return nil
+}
+
+func (s *rvBDD) cannotRecoverPlaintext() error {
+	vs := s.a.shared.(*valkeyStore)
+	raw, _ := vs.rdb.Get(context.Background(), capsuleKeyPrefix+s.lookup).Bytes()
+	// Only the raw code recovers it.
+	got, err := capsule.OpenWithCode(raw, s.code)
+	if err != nil || !bytes.Equal(got, s.plaintext) {
+		return bddErrf("the raw code must recover the plaintext: %v", err)
+	}
+	return nil
+}
+
+func (s *rvBDD) bothUniform404Identical() error {
+	if s.unknown.Code != http.StatusNotFound || s.empty.Code != http.StatusNotFound {
+		return bddErrf("unknown=%d empty=%d, both want 404", s.unknown.Code, s.empty.Code)
+	}
+	if s.unknown.Body.String() != s.empty.Body.String() {
+		return bddErrf("unknown vs empty gave different bodies (an oracle)")
+	}
+	return nil
+}
+
+func (s *rvBDD) resolveIsUniform404() error {
+	if s.res.Code != http.StatusNotFound {
+		return bddErrf("resolve status %d, want 404", s.res.Code)
+	}
+	return nil
+}
+
+func (s *rvBDD) mintRefusedTooLarge() error {
+	if s.mintCode != http.StatusRequestEntityTooLarge {
+		return bddErrf("mint status %d, want 413", s.mintCode)
+	}
+	return nil
+}
+
+func (s *rvBDD) nothingStoredUnderLookup() error {
+	if w := capsuleResolveReq(s.t, s.a, s.lookup); w.Code != http.StatusNotFound {
+		return bddErrf("a refused mint must store nothing, got resolve %d", w.Code)
+	}
+	return nil
+}
+
+func (s *rvBDD) mintRejectedUnauthorized() error {
+	if s.mintCode != http.StatusUnauthorized {
+		return bddErrf("mint status %d, want 401", s.mintCode)
+	}
+	return nil
+}
+
+func (s *rvBDD) resolvingIsUniform404() error {
+	if w := capsuleResolveReq(s.t, s.a, s.lookup); w.Code != http.StatusNotFound {
+		return bddErrf("resolve status %d, want 404", w.Code)
+	}
+	return nil
+}
+
+func (s *rvBDD) resolveOnBReturnsExact() error {
+	if s.resB.Code != http.StatusOK {
+		return bddErrf("resolve on B status %d, want 200", s.resB.Code)
+	}
+	if got := decodeBlob(s.resB); !bytes.Equal(got, s.blob) {
+		return bddErrf("resolve on B blob %q, want %q", got, s.blob)
+	}
+	return nil
+}
+
+func (s *rvBDD) exactlyOneWins() error {
+	wins, misses := 0, 0
+	for _, w := range []*httptest.ResponseRecorder{s.res, s.resB} {
+		switch w.Code {
+		case http.StatusOK:
+			wins++
+		case http.StatusNotFound:
+			misses++
+		default:
+			return bddErrf("unexpected resolve status %d", w.Code)
+		}
+	}
+	if wins != 1 || misses != 1 {
+		return bddErrf("race must yield exactly one winner: wins=%d misses=%d", wins, misses)
+	}
+	return nil
+}
+
+func (s *rvBDD) noStoredValueLeaks() error {
+	if err := s.holdsOnlyLookupAndCiphertext(); err != nil {
+		return err
+	}
+	return s.hasNeitherCodeNorKey()
+}
+
+func decodeBlob(w *httptest.ResponseRecorder) []byte {
+	var out struct{ Blob string }
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	b, _ := base64.StdEncoding.DecodeString(out.Blob)
+	return b
+}
+
+func TestBrokerRendezvousBDD(t *testing.T) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			st := &rvBDD{}
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				_, priv, _ := ed25519.GenerateKey(nil)
+				*st = rvBDD{t: t, url: xiRedisURL(t), priv: priv}
+				return ctx, nil
+			})
+			sc.Step(`^a signed capsule mint of an opaque blob under a lookup$`, st.signedMintUnderLookup)
+			sc.Step(`^a stranger capsule sealed under a code and minted under its lookup$`, st.sealedAndMinted)
+			sc.Step(`^a blob minted with an already-expired TTL$`, st.expiredMint)
+			sc.Step(`^a signed capsule mint of a blob larger than the cap$`, st.oversizeMint)
+			sc.Step(`^an UNSIGNED capsule mint under a lookup$`, st.unsignedMint)
+			sc.Step(`^two broker instances sharing one store$`, st.twoInstances)
+			sc.Step(`^a blob minted under a lookup$`, st.minted)
+			sc.Step(`^I mint a blob on instance A under a lookup$`, st.mintOnAUnderLookup)
+
+			sc.Step(`^I resolve that lookup$`, st.resolveLookup)
+			sc.Step(`^I resolve its lookup$`, st.resolveExpired)
+			sc.Step(`^I resolve an unknown lookup$`, st.resolveUnknown)
+			sc.Step(`^I resolve an empty lookup$`, st.resolveEmpty)
+			sc.Step(`^I resolve that lookup on instance B$`, st.resolveOnB)
+			sc.Step(`^both instances resolve the same lookup concurrently$`, st.resolveConcurrently)
+
+			sc.Step(`^the resolve returns the exact blob$`, st.resolveReturnsExact)
+			sc.Step(`^a second resolve of the same lookup is a uniform 404$`, st.secondResolveUniform404)
+			sc.Step(`^the broker holds only the lookup and the ciphertext$`, st.holdsOnlyLookupAndCiphertext)
+			sc.Step(`^the broker has neither the code nor the key$`, st.hasNeitherCodeNorKey)
+			sc.Step(`^the broker cannot recover the plaintext from what it stores$`, st.cannotRecoverPlaintext)
+			sc.Step(`^both are a 404 with byte-identical bodies$`, st.bothUniform404Identical)
+			sc.Step(`^the resolve is a uniform 404$`, st.resolveIsUniform404)
+			sc.Step(`^the mint is refused as too-large$`, st.mintRefusedTooLarge)
+			sc.Step(`^nothing is stored under its lookup$`, st.nothingStoredUnderLookup)
+			sc.Step(`^the mint is rejected as unauthorized$`, st.mintRejectedUnauthorized)
+			sc.Step(`^resolving that lookup is a uniform 404$`, st.resolvingIsUniform404)
+			sc.Step(`^the resolve on B returns the exact blob$`, st.resolveOnBReturnsExact)
+			sc.Step(`^exactly one resolve returns the blob and the other is a 404$`, st.exactlyOneWins)
+			sc.Step(`^no stored value and no log line contains the code or the plaintext$`, st.noStoredValueLeaks)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/capsule/broker_rendezvous.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("broker rendezvous scenarios failed (see godog output above)")
+	}
+}

--- a/cmd/rogerai-broker/capsule_test.go
+++ b/cmd/rogerai-broker/capsule_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// capsuleBroker builds a broker with an initialized capsule store (buildBroker wires b.capsules).
+func capsuleBroker(t *testing.T) *broker {
+	t.Helper()
+	_, priv, _ := ed25519.GenerateKey(nil)
+	return buildBroker(store.NewMem(), priv, 0.30, 100, time.Hour)
+}
+
+func capsuleMintReq(t *testing.T, b *broker, priv ed25519.PrivateKey, lookup string, blob []byte, sign bool) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"lookup": lookup, "blob": base64.StdEncoding.EncodeToString(blob)})
+	r := httptest.NewRequest(http.MethodPost, "/capsule", bytes.NewReader(body))
+	if sign {
+		signReq(r, priv, body)
+	}
+	w := httptest.NewRecorder()
+	b.capsuleMint(w, r)
+	return w
+}
+
+func capsuleResolveReq(t *testing.T, b *broker, lookup string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"lookup": lookup})
+	r := httptest.NewRequest(http.MethodPost, "/capsule/resolve", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	b.capsuleResolve(w, r)
+	return w
+}
+
+func TestCapsuleMintResolveRoundTrip(t *testing.T) {
+	b := capsuleBroker(t)
+	_, priv, _ := ed25519.GenerateKey(nil)
+	lookup := "abc123" // stands in for hex(sha256(code)); the broker treats it as opaque
+	blob := []byte("this-is-ciphertext-the-broker-cannot-read")
+
+	if w := capsuleMintReq(t, b, priv, lookup, blob, true); w.Code != http.StatusOK {
+		t.Fatalf("mint status %d: %s", w.Code, w.Body.String())
+	}
+
+	// resolve returns the exact blob once
+	w := capsuleResolveReq(t, b, lookup)
+	if w.Code != http.StatusOK {
+		t.Fatalf("resolve status %d: %s", w.Code, w.Body.String())
+	}
+	var out struct {
+		Blob string `json:"blob"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	got, _ := base64.StdEncoding.DecodeString(out.Blob)
+	if !bytes.Equal(got, blob) {
+		t.Fatalf("resolved blob = %q, want %q", got, blob)
+	}
+
+	// ONE-TIME: a second resolve of the same lookup is the uniform 404
+	w2 := capsuleResolveReq(t, b, lookup)
+	if w2.Code != http.StatusNotFound {
+		t.Errorf("second resolve status %d, want 404 (one-time, delete-on-read)", w2.Code)
+	}
+}
+
+func TestCapsuleResolveUniform404(t *testing.T) {
+	b := capsuleBroker(t)
+	miss := capsuleResolveReq(t, b, "does-not-exist")
+	empty := capsuleResolveReq(t, b, "")
+	// an unknown lookup and an empty lookup must produce the IDENTICAL response (no existence oracle)
+	if miss.Code != http.StatusNotFound || empty.Code != http.StatusNotFound {
+		t.Fatalf("miss=%d empty=%d, both want 404", miss.Code, empty.Code)
+	}
+	if miss.Body.String() != empty.Body.String() {
+		t.Errorf("unknown vs empty lookup gave different bodies (%q vs %q) - that is an oracle", miss.Body.String(), empty.Body.String())
+	}
+}
+
+func TestCapsuleExpired(t *testing.T) {
+	b := capsuleBroker(t)
+	// store a blob that expired in the past (put with a `now` two TTLs ago -> expires one TTL ago)
+	b.capsules.put("stale", []byte("old"), time.Now().Add(-2*capsuleTTL))
+	if w := capsuleResolveReq(t, b, "stale"); w.Code != http.StatusNotFound {
+		t.Errorf("expired blob resolve status %d, want 404", w.Code)
+	}
+}
+
+func TestCapsuleOversize(t *testing.T) {
+	b := capsuleBroker(t)
+	_, priv, _ := ed25519.GenerateKey(nil)
+	big := bytes.Repeat([]byte{0x41}, capsuleMaxBlob+1)
+	if w := capsuleMintReq(t, b, priv, "toobig", big, true); w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("oversize mint status %d, want 413", w.Code)
+	}
+}
+
+func TestCapsuleUnsignedMintRejected(t *testing.T) {
+	b := capsuleBroker(t)
+	_, priv, _ := ed25519.GenerateKey(nil)
+	if w := capsuleMintReq(t, b, priv, "nosig", []byte("x"), false); w.Code != http.StatusUnauthorized {
+		t.Errorf("unsigned mint status %d, want 401", w.Code)
+	}
+	// and it must NOT have stored anything (content-blind + no unsigned writes)
+	if w := capsuleResolveReq(t, b, "nosig"); w.Code != http.StatusNotFound {
+		t.Errorf("an unsigned mint must store nothing, got resolve status %d", w.Code)
+	}
+}
+
+// TestCapsuleStoreBounded: the in-memory store sheds load at capacity rather than growing unbounded.
+func TestCapsuleStoreBounded(t *testing.T) {
+	c := newCapsuleStore()
+	now := time.Now()
+	exp := now.Add(capsuleTTL).Unix()
+	for i := 0; i < capsuleMaxEntries; i++ {
+		c.m[string(rune(i))+"-k"] = capsuleBlob{blob: []byte("v"), expires: exp} // fill to capacity (all live)
+	}
+	if c.put("one-too-many", []byte("v"), now) {
+		t.Error("put past capacity should be refused, not grow unbounded")
+	}
+}

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -149,6 +149,7 @@ type broker struct {
 	// host inbound channel, viewer fan-out, a bounded replay ring). See rc.go.
 	rcMu        sync.Mutex
 	rcHubs      map[string]*rcHub
+	capsules    *capsuleStore // content-blind one-time-code capsule handoff blobs (capsule.go); per-instance, ephemeral
 	bill        billing
 	conn        connect
 	mod         moderation
@@ -503,6 +504,7 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		private: map[string]bool{}, bandOf: map[string]string{}, tps: map[string]float64{},
 		attestedAt: map[string]time.Time{}, localRegAt: map[string]time.Time{}, localPollAt: map[string]time.Time{}, attest: loadAttestRegistry(),
 		quotes: map[string]priceQuote{}, streams: map[string]*streamSink{}, db: db,
+		capsules:  newCapsuleStore(),
 		pubOfUser: map[string]string{},
 		inflight:  map[string]int{}, success: map[string]float64{}, trust: map[string]trustState{},
 		successCount: map[string]int{}, concurrentTPS: map[string]float64{},
@@ -510,8 +512,8 @@ func buildBroker(db store.Store, priv ed25519.PrivateKey, fee, seed float64, loc
 		toolsMerged:  map[string]bool{},
 		lastToolMark: map[string]time.Time{},
 		probeSched:   map[string]*probeState{},
-		lastPersist: map[string]time.Time{},
-		priv:        priv, feeRate: fee, seedFunds: seed, lockWin: lock,
+		lastPersist:  map[string]time.Time{},
+		priv:         priv, feeRate: fee, seedFunds: seed, lockWin: lock,
 		ttsMaxChars: audioTTSMaxChars(), audioSem: newAudioSem(),
 		banned:                 map[string]bool{},
 		reportEjectAt:          reportEjectThreshold(),
@@ -697,6 +699,8 @@ func (b *broker) routes() *http.ServeMux {
 	mux.HandleFunc("/rc/attach", b.rcAttach)                                                          // remote surface: attach with the link code (uniform-404)
 	mux.HandleFunc("/rc/revoke-all", b.rcRevokeAll)                                                   // owner: end every remote-control session
 	mux.HandleFunc("/rc/", b.rcSubtree)                                                               // /rc/{sid}/{poll|events|send|stream|code|disable}
+	mux.HandleFunc("/capsule", b.capsuleMint)                                                         // signed: store an encrypted context-capsule blob under a one-time-code hash (content-blind)
+	mux.HandleFunc("/capsule/resolve", b.capsuleResolve)                                              // code-authed: fetch the blob ONCE (uniform-404, delete-on-read)
 	mux.HandleFunc("/admin/csam", b.adminCSAMQueue)                                                   // admin-authed: the CyberTipline drain queue (metadata only) + backlog stats
 	mux.HandleFunc("/admin/csam/submit", b.adminCSAMSubmit)                                           // admin-authed: mark an incident submitted with its CyberTipline report id
 	mux.HandleFunc("/admin/live", b.adminLive)                                                        // admin-authed: LIVE in-memory ops (health, marketplace, dispatch, seed/fee/stripe) the private roger-admin portal merges with its own Postgres rollups

--- a/cmd/rogerai-broker/sharedstore.go
+++ b/cmd/rogerai-broker/sharedstore.go
@@ -106,6 +106,21 @@ type sharedStore interface {
 	// (the TTL is the backstop). A missing key is not an error.
 	cacheDel(key string) error
 
+	// --- content-blind capsule rendezvous (capsule.go), keyed on the LOOKUP hash ---
+	//
+	// putCapsule stores an OPAQUE encrypted capsule blob under lookup with a TTL, so a
+	// mint on one instance resolves on another (the multi-instance content-blind handoff).
+	// It holds ONLY {lookup, ciphertext}: never the code, the key, or the plaintext. A
+	// non-nil err (incl. errNoSharedStore on memStore) means the shared path is unavailable
+	// and the caller uses its per-instance fallback map. ttl<=0 is treated as no-store.
+	putCapsule(lookup string, blob []byte, ttl time.Duration) error
+
+	// takeCapsule ATOMICALLY returns AND deletes the blob under lookup (one-time,
+	// delete-on-read via GETDEL), so exactly one of N concurrent resolves across all
+	// instances wins and every later resolve is a miss. found==false for an absent/expired
+	// lookup. A non-nil err (incl. errNoSharedStore) routes the caller to its fallback map.
+	takeCapsule(lookup string) (blob []byte, found bool, err error)
+
 	// counterGet reads a numeric counter (a stringified float) for key. found==false on a
 	// miss; a non-nil err means the backend was unreachable. It is a fast-path accelerator
 	// for a value the caller can always RECONCILE from Postgres (the source of truth) on a
@@ -327,6 +342,11 @@ func (m *memStore) cacheSet(string, []byte, time.Duration) error { return errNoS
 
 // cacheDel on memStore is a no-op (nothing cached to invalidate).
 func (m *memStore) cacheDel(string) error { return errNoSharedStore }
+
+// The capsule rendezvous is inert on memStore: no shared backend, so the broker uses its
+// per-instance capsuleStore map (single-instance / no-Valkey path).
+func (m *memStore) putCapsule(string, []byte, time.Duration) error { return errNoSharedStore }
+func (m *memStore) takeCapsule(string) ([]byte, bool, error)       { return nil, false, errNoSharedStore }
 
 // The counter / setIfAbsent primitives on memStore are all "unavailable" no-ops, so
 // every money/seed fast-path falls back to its Postgres-authoritative computation.
@@ -1182,6 +1202,54 @@ func (v *valkeyStore) cacheDel(key string) error {
 	}
 	v.setUp(true)
 	return nil
+}
+
+// capsuleKeyPrefix namespaces the content-blind capsule blobs under the shared keyspace so
+// they never collide with another project or with the rl:/node:/cache: keys. Every capsule
+// key is rogerai:cap:<lookup>. The value is opaque ciphertext; the broker never reads it.
+const capsuleKeyPrefix = keyPrefix + "cap:"
+
+// putCapsule SETs the opaque blob under the lookup with a TTL (atomic set+expire), so an
+// expired blob can never outlive its window. ttl<=0 is a no-op. Content-blind: only the
+// lookup + ciphertext are written.
+func (v *valkeyStore) putCapsule(lookup string, blob []byte, ttl time.Duration) error {
+	if v == nil || v.rdb == nil {
+		return errNoSharedStore
+	}
+	if ttl <= 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sharedOpTimeout)
+	defer cancel()
+	if err := v.rdb.Set(ctx, capsuleKeyPrefix+lookup, blob, ttl).Err(); err != nil {
+		v.noteErr("putCapsule", err)
+		return err
+	}
+	v.setUp(true)
+	return nil
+}
+
+// takeCapsule GETDELs the blob under the lookup: a single atomic get-and-delete, so exactly
+// one of N concurrent resolves (across all instances) gets the bytes and every later resolve
+// is a clean miss (delete-on-read, one-time). A miss (absent/expired) returns found=false
+// with a nil error so the handler returns the uniform 404 without logging a backend error.
+func (v *valkeyStore) takeCapsule(lookup string) ([]byte, bool, error) {
+	if v == nil || v.rdb == nil {
+		return nil, false, errNoSharedStore
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sharedOpTimeout)
+	defer cancel()
+	raw, err := v.rdb.GetDel(ctx, capsuleKeyPrefix+lookup).Bytes()
+	if err == redis.Nil {
+		v.setUp(true)
+		return nil, false, nil // clean miss / expired / already consumed
+	}
+	if err != nil {
+		v.noteErr("takeCapsule", err)
+		return nil, false, err
+	}
+	v.setUp(true)
+	return raw, true, nil
 }
 
 // counterKeyPrefix namespaces the numeric fast-path counters (the monthly-spend

--- a/cmd/rogerai-broker/sharedstore_cov_test.go
+++ b/cmd/rogerai-broker/sharedstore_cov_test.go
@@ -59,6 +59,11 @@ func TestValkeyDownedBackendErrorsExtra(t *testing.T) {
 	}
 	sharedErrWanted(t, "dropSharedNode", vs.dropSharedNode("p"))
 
+	sharedErrWanted(t, "putCapsule", vs.putCapsule("lk", []byte("blob"), time.Second))
+	if _, _, err := vs.takeCapsule("lk"); err == nil {
+		t.Error("takeCapsule against a dead backend should error")
+	}
+
 	sharedErrWanted(t, "markInflight", vs.markInflight("inst", "n", 3, time.Now()))
 	if _, err := vs.inflightByNode("inst"); err == nil {
 		t.Error("inflightByNode against a dead backend should error")

--- a/cmd/rogerai-broker/sharedstore_test.go
+++ b/cmd/rogerai-broker/sharedstore_test.go
@@ -50,11 +50,62 @@ func TestSharedStoreInterface(t *testing.T) {
 	if err := m.cacheSet("k", []byte("v"), time.Second); err == nil {
 		t.Error("memStore.cacheSet is a no-op and should report unavailable")
 	}
+	if err := m.putCapsule("lk", []byte("blob"), time.Minute); err == nil {
+		t.Error("memStore.putCapsule should report unavailable so the caller uses the local map")
+	}
+	if _, found, err := m.takeCapsule("lk"); found || err == nil {
+		t.Error("memStore.takeCapsule must be a miss with a non-nil error")
+	}
 	if m.healthy() {
 		t.Error("memStore is never healthy (no backend)")
 	}
 	if err := m.Close(); err != nil {
 		t.Errorf("memStore.Close: %v", err)
+	}
+}
+
+// TestValkeyCapsuleRoundTrip exercises the content-blind capsule rendezvous end-to-end on a
+// live backend: put stores the opaque blob namespaced under rogerai:cap:, takeCapsule GETDELs
+// it exactly once (one-time), a miss is (nil,false,nil), and the TTL expires the blob.
+func TestValkeyCapsuleRoundTrip(t *testing.T) {
+	vs, mr := newTestValkey(t)
+
+	// miss -> (nil,false,nil): a clean miss, no logged backend error.
+	if blob, found, err := vs.takeCapsule("absent"); found || err != nil || blob != nil {
+		t.Fatalf("miss = (%v,%v,%v), want (nil,false,nil)", blob, found, err)
+	}
+	// put then take returns the exact ciphertext ONCE.
+	want := []byte("opaque-ciphertext")
+	if err := vs.putCapsule("lk1", want, time.Minute); err != nil {
+		t.Fatalf("putCapsule: %v", err)
+	}
+	for _, k := range mr.Keys() { // shared-instance namespacing
+		if !strings.HasPrefix(k, capsuleKeyPrefix) {
+			t.Errorf("capsule key %q is NOT under %q", k, capsuleKeyPrefix)
+		}
+	}
+	got, found, err := vs.takeCapsule("lk1")
+	if err != nil || !found || string(got) != string(want) {
+		t.Fatalf("take = (%q,%v,%v), want (%q,true,nil)", got, found, err, want)
+	}
+	// one-time: a second take is a miss (delete-on-read).
+	if _, found, _ := vs.takeCapsule("lk1"); found {
+		t.Error("second takeCapsule must miss (one-time, delete-on-read)")
+	}
+	// ttl<=0 is a no-op.
+	if err := vs.putCapsule("noop", []byte("x"), 0); err != nil {
+		t.Errorf("putCapsule ttl<=0 should be a no-op nil, got %v", err)
+	}
+	if _, found, _ := vs.takeCapsule("noop"); found {
+		t.Error("putCapsule ttl<=0 must not write a key")
+	}
+	// TTL expiry -> miss.
+	if err := vs.putCapsule("lk2", want, 2*time.Second); err != nil {
+		t.Fatalf("putCapsule: %v", err)
+	}
+	mr.FastForward(3 * time.Second)
+	if _, found, _ := vs.takeCapsule("lk2"); found {
+		t.Error("capsule blob should have expired after its TTL")
 	}
 }
 

--- a/cmd/rogerai/context.go
+++ b/cmd/rogerai/context.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/json"
 	"flag"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/rogerai-fyi/roger/internal/capsule"
 	"github.com/rogerai-fyi/roger/internal/client"
+	"github.com/rogerai-fyi/roger/internal/protocol"
 )
 
 // context.go is the `roger context` verb group: portable signed context capsules
@@ -34,11 +36,15 @@ func cmdContext(cfg config, args []string) error {
 		return cmdContextExport(args[1:])
 	case "import":
 		return cmdContextImport(args[1:])
+	case "publish":
+		return cmdContextPublish(cfg, args[1:])
+	case "resolve":
+		return cmdContextResolve(cfg, args[1:])
 	case "-h", "--help", "help":
 		contextUsage()
 		return nil
 	default:
-		return fmt.Errorf("unknown context command %q (try export|import)", args[0])
+		return fmt.Errorf("unknown context command %q (try export|import|publish|resolve)", args[0])
 	}
 }
 
@@ -98,6 +104,83 @@ func cmdContextImport(args []string) error {
 	}
 	defer closeOut()
 	return contextImportMerge(in, base, w, client.LoadOrCreateUserKey())
+}
+
+// cmdContextPublish drives the ENCRYPTED STRANGER transport (Stage 3) from the CLI: it reads
+// a signed capsule (.rcap.json, from a file or stdin), MINTS it to the broker's content-blind
+// rendezvous under a FRESH one-time code (or --code), and prints the code for the DJ to hand
+// to the guest out-of-band. The redaction floor is enforced (client.PublishStrangerCapsule
+// refuses a non-summary capsule). The broker only ever stores {lookup, ciphertext}.
+func cmdContextPublish(cfg config, args []string) error {
+	fs := flag.NewFlagSet("context publish", flag.ExitOnError)
+	code := fs.String("code", "", "one-time code to seal under (default: a fresh code, printed)")
+	fs.Usage = contextPublishUsage
+	inPath, rest := leadingPositional(args)
+	fs.Parse(rest)
+	if inPath == "" {
+		inPath = fs.Arg(0)
+	}
+	if cfg.Broker == "" {
+		return fmt.Errorf("no broker configured (set one up with `roger` first)")
+	}
+	in, closeIn, err := openIn(inPath)
+	if err != nil {
+		return err
+	}
+	defer closeIn()
+	raw, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+	// a fresh code REUSES the 40-bit RC/band tail (no new code format).
+	full := *code
+	if full == "" {
+		full, _, _ = protocol.NewRCLinkCode()
+	}
+	if err := client.PublishStrangerCapsule(cfg.Broker, full, raw); err != nil {
+		return err
+	}
+	fmt.Printf("published · hand this one-time code to the guest (expires in 10 min, single use):\n\n  %s\n\nthe guest runs: roger context resolve \"%s\"\n", full, full)
+	return nil
+}
+
+// cmdContextResolve is the guest/receiver side: it RESOLVES the sealed capsule for a code from
+// the broker (one-time, delete-on-read), OPENS it with the code, verifies the owner signature,
+// and prints a summary - or with --into append-only merges it into a base thread. A gone/
+// expired/wrong-code resolve is reported as such (the broker gives no existence oracle).
+func cmdContextResolve(cfg config, args []string) error {
+	fs := flag.NewFlagSet("context resolve", flag.ExitOnError)
+	into := fs.String("into", "", "base capsule to append-only merge the resolved one into (.rcap.json)")
+	out := fs.String("o", "-", "output file for the merged capsule (default: stdout; --into only)")
+	fs.Usage = contextResolveUsage
+	codeArg, rest := leadingPositional(args)
+	fs.Parse(rest)
+	if codeArg == "" {
+		codeArg = fs.Arg(0)
+	}
+	if cfg.Broker == "" {
+		return fmt.Errorf("no broker configured (set one up with `roger` first)")
+	}
+	if codeArg == "" {
+		return fmt.Errorf("a one-time code is required (roger context resolve \"<code>\")")
+	}
+	raw, err := client.FetchCapsule(cfg.Broker, codeArg)
+	if err != nil {
+		return err
+	}
+	if *into == "" {
+		return contextImportSummary(bytes.NewReader(raw), os.Stdout)
+	}
+	base, err := os.ReadFile(*into)
+	if err != nil {
+		return err
+	}
+	w, closeOut, err := openOut(*out)
+	if err != nil {
+		return err
+	}
+	defer closeOut()
+	return contextImportMerge(bytes.NewReader(raw), base, w, client.LoadOrCreateUserKey())
 }
 
 // contextExport reads a draft capsule JSON from in, signs it with priv (stamping
@@ -246,14 +329,42 @@ the merged capsule is re-signed with your key.
 `)
 }
 
+func contextPublishUsage() {
+	fmt.Print(`roger context publish - hand a summary capsule to a stranger over the broker
+
+  roger context publish convo.rcap.json               seal + mint under a fresh one-time code
+  roger context publish convo.rcap.json --code "..."   seal + mint under a supplied code
+
+The capsule is encrypted client-side under a one-time code and stored on the broker as an
+opaque blob (the broker never sees the code, the key, or the plaintext). It must be
+summary-only (a full capsule is refused). Hand the printed code to the guest out-of-band;
+they run 'roger context resolve'. The blob is single-use and expires in 10 minutes.
+`)
+}
+
+func contextResolveUsage() {
+	fmt.Print(`roger context resolve - fetch + open a stranger capsule by its one-time code
+
+  roger context resolve "147.520 MHz · 8F3K-9M2Q"                    verify + print a summary
+  roger context resolve "<code>" --into mine.rcap.json -o merged.rcap.json
+
+Resolve fetches the sealed blob ONCE (delete-on-read), opens it with the code, and verifies
+the owner signature. With --into, the turns are APPENDED (never replace/truncate) to the base
+thread and the merged capsule is re-signed with your key. A wrong/expired/used code is gone.
+`)
+}
+
 func contextUsage() {
 	fmt.Print(`roger context - carry a conversation across operators (roger.context.v1)
 
   roger context export draft.json -o convo.rcap.json   sign a portable context capsule
   roger context import convo.rcap.json                 verify a capsule + print a summary
   roger context import guest.rcap.json --into mine.rcap.json -o merged.rcap.json
+  roger context publish convo.rcap.json                seal + mint to a stranger (one-time code)
+  roger context resolve "<code>"                       fetch + open a stranger capsule
 
 A capsule is a signed, portable snapshot of a thread. Import verifies the owner
-signature and merges APPEND-ONLY (a handoff never erases context).
+signature and merges APPEND-ONLY (a handoff never erases context). publish/resolve carry it
+encrypted over the broker's content-blind one-time-code rendezvous.
 `)
 }

--- a/cmd/rogerai/context_stranger_test.go
+++ b/cmd/rogerai/context_stranger_test.go
@@ -1,0 +1,139 @@
+package main
+
+// context_stranger_test.go drives the CLI `roger context publish|resolve` verbs (Stage 3) end
+// to end through a content-blind rendezvous stub: publish a summary capsule, scrape the
+// printed one-time code, resolve it back. REAL seal/open crypto; the stub is only the store.
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/capsule"
+)
+
+func rendezvousServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	store := map[string]string{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/capsule", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct{ Lookup, Blob string }
+		_ = json.Unmarshal(body, &req)
+		mu.Lock()
+		store[req.Lookup] = req.Blob
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	mux.HandleFunc("/capsule/resolve", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct{ Lookup string }
+		_ = json.Unmarshal(body, &req)
+		mu.Lock()
+		blob, ok := store[req.Lookup]
+		delete(store, req.Lookup)
+		mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"no such capsule"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"blob": blob})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// summaryCapsuleFile writes a signed summary-only capsule and returns its path.
+func summaryCapsuleFile(t *testing.T) string {
+	t.Helper()
+	d := capsule.SummaryOnly(capsule.Draft{
+		ID:        "cap_cli",
+		Thread:    capsule.Thread{OriginThreadID: "t1", BaseWatermark: 1},
+		Redaction: "full",
+		Messages:  []capsule.Message{{Role: "user", Content: "current", XRoger: capsule.XRoger{Turn: 0, Agent: "user"}}},
+	})
+	c, err := capsule.Export(d, ephemeralKey(t), "roger-cli", func() int64 { return 100 })
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := c.Marshal()
+	p := filepath.Join(t.TempDir(), "convo.rcap.json")
+	if err := os.WriteFile(p, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+var codeLine = regexp.MustCompile(`(?m)^\s{2}(\S.*\S)\s*$`)
+
+func TestContextPublishResolveRoundTrip(t *testing.T) {
+	srv := rendezvousServer(t)
+	cfg := config{Broker: srv.URL}
+	file := summaryCapsuleFile(t)
+
+	out, err := captureCtxStdout(func() error { return cmdContext(cfg, []string{"publish", file}) })
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	// scrape the printed one-time code (the indented line).
+	var code string
+	for _, m := range codeLine.FindAllStringSubmatch(out, -1) {
+		if strings.Contains(m[1], "MHz") {
+			code = m[1]
+			break
+		}
+	}
+	if code == "" {
+		t.Fatalf("publish did not print a code:\n%s", out)
+	}
+
+	sum, err := captureCtxStdout(func() error { return cmdContext(cfg, []string{"resolve", code}) })
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !strings.Contains(sum, "verified capsule") || !strings.Contains(sum, "redaction=summary") {
+		t.Fatalf("resolve summary unexpected:\n%s", sum)
+	}
+	// one-time: a second resolve of the same code is gone.
+	if _, err := captureCtxStdout(func() error { return cmdContext(cfg, []string{"resolve", code}) }); err == nil {
+		t.Fatal("second resolve must fail (one-time, delete-on-read)")
+	}
+}
+
+func TestContextPublishRefusesFull(t *testing.T) {
+	srv := rendezvousServer(t)
+	cfg := config{Broker: srv.URL}
+	// a FULL capsule file must be refused by publish (redaction floor).
+	c, _ := capsule.Export(capsule.Draft{
+		ID: "cap_full", Thread: capsule.Thread{BaseWatermark: 1}, Redaction: "full",
+		Messages: []capsule.Message{{Role: "user", Content: "x", XRoger: capsule.XRoger{Turn: 0}}},
+	}, ephemeralKey(t), "roger-cli", func() int64 { return 100 })
+	raw, _ := c.Marshal()
+	p := filepath.Join(t.TempDir(), "full.rcap.json")
+	_ = os.WriteFile(p, raw, 0o600)
+	if _, err := captureCtxStdout(func() error { return cmdContext(cfg, []string{"publish", p}) }); err == nil {
+		t.Fatal("publishing a full capsule to a stranger must be refused")
+	}
+}
+
+func TestContextPublishResolveNeedBroker(t *testing.T) {
+	if err := cmdContext(config{}, []string{"publish", "x.json"}); err == nil {
+		t.Error("publish without a broker must error")
+	}
+	if err := cmdContext(config{}, []string{"resolve", "somecode"}); err == nil {
+		t.Error("resolve without a broker must error")
+	}
+	if err := cmdContext(config{Broker: "http://x"}, []string{"resolve"}); err == nil {
+		t.Error("resolve without a code must error")
+	}
+}

--- a/features/capsule/broker_rendezvous.feature
+++ b/features/capsule/broker_rendezvous.feature
@@ -1,0 +1,55 @@
+Feature: Content-blind broker rendezvous (Stage 3, broker half)
+  The broker is a content-blind one-time-code rendezvous for the encrypted stranger capsule.
+  It stores ONLY {lookup, ciphertext}: never the code, never the key, never the plaintext.
+  A mint is owner-signed (attribution / rate-limiting); a resolve is authed by possession of
+  the lookup and returns the blob exactly ONCE. Every miss/expired/garbage resolve is a
+  byte-identical 404 (no existence oracle). The store is SHARED so a mint on one instance
+  resolves on another, and a blob is consumed atomically exactly once across instances.
+
+  Scenario: Mint then resolve round-trips the opaque blob once
+    Given a signed capsule mint of an opaque blob under a lookup
+    When I resolve that lookup
+    Then the resolve returns the exact blob
+    And a second resolve of the same lookup is a uniform 404
+
+  Scenario: The broker cannot decrypt what it stores
+    Given a stranger capsule sealed under a code and minted under its lookup
+    Then the broker holds only the lookup and the ciphertext
+    And the broker has neither the code nor the key
+    And the broker cannot recover the plaintext from what it stores
+
+  Scenario: An unknown lookup and an empty lookup are the identical 404
+    When I resolve an unknown lookup
+    And I resolve an empty lookup
+    Then both are a 404 with byte-identical bodies
+
+  Scenario: An expired blob resolves to a 404
+    Given a blob minted with an already-expired TTL
+    When I resolve its lookup
+    Then the resolve is a uniform 404
+
+  Scenario: An oversize blob is refused at mint
+    Given a signed capsule mint of a blob larger than the cap
+    Then the mint is refused as too-large
+    And nothing is stored under its lookup
+
+  Scenario: An unsigned mint is rejected and stores nothing
+    Given an UNSIGNED capsule mint under a lookup
+    Then the mint is rejected as unauthorized
+    And resolving that lookup is a uniform 404
+
+  Scenario: Multi-instance - mint on A resolves on B
+    Given two broker instances sharing one store
+    When I mint a blob on instance A under a lookup
+    And I resolve that lookup on instance B
+    Then the resolve on B returns the exact blob
+
+  Scenario: Multi-instance single-use - two concurrent resolves, exactly one wins
+    Given two broker instances sharing one store
+    And a blob minted under a lookup
+    When both instances resolve the same lookup concurrently
+    Then exactly one resolve returns the blob and the other is a 404
+
+  Scenario: The code and plaintext are never logged or persisted
+    Given a stranger capsule sealed under a code and minted under its lookup
+    Then no stored value and no log line contains the code or the plaintext

--- a/features/capsule/stranger_transport.feature
+++ b/features/capsule/stranger_transport.feature
@@ -1,0 +1,68 @@
+Feature: Encrypted stranger transport (Stage 3, client crypto)
+  A conversation handed to a MARKETPLACE / STRANGER operator rides as a summary-only,
+  owner-signed capsule, encrypted client-side under a one-time code and stored on the broker
+  as an opaque blob. The code (never the bytes, never the key) travels the reference channel.
+  The encryption key is HKDF-derived from the code and DOMAIN-SEPARATED from the broker lookup,
+  so the broker is content-blind by construction.
+
+  Background:
+    Given a fresh operator keypair
+
+  Scenario: Round-trip a summary-only capsule under a code
+    Given a signed summary-only capsule for a stranger
+    When I seal it for a fresh code and open it with the same code
+    Then the opened capsule verifies
+    And the opened capsule redaction is "summary"
+
+  Scenario: The wrong code recovers no plaintext
+    Given a signed summary-only capsule for a stranger
+    When I seal it for a fresh code
+    And I open it with a different code
+    Then opening fails and yields no plaintext
+
+  Scenario: A flipped ciphertext byte fails the GCM tag
+    Given a signed summary-only capsule for a stranger
+    When I seal it for a fresh code
+    And I flip a byte of the sealed blob
+    Then opening fails and yields no plaintext
+
+  Scenario: A truncated blob is rejected, never a panic
+    Given a signed summary-only capsule for a stranger
+    When I seal it for a fresh code
+    And I truncate the sealed blob to the nonce length
+    Then opening fails and yields no plaintext
+
+  Scenario: A decrypt-valid but signature-tampered capsule still fails ed25519
+    Given a signed summary-only capsule for a stranger
+    When I tamper the capsule body then seal it for a fresh code
+    And I open it with the same code
+    Then the opened bytes decrypt but fail verification on merge
+
+  Scenario: The encryption key is domain-separated from the broker lookup
+    When I seal any capsule for a fresh code
+    Then the derived key does not equal the broker lookup
+    And the broker lookup is the sha256 of the canonical code tail
+    And from the lookup and the blob alone the plaintext is unrecoverable without the code
+
+  Scenario: The redaction floor holds - a stranger capsule is summary-only
+    Given a full-transcript conversation with memory and many turns
+    When I build the stranger capsule
+    Then the stranger capsule redaction is "summary"
+    And it carries only the current turn and no memory
+
+  Scenario: The handing side refuses to seal a full capsule for a stranger
+    Given a signed FULL capsule
+    When I try to seal it for a stranger under a fresh code
+    Then sealing is refused as full-not-allowed-for-stranger
+
+  Scenario: Verify-before-merge survives the decrypt path
+    Given a signed summary-only capsule for a stranger
+    When I seal it for a fresh code and open it with the same code
+    And I merge the opened capsule into a fresh thread
+    Then the merge succeeds and appends the turn append-only
+
+  Scenario: Recall rides back under a FRESH code (no key reuse)
+    Given a stranger capsule sealed under an outbound code
+    When the guest returns a capsule sealed under a fresh recall code
+    Then the recall code differs from the outbound code
+    And opening the recall with the outbound code fails

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,10 @@ require (
 	github.com/google/go-sev-guest v0.15.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/mattn/go-isatty v0.0.20
+	github.com/muesli/termenv v0.16.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/tiktoken-go/tokenizer v0.6.1
+	golang.org/x/crypto v0.17.0
 	golang.org/x/sync v0.17.0
 	golang.org/x/text v0.29.0
 )
@@ -52,14 +54,12 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/internal/capsule/stranger_transport_bdd_test.go
+++ b/internal/capsule/stranger_transport_bdd_test.go
@@ -1,0 +1,379 @@
+package capsule
+
+// stranger_transport_bdd_test.go makes features/capsule/stranger_transport.feature EXECUTABLE
+// under godog: the client-side seal/open, the redaction floor + full-refusal, and that a
+// decrypt-valid but tamper-signed capsule still fails verify-before-merge. REAL ed25519 + AES-
+// GCM/HKDF, no mocks.
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+type strangerBDD struct {
+	priv        ed25519.PrivateKey
+	capsuleJSON []byte // the signed summary-only capsule (wire JSON)
+	code        string
+	blob        []byte
+	opened      []byte
+	openErr     error
+	sealErr     error
+	built       Capsule
+	recall      string
+	recallBlob  []byte
+	openTried   bool
+}
+
+// --- key domain-separation steps (the load-bearing invariant) ---
+
+func (s *strangerBDD) keyNeqLookup() error {
+	key := transportKey(s.code)
+	lookup := TransportLookup(s.code)
+	if len(key) != 32 {
+		return bddErrf("key length %d, want 32", len(key))
+	}
+	if bytes.Equal([]byte(lookup), key) {
+		return bddErrf("key equals lookup (not domain-separated)")
+	}
+	return nil
+}
+
+func (s *strangerBDD) lookupIsSha256Tail() error {
+	if TransportLookup(s.code) != protocol.BandCodeHash(s.code) {
+		return bddErrf("lookup is not BandCodeHash(code)")
+	}
+	return nil
+}
+
+func (s *strangerBDD) unrecoverableWithoutCode() error {
+	lookup := TransportLookup(s.code)
+	if _, err := OpenWithCode(s.blob, lookup); err == nil {
+		return bddErrf("the lookup opened the blob (broker could decrypt)")
+	}
+	if _, err := OpenWithCode(s.blob, ""); err == nil {
+		return bddErrf("an empty code opened the blob")
+	}
+	return nil
+}
+
+
+func (s *strangerBDD) freshKeypair() error {
+	_, s.priv, _ = ed25519.GenerateKey(nil)
+	return nil
+}
+
+// signedSummaryCapsule builds a signed summary-only capsule (one turn, no memory).
+func (s *strangerBDD) signedSummaryCapsule() error {
+	d := SummaryOnly(Draft{
+		ID:        "cap_s",
+		Thread:    Thread{OriginThreadID: "t1", BaseWatermark: 3},
+		Redaction: "full",
+		Memory:    Memory{Notes: "should-be-dropped", Facts: []string{"secret"}},
+		Messages: []Message{
+			{Role: "user", Content: "old-1", XRoger: XRoger{Turn: 0}},
+			{Role: "assistant", Content: "old-2", XRoger: XRoger{Turn: 1}},
+			{Role: "user", Content: "current-turn", XRoger: XRoger{Turn: 2}},
+		},
+	})
+	c, err := Export(d, s.priv, "roger-cli", func() int64 { return 100 })
+	if err != nil {
+		return err
+	}
+	s.built = c
+	raw, err := c.Marshal()
+	s.capsuleJSON = raw
+	return err
+}
+
+func (s *strangerBDD) signedFullCapsule() error {
+	d := Draft{
+		ID:        "cap_f",
+		Thread:    Thread{OriginThreadID: "t1", BaseWatermark: 1},
+		Redaction: "full",
+		Messages:  []Message{{Role: "user", Content: "full-body", XRoger: XRoger{Turn: 0}}},
+	}
+	c, err := Export(d, s.priv, "roger-cli", func() int64 { return 100 })
+	if err != nil {
+		return err
+	}
+	s.capsuleJSON, err = c.Marshal()
+	return err
+}
+
+func (s *strangerBDD) fullTranscriptConversation() error {
+	// a "full" draft with memory + many turns, pre-redaction.
+	s.built = Capsule{}
+	d := Draft{
+		ID:        "cap_full",
+		Thread:    Thread{OriginThreadID: "t1", BaseWatermark: 4},
+		Redaction: "full",
+		Memory:    Memory{Notes: "notes", Facts: []string{"f1", "f2"}},
+		Messages: []Message{
+			{Role: "user", Content: "t0", XRoger: XRoger{Turn: 0}},
+			{Role: "assistant", Content: "t1", XRoger: XRoger{Turn: 1}},
+			{Role: "user", Content: "t2", XRoger: XRoger{Turn: 2}},
+			{Role: "assistant", Content: "t3-current", XRoger: XRoger{Turn: 3}},
+		},
+	}
+	c, err := Export(SummaryOnly(d), s.priv, "roger-cli", func() int64 { return 100 })
+	if err != nil {
+		return err
+	}
+	s.built = c
+	return nil
+}
+
+func (s *strangerBDD) sealAnyForFreshCode() error {
+	s.code, _, _ = protocol.NewRCLinkCode()
+	blob, err := SealForCode([]byte(`{"capsule":"roger.context.v1","redaction":"summary"}`), s.code)
+	s.blob = blob
+	return err
+}
+
+func (s *strangerBDD) sealForFreshCode() error {
+	s.code, _, _ = protocol.NewRCLinkCode()
+	blob, err := SealForStranger(s.capsuleJSON, s.code)
+	s.blob = blob
+	return err
+}
+
+func (s *strangerBDD) sealAndOpenSameCode() error {
+	if err := s.sealForFreshCode(); err != nil {
+		return err
+	}
+	s.opened, s.openErr = OpenWithCode(s.blob, s.code)
+	return s.openErr
+}
+
+func (s *strangerBDD) openSameCode() error {
+	s.opened, s.openErr = OpenWithCode(s.blob, s.code)
+	s.openTried = true
+	return nil
+}
+
+func (s *strangerBDD) openDifferentCode() error {
+	other, _, _ := protocol.NewRCLinkCode()
+	s.opened, s.openErr = OpenWithCode(s.blob, other)
+	s.openTried = true
+	return nil
+}
+
+func (s *strangerBDD) flipAByte() error {
+	s.blob[len(s.blob)-1] ^= 0x01
+	return nil
+}
+
+func (s *strangerBDD) truncateToNonce() error {
+	s.blob = s.blob[:12]
+	return nil
+}
+
+func (s *strangerBDD) tamperThenSeal() error {
+	// tamper the SIGNED body then seal: decrypt will succeed, verify must fail.
+	tampered := bytes.Replace(s.capsuleJSON, []byte("current-turn"), []byte("HIJACKED-TURN"), 1)
+	s.code, _, _ = protocol.NewRCLinkCode()
+	blob, err := SealForCode(tampered, s.code) // SealForCode, not SealForStranger (redaction still summary)
+	s.blob = blob
+	return err
+}
+
+func (s *strangerBDD) tryStrangerSeal() error {
+	s.code, _, _ = protocol.NewRCLinkCode()
+	_, s.sealErr = SealForStranger(s.capsuleJSON, s.code)
+	return nil
+}
+
+func (s *strangerBDD) buildStrangerCapsule() error { return s.fullTranscriptConversation() }
+
+// --- Then ---
+
+func (s *strangerBDD) openedVerifies() error {
+	if s.openErr != nil {
+		return bddErrf("open failed: %v", s.openErr)
+	}
+	c, err := Import(s.opened)
+	if err != nil {
+		return bddErrf("opened capsule does not import/verify: %v", err)
+	}
+	s.built = c
+	return nil
+}
+
+func (s *strangerBDD) openedRedactionIs(want string) error {
+	c, err := Import(s.opened)
+	if err != nil {
+		return err
+	}
+	if c.Redaction != want {
+		return bddErrf("redaction=%q want %q", c.Redaction, want)
+	}
+	return nil
+}
+
+func (s *strangerBDD) openFailsNoPlaintext() error {
+	// scenarios that flip/truncate the blob have no explicit open step: perform the open
+	// here (with the correct code) so the assertion is that a MANGLED blob cannot be opened.
+	if !s.openTried {
+		s.opened, s.openErr = OpenWithCode(s.blob, s.code)
+	}
+	if s.openErr == nil {
+		return bddErrf("open unexpectedly succeeded (plaintext leaked)")
+	}
+	if len(s.opened) != 0 {
+		return bddErrf("open returned bytes on failure")
+	}
+	return nil
+}
+
+func (s *strangerBDD) decryptOKButVerifyFails() error {
+	if s.openErr != nil {
+		return bddErrf("decrypt should succeed (valid GCM): %v", s.openErr)
+	}
+	// the bytes decrypt, but merging must reject on the ed25519 signature.
+	_, err := Merge(mustImportRaw(s.opened), Capsule{Capsule: Version, Thread: Thread{BaseWatermark: 0}})
+	if err != ErrUnverified {
+		return bddErrf("merge err = %v, want ErrUnverified (tamper must fail verify-before-merge)", err)
+	}
+	return nil
+}
+
+func (s *strangerBDD) mergeSucceedsAppendOnly() error {
+	incoming, err := Import(s.opened)
+	if err != nil {
+		return err
+	}
+	out, err := Merge(incoming, Capsule{Capsule: Version, Thread: Thread{BaseWatermark: incoming.Messages[0].XRoger.Turn}})
+	if err != nil {
+		return bddErrf("merge failed: %v", err)
+	}
+	if len(out.Messages) == 0 {
+		return bddErrf("merge appended nothing")
+	}
+	return nil
+}
+
+func (s *strangerBDD) strangerRedactionSummary() error {
+	if s.built.Redaction != "summary" {
+		return bddErrf("stranger capsule redaction=%q want summary", s.built.Redaction)
+	}
+	return nil
+}
+
+func (s *strangerBDD) onlyCurrentTurnNoMemory() error {
+	if len(s.built.Messages) != 1 {
+		return bddErrf("stranger capsule carries %d turns, want 1 (current only)", len(s.built.Messages))
+	}
+	if s.built.Memory.Notes != "" || len(s.built.Memory.Facts) != 0 {
+		return bddErrf("stranger capsule still carries memory")
+	}
+	return nil
+}
+
+func (s *strangerBDD) sealRefusedFull() error {
+	if s.sealErr != ErrNotSummary {
+		return bddErrf("seal err = %v, want ErrNotSummary", s.sealErr)
+	}
+	return nil
+}
+
+// --- recall (fresh code) ---
+
+func (s *strangerBDD) sealedUnderOutbound() error {
+	s.code, _, _ = protocol.NewRCLinkCode()
+	blob, err := SealForCode([]byte(`{"capsule":"roger.context.v1","redaction":"summary"}`), s.code)
+	s.blob = blob
+	return err
+}
+
+func (s *strangerBDD) guestReturnsFreshRecall() error {
+	recallCode, _, _ := protocol.NewRCLinkCode()
+	if recallCode == s.code {
+		return bddErrf("recall code collided with outbound (no fresh code)")
+	}
+	s.recall = recallCode
+	blob, err := SealForCode([]byte(`{"capsule":"roger.context.v1","redaction":"summary"}`), recallCode)
+	s.recallBlob = blob
+	return err
+}
+
+func (s *strangerBDD) recallDiffersFromOutbound() error {
+	if s.recall == s.code {
+		return bddErrf("recall code equals outbound code")
+	}
+	if protocol.BandCodeHash(s.recall) == protocol.BandCodeHash(s.code) {
+		return bddErrf("recall lookup equals outbound lookup (key reuse)")
+	}
+	return nil
+}
+
+func (s *strangerBDD) openRecallWithOutboundFails() error {
+	if _, err := OpenWithCode(s.recallBlob, s.code); err == nil {
+		return bddErrf("the outbound code opened the recall blob (key reuse)")
+	}
+	return nil
+}
+
+func mustImportRaw(raw []byte) Capsule {
+	var c Capsule
+	_ = json.Unmarshal(raw, &c)
+	return c
+}
+
+func TestStrangerTransportBDD(t *testing.T) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			st := &strangerBDD{}
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				*st = strangerBDD{}
+				return ctx, nil
+			})
+			sc.Step(`^a fresh operator keypair$`, st.freshKeypair)
+			sc.Step(`^a signed summary-only capsule for a stranger$`, st.signedSummaryCapsule)
+			sc.Step(`^a signed FULL capsule$`, st.signedFullCapsule)
+			sc.Step(`^a full-transcript conversation with memory and many turns$`, st.fullTranscriptConversation)
+			sc.Step(`^a stranger capsule sealed under an outbound code$`, st.sealedUnderOutbound)
+
+			sc.Step(`^I seal it for a fresh code and open it with the same code$`, st.sealAndOpenSameCode)
+			sc.Step(`^I seal it for a fresh code$`, st.sealForFreshCode)
+			sc.Step(`^I seal any capsule for a fresh code$`, st.sealAnyForFreshCode)
+			sc.Step(`^I open it with the same code$`, st.openSameCode)
+			sc.Step(`^I open it with a different code$`, st.openDifferentCode)
+			sc.Step(`^I flip a byte of the sealed blob$`, st.flipAByte)
+			sc.Step(`^I truncate the sealed blob to the nonce length$`, st.truncateToNonce)
+			sc.Step(`^I tamper the capsule body then seal it for a fresh code$`, st.tamperThenSeal)
+			sc.Step(`^I merge the opened capsule into a fresh thread$`, func() error { return nil })
+			sc.Step(`^I build the stranger capsule$`, st.buildStrangerCapsule)
+			sc.Step(`^I try to seal it for a stranger under a fresh code$`, st.tryStrangerSeal)
+			sc.Step(`^the guest returns a capsule sealed under a fresh recall code$`, st.guestReturnsFreshRecall)
+
+			sc.Step(`^the opened capsule verifies$`, st.openedVerifies)
+			sc.Step(`^the opened capsule redaction is "([^"]*)"$`, st.openedRedactionIs)
+			sc.Step(`^opening fails and yields no plaintext$`, st.openFailsNoPlaintext)
+			sc.Step(`^the opened bytes decrypt but fail verification on merge$`, st.decryptOKButVerifyFails)
+			sc.Step(`^the derived key does not equal the broker lookup$`, st.keyNeqLookup)
+			sc.Step(`^the broker lookup is the sha256 of the canonical code tail$`, st.lookupIsSha256Tail)
+			sc.Step(`^from the lookup and the blob alone the plaintext is unrecoverable without the code$`, st.unrecoverableWithoutCode)
+			sc.Step(`^the stranger capsule redaction is "([^"]*)"$`, func(string) error { return st.strangerRedactionSummary() })
+			sc.Step(`^it carries only the current turn and no memory$`, st.onlyCurrentTurnNoMemory)
+			sc.Step(`^sealing is refused as full-not-allowed-for-stranger$`, st.sealRefusedFull)
+			sc.Step(`^the merge succeeds and appends the turn append-only$`, st.mergeSucceedsAppendOnly)
+			sc.Step(`^the recall code differs from the outbound code$`, st.recallDiffersFromOutbound)
+			sc.Step(`^opening the recall with the outbound code fails$`, st.openRecallWithOutboundFails)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/capsule/stranger_transport.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("stranger transport scenarios failed (see godog output above)")
+	}
+}

--- a/internal/capsule/transport.go
+++ b/internal/capsule/transport.go
@@ -22,6 +22,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"io"
 
@@ -44,7 +45,27 @@ var (
 	// authentication fails (wrong code / tamper). One error for both so open leaks nothing
 	// about which failed.
 	ErrBadBlob = errors.New("capsule: sealed blob invalid or wrong code")
+	// ErrNotSummary rejects sealing a non-summary (full) capsule for a stranger: the
+	// redaction floor. A marketplace/stranger handoff may only carry a summary-only capsule.
+	ErrNotSummary = errors.New("capsule: refusing to seal a non-summary capsule for a stranger")
 )
+
+// SealForStranger enforces the redaction FLOOR before sealing: a capsule handed to a
+// marketplace/stranger operator MUST be summary-only (redaction=="summary"). It refuses any
+// full/other capsule (ErrNotSummary) before it touches the code, so a stranger transport can
+// never carry a full transcript even if a caller forgets to redact. capsuleJSON is the signed
+// wire object; the redaction level is signed, so this checks the same field the signature
+// covers. On acceptance it seals under code exactly like SealForCode.
+func SealForStranger(capsuleJSON []byte, code string) ([]byte, error) {
+	var c Capsule
+	if err := json.Unmarshal(capsuleJSON, &c); err != nil {
+		return nil, err
+	}
+	if c.Redaction != "summary" {
+		return nil, ErrNotSummary
+	}
+	return SealForCode(capsuleJSON, code)
+}
 
 // TransportLookup is the broker lookup key for a code: BandCodeHash(code) = sha256 over the
 // canonical secret tail (hex). It is what the client sends to mint/resolve; it is DISTINCT

--- a/internal/capsule/transport.go
+++ b/internal/capsule/transport.go
@@ -1,0 +1,121 @@
+package capsule
+
+// transport.go is the CLIENT half of the encrypted stranger transport (Stage 3): it seals a
+// signed, redacted capsule under a one-time CODE and opens it with the same code. The broker
+// (cmd/rogerai-broker/capsule.go) only ever stores {lookup, ciphertext} and does ZERO crypto.
+//
+// THE LOAD-BEARING CONTENT-BLIND INVARIANT: the encryption KEY is DOMAIN-SEPARATED from the
+// broker LOOKUP. Both derive from the code, but:
+//
+//	lookup = BandCodeHash(code)                       = sha256(canonical tail)   [sent to broker]
+//	key    = HKDF-SHA256(ikm=CanonicalBandTail(code),                            [never sent]
+//	                     salt="rogerai-capsule-transport-v1",
+//	                     info=BandCodeHash(code))[:32]
+//
+// The IKM is the SECRET tail; the lookup is a one-way hash of that tail. Knowing the lookup
+// (all the broker holds) reveals neither the tail nor the key, so from {lookup, ciphertext}
+// the plaintext is unrecoverable without the raw code. key != lookup by construction
+// (transport_test.go pins this). The code REUSES the 40-bit RC/band tail - no new code format.
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"io"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"golang.org/x/crypto/hkdf"
+)
+
+// transportSalt is the fixed HKDF salt, versioned so a future key-derivation change is a new
+// namespace (an old blob never opens under a new scheme). It is NOT secret.
+const transportSalt = "rogerai-capsule-transport-v1"
+
+// transportKeyLen is the AES-256 key length.
+const transportKeyLen = 32
+
+var (
+	// ErrNoCode rejects a seal/open whose code carries no valid Crockford tail (no key
+	// material). Terse by design (public repo).
+	ErrNoCode = errors.New("capsule: code has no valid tail")
+	// ErrBadBlob rejects a sealed blob too short to carry a nonce + GCM tag, or one whose
+	// authentication fails (wrong code / tamper). One error for both so open leaks nothing
+	// about which failed.
+	ErrBadBlob = errors.New("capsule: sealed blob invalid or wrong code")
+)
+
+// TransportLookup is the broker lookup key for a code: BandCodeHash(code) = sha256 over the
+// canonical secret tail (hex). It is what the client sends to mint/resolve; it is DISTINCT
+// from the encryption key (which HKDFs over the tail with this as info). An empty/tail-less
+// code hashes the empty string, which never matches a minted blob.
+func TransportLookup(code string) string { return protocol.BandCodeHash(code) }
+
+// transportKey derives the 32-byte AES-256-GCM key from the code via HKDF-SHA256 over the
+// canonical tail (the secret), domain-separated from the lookup by the salt+info. It returns
+// nil for a code with no valid tail (SealForCode/OpenWithCode reject that as ErrNoCode).
+func transportKey(code string) []byte {
+	tail := protocol.CanonicalBandTail(code)
+	if tail == "" {
+		return nil
+	}
+	info := []byte(protocol.BandCodeHash(code)) // public; binds the key to this exact lookup
+	r := hkdf.New(sha256.New, []byte(tail), []byte(transportSalt), info)
+	key := make([]byte, transportKeyLen)
+	if _, err := io.ReadFull(r, key); err != nil {
+		return nil // HKDF over sha256 never under-delivers 32 bytes; defensive only
+	}
+	return key
+}
+
+// newGCM builds the AES-256-GCM AEAD for a code, or an error for a tail-less code.
+func newGCM(code string) (cipher.AEAD, error) {
+	key := transportKey(code)
+	if key == nil {
+		return nil, ErrNoCode
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+// SealForCode encrypts plaintext under the code with AES-256-GCM: a fresh random 12-byte
+// nonce is PREPENDED to the ciphertext (mirroring report.go encryptCSAM), and the AAD is the
+// broker lookup (BandCodeHash) so a blob cannot be spliced under a different code. Returns
+// ErrNoCode for a code with no valid tail.
+func SealForCode(plaintext []byte, code string) ([]byte, error) {
+	gcm, err := newGCM(code)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	aad := []byte(TransportLookup(code))
+	return gcm.Seal(nonce, nonce, plaintext, aad), nil
+}
+
+// OpenWithCode reverses SealForCode: it splits the prepended nonce, then AES-256-GCM-opens
+// the remainder with the code-derived key and the lookup AAD. Any failure (too-short blob,
+// wrong code, tamper) returns ErrBadBlob and never panics - the plaintext is unrecoverable.
+func OpenWithCode(blob []byte, code string) ([]byte, error) {
+	gcm, err := newGCM(code)
+	if err != nil {
+		return nil, err
+	}
+	ns := gcm.NonceSize()
+	if len(blob) < ns+gcm.Overhead() {
+		return nil, ErrBadBlob // no room for a nonce + a GCM tag
+	}
+	nonce, ct := blob[:ns], blob[ns:]
+	aad := []byte(TransportLookup(code))
+	pt, err := gcm.Open(nil, nonce, ct, aad)
+	if err != nil {
+		return nil, ErrBadBlob
+	}
+	return pt, nil
+}

--- a/internal/capsule/transport_test.go
+++ b/internal/capsule/transport_test.go
@@ -1,0 +1,195 @@
+package capsule
+
+// transport_test.go pins the client-side encrypted stranger transport (Stage 3): the
+// HKDF-SHA256 key derivation, the AES-256-GCM seal/open, and - the load-bearing security
+// claim - that the encryption KEY is DOMAIN-SEPARATED from the broker LOOKUP. Real crypto,
+// no mocks. Whitebox (package capsule) so it can assert transportKey vs TransportLookup.
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// testCode mints a plausible reused RC/band code (40-bit Crockford tail); the transport
+// never invents a new code format.
+func testCode(t *testing.T) string {
+	t.Helper()
+	code, _, tail := protocol.NewRCLinkCode()
+	if tail == "" {
+		t.Fatal("mint produced a codeless tail")
+	}
+	return code
+}
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	code := testCode(t)
+	plain := []byte(`{"capsule":"roger.context.v1","redaction":"summary"}`)
+
+	blob, err := SealForCode(plain, code)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if len(blob) == 0 {
+		t.Fatal("empty blob")
+	}
+	if bytes.Contains(blob, plain) {
+		t.Fatal("ciphertext must not contain the plaintext")
+	}
+	got, err := OpenWithCode(blob, code)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, plain)
+	}
+}
+
+// TestKeyIsDomainSeparatedFromLookup is THE LOAD-BEARING CONTENT-BLIND INVARIANT: the AES
+// key derived from the code must be domain-separated from the sha256 lookup the broker
+// stores. The broker holds {lookup, ciphertext}; it must never derive the key from the
+// lookup.
+func TestKeyIsDomainSeparatedFromLookup(t *testing.T) {
+	code := testCode(t)
+
+	key := transportKey(code)       // the AES-256 key (client-only)
+	lookup := TransportLookup(code) // what the broker stores/receives (hex sha256 tail)
+	if len(key) != 32 {
+		t.Fatalf("AES-256 key must be 32 bytes, got %d", len(key))
+	}
+	if lookup == "" {
+		t.Fatal("empty lookup")
+	}
+	// key != lookup, in every representation.
+	if hex.EncodeToString(key) == lookup {
+		t.Fatal("key must not equal the lookup (hex)")
+	}
+	if bytes.Equal([]byte(lookup), key) {
+		t.Fatal("key must not equal the lookup (bytes)")
+	}
+	// The lookup is exactly sha256(canonical tail); the key is HKDF over that tail. Knowing
+	// the lookup (a hash) yields neither the tail nor the key.
+	if lookup != protocol.BandCodeHash(code) {
+		t.Fatalf("lookup must be BandCodeHash(code): got %q want %q", lookup, protocol.BandCodeHash(code))
+	}
+	// Prove the broker's stored pair {lookup, ciphertext} is undecryptable without the raw
+	// code: opening with the lookup-as-code, or any non-code, fails.
+	blob, err := SealForCode([]byte("secret-plaintext"), code)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := OpenWithCode(blob, lookup); err == nil {
+		t.Fatal("the broker's lookup must not open the blob")
+	}
+	if _, err := OpenWithCode(blob, ""); err == nil {
+		t.Fatal("an empty code must not open the blob")
+	}
+}
+
+func TestWrongCodeNoPlaintext(t *testing.T) {
+	code := testCode(t)
+	other := testCode(t)
+	if protocol.BandCodeHash(code) == protocol.BandCodeHash(other) {
+		t.Fatal("two fresh codes collided (astronomically unlikely)")
+	}
+	blob, err := SealForCode([]byte("top secret"), code)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := OpenWithCode(blob, other); err == nil {
+		t.Fatal("a different code must not decrypt (GCM auth fails)")
+	}
+}
+
+func TestFlippedByteFailsGCM(t *testing.T) {
+	code := testCode(t)
+	blob, err := SealForCode([]byte("integrity-protected"), code)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	// flip a byte in the ciphertext body (past the 12-byte nonce) -> GCM tag mismatch.
+	tampered := append([]byte(nil), blob...)
+	tampered[len(tampered)-1] ^= 0x01
+	if _, err := OpenWithCode(tampered, code); err == nil {
+		t.Fatal("a flipped ciphertext byte must fail the GCM tag")
+	}
+	// flip a nonce byte -> also fails.
+	tampered2 := append([]byte(nil), blob...)
+	tampered2[0] ^= 0x01
+	if _, err := OpenWithCode(tampered2, code); err == nil {
+		t.Fatal("a flipped nonce byte must fail")
+	}
+}
+
+func TestTruncatedBlob(t *testing.T) {
+	code := testCode(t)
+	blob, err := SealForCode([]byte("x"), code)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	for _, n := range []int{0, 1, 11, 12} { // shorter than nonce+tag: never a valid frame
+		if _, err := OpenWithCode(blob[:n], code); err == nil {
+			t.Fatalf("a truncated blob (%d bytes) must be rejected, not panic", n)
+		}
+	}
+}
+
+// TestNonceRandomPerSeal: every seal uses a fresh random nonce, so two seals of the same
+// plaintext+code differ (no deterministic ciphertext).
+func TestNonceRandomPerSeal(t *testing.T) {
+	code := testCode(t)
+	blob, err := SealForCode([]byte("bound to this code"), code)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	blob2, err := SealForCode([]byte("bound to this code"), code)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if bytes.Equal(blob, blob2) {
+		t.Fatal("nonce must be random per seal (no deterministic ciphertext)")
+	}
+}
+
+func TestSealEmptyCodeRejected(t *testing.T) {
+	if _, err := SealForCode([]byte("x"), ""); err == nil {
+		t.Fatal("a codeless seal must be refused (no tail => no key)")
+	}
+	// only dashes/spaces/dots/middots (all dropped by CanonicalBandTail) => no tail.
+	if _, err := SealForCode([]byte("x"), " ---... · --- "); err == nil {
+		t.Fatal("a code with no valid tail must be refused")
+	}
+}
+
+// TestKeyDeterministicPerCode: the derived key is a pure function of the code, so the guest
+// re-derives the SAME key from the same code (a fresh process opens what another sealed).
+func TestKeyDeterministicPerCode(t *testing.T) {
+	code := testCode(t)
+	if !bytes.Equal(transportKey(code), transportKey(code)) {
+		t.Fatal("key derivation must be deterministic per code")
+	}
+	if bytes.Equal(transportKey(code), transportKey(testCode(t))) {
+		t.Fatal("different codes must give different keys")
+	}
+}
+
+// TestSealOpenLarge: a large capsule (near the broker's 1MB cap) still round-trips.
+func TestSealOpenLarge(t *testing.T) {
+	code := testCode(t)
+	plain := make([]byte, 900*1024)
+	_, _ = rand.Read(plain)
+	blob, err := SealForCode(plain, code)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	got, err := OpenWithCode(blob, code)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatal("large round-trip mismatch")
+	}
+}

--- a/internal/client/capsule.go
+++ b/internal/client/capsule.go
@@ -34,7 +34,12 @@ const capsuleResolveReadCap = 1<<20*3/2 + 1<<12
 // PublishCapsule seals capsuleJSON (a signed roger.context.v1 wire object) under code and
 // MINTS it to the broker: POST /capsule {lookup, blob}, owner-signed (attribution). The
 // lookup is BandCodeHash(code); the blob is the AES-256-GCM ciphertext. The raw code is
-// handed to the guest out-of-band (the reference channel) - never here, never on a frame.
+// handed to the peer out-of-band (the reference channel) - never here, never on a frame.
+//
+// This is the NON-floor publisher used for the RECALL / return leg (the guest hands context
+// back under a FRESH code): a return capsule is not a stranger export, so the summary-only
+// floor does not apply (the receiver is protected by verify-before-merge + append-only, not
+// redaction). The DJ->stranger leg uses PublishStrangerCapsule, which enforces the floor.
 func PublishCapsule(broker, code string, capsuleJSON []byte) error {
 	sealed, err := capsule.SealForCode(capsuleJSON, code)
 	if err != nil {

--- a/internal/client/capsule.go
+++ b/internal/client/capsule.go
@@ -1,0 +1,98 @@
+package client
+
+// capsule.go is the CLIENT side of the encrypted stranger transport (Stage 3): it seals a
+// signed, redacted context capsule under a one-time CODE and mints it to the broker's
+// content-blind rendezvous, and resolves+opens one on the receiving side. The broker only
+// ever sees {lookup, ciphertext}: the code, the HKDF key, and the plaintext never leave the
+// client (internal/capsule/transport.go).
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/capsule"
+)
+
+// ErrCapsuleGone is the receiver's view of a uniform 404 from /capsule/resolve: the code is
+// wrong, or the blob expired, or it was already consumed (one-time). The broker returns the
+// same 404 for all three (no existence oracle), so the client cannot distinguish them either.
+var ErrCapsuleGone = errors.New("capsule: no such capsule (wrong code, expired, or already used)")
+
+// capsuleHTTP is the bounded client for the mint/resolve calls (small JSON, fast paths).
+var capsuleHTTP = &http.Client{Timeout: 30 * time.Second}
+
+// capsuleResolveReadCap bounds the resolve response read: the broker caps a blob at 1 MB, and
+// base64 expands ~4/3, plus JSON envelope slack - so ~1.5 MB is a safe ceiling.
+const capsuleResolveReadCap = 1<<20*3/2 + 1<<12
+
+// PublishCapsule seals capsuleJSON (a signed roger.context.v1 wire object) under code and
+// MINTS it to the broker: POST /capsule {lookup, blob}, owner-signed (attribution). The
+// lookup is BandCodeHash(code); the blob is the AES-256-GCM ciphertext. The raw code is
+// handed to the guest out-of-band (the reference channel) - never here, never on a frame.
+func PublishCapsule(broker, code string, capsuleJSON []byte) error {
+	sealed, err := capsule.SealForCode(capsuleJSON, code)
+	if err != nil {
+		return err
+	}
+	body, _ := json.Marshal(map[string]string{
+		"lookup": capsule.TransportLookup(code),
+		"blob":   base64.StdEncoding.EncodeToString(sealed),
+	})
+	req, err := http.NewRequest(http.MethodPost, broker+"/capsule", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	signRequest(req, body) // owner-signed mint
+	resp, err := capsuleHTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<12))
+		return fmt.Errorf("capsule mint failed: %s: %s", resp.Status, bytes.TrimSpace(msg))
+	}
+	return nil
+}
+
+// FetchCapsule resolves the blob for code from the broker (POST /capsule/resolve {lookup},
+// authed by possession of the lookup - no signature) and OPENS it with the code, returning
+// the plaintext capsule JSON. A uniform 404 becomes ErrCapsuleGone. The resolve is one-time:
+// the broker deletes the blob on read, so a second call is ErrCapsuleGone.
+func FetchCapsule(broker, code string) ([]byte, error) {
+	body, _ := json.Marshal(map[string]string{"lookup": capsule.TransportLookup(code)})
+	req, err := http.NewRequest(http.MethodPost, broker+"/capsule/resolve", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := capsuleHTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrCapsuleGone
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("capsule resolve failed: %s", resp.Status)
+	}
+	var out struct {
+		Blob string `json:"blob"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, capsuleResolveReadCap)).Decode(&out); err != nil {
+		return nil, err
+	}
+	sealed, err := base64.StdEncoding.DecodeString(out.Blob)
+	if err != nil {
+		return nil, err
+	}
+	return capsule.OpenWithCode(sealed, code)
+}

--- a/internal/client/capsule.go
+++ b/internal/client/capsule.go
@@ -40,6 +40,23 @@ func PublishCapsule(broker, code string, capsuleJSON []byte) error {
 	if err != nil {
 		return err
 	}
+	return mintCapsule(broker, code, sealed)
+}
+
+// PublishStrangerCapsule is PublishCapsule with the redaction FLOOR: it refuses to mint a
+// non-summary (full) capsule to a marketplace/stranger (ErrNotSummary), so a stranger
+// transport can never carry a full transcript. This is the DJ->stranger handoff path.
+func PublishStrangerCapsule(broker, code string, capsuleJSON []byte) error {
+	sealed, err := capsule.SealForStranger(capsuleJSON, code)
+	if err != nil {
+		return err
+	}
+	return mintCapsule(broker, code, sealed)
+}
+
+// mintCapsule POSTs the sealed blob to the broker's content-blind /capsule endpoint,
+// owner-signed. It is the shared tail of PublishCapsule / PublishStrangerCapsule.
+func mintCapsule(broker, code string, sealed []byte) error {
 	body, _ := json.Marshal(map[string]string{
 		"lookup": capsule.TransportLookup(code),
 		"blob":   base64.StdEncoding.EncodeToString(sealed),

--- a/internal/client/capsule_test.go
+++ b/internal/client/capsule_test.go
@@ -1,0 +1,117 @@
+package client
+
+// capsule_test.go exercises the client publish/fetch transport against a STREAM-FAITHFUL
+// in-memory rendezvous stub that matches the broker's /capsule + /capsule/resolve contract
+// (store {lookup, blob}; delete-on-read; uniform 404). REAL seal/open crypto - the stub only
+// stands in for the content-blind store, never the crypto.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/capsule"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// rendezvousStub is a minimal content-blind store: it stores exactly what the client sends
+// (lookup -> base64 blob) and hands it back once. It never decrypts.
+func rendezvousStub(t *testing.T) (*httptest.Server, map[string]string) {
+	t.Helper()
+	var mu sync.Mutex
+	store := map[string]string{} // lookup -> base64(ciphertext)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/capsule", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct{ Lookup, Blob string }
+		_ = json.Unmarshal(body, &req)
+		mu.Lock()
+		store[req.Lookup] = req.Blob
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	mux.HandleFunc("/capsule/resolve", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct{ Lookup string }
+		_ = json.Unmarshal(body, &req)
+		mu.Lock()
+		blob, ok := store[req.Lookup]
+		delete(store, req.Lookup) // delete-on-read (one-time)
+		mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"no such capsule"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"blob": blob})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, store
+}
+
+func TestPublishFetchRoundTrip(t *testing.T) {
+	srv, store := rendezvousStub(t)
+	code, _, _ := protocol.NewRCLinkCode()
+	capsuleJSON := []byte(`{"capsule":"roger.context.v1","redaction":"summary"}`)
+
+	if err := PublishCapsule(srv.URL, code, capsuleJSON); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	// what landed in the store must be the CIPHERTEXT, not the plaintext.
+	stored, _ := base64.StdEncoding.DecodeString(store[capsule.TransportLookup(code)])
+	if len(stored) == 0 {
+		t.Fatal("nothing stored under the lookup")
+	}
+	if string(stored) == string(capsuleJSON) {
+		t.Fatal("the stub stored plaintext - the client must seal before minting")
+	}
+
+	got, err := FetchCapsule(srv.URL, code)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if string(got) != string(capsuleJSON) {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, capsuleJSON)
+	}
+}
+
+func TestFetchOneTimeThenGone(t *testing.T) {
+	srv, _ := rendezvousStub(t)
+	code, _, _ := protocol.NewRCLinkCode()
+	if err := PublishCapsule(srv.URL, code, []byte(`{"capsule":"roger.context.v1"}`)); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if _, err := FetchCapsule(srv.URL, code); err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if _, err := FetchCapsule(srv.URL, code); err != ErrCapsuleGone {
+		t.Fatalf("second fetch err = %v, want ErrCapsuleGone (one-time)", err)
+	}
+}
+
+func TestFetchWrongCodeGone(t *testing.T) {
+	srv, _ := rendezvousStub(t)
+	code, _, _ := protocol.NewRCLinkCode()
+	if err := PublishCapsule(srv.URL, code, []byte(`{"capsule":"roger.context.v1"}`)); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	// a DIFFERENT code hashes to a different lookup -> the broker never finds it -> gone.
+	other, _, _ := protocol.NewRCLinkCode()
+	if _, err := FetchCapsule(srv.URL, other); err != ErrCapsuleGone {
+		t.Fatalf("wrong-code fetch err = %v, want ErrCapsuleGone", err)
+	}
+}
+
+func TestPublishRefusesTaillessCode(t *testing.T) {
+	srv, _ := rendezvousStub(t)
+	if err := PublishCapsule(srv.URL, " --- ", []byte(`{}`)); err == nil {
+		t.Fatal("a tail-less code must be refused before any broker call")
+	}
+}

--- a/internal/tui/context_capsule.go
+++ b/internal/tui/context_capsule.go
@@ -127,6 +127,52 @@ func (m *model) writeHandoffCapsule(workdir string) (string, error) {
 	return path, nil
 }
 
+// strangerHandoffBroker returns the broker endpoint to publish a stranger capsule to, or ""
+// when the encrypted stranger transport is not enabled. It is OFF by default (Stage 3 is
+// build-and-hold, pending founder ratification of the crypto choices): it requires BOTH the
+// ROGERAI_CAPSULE_STRANGER opt-in AND a known broker endpoint. Gating it here (not in the
+// operator exec) keeps the same-owner LOCAL handoff the unchanged default.
+func (m *model) strangerHandoffBroker() string {
+	if os.Getenv("ROGERAI_CAPSULE_STRANGER") == "" || m.endpoint == "" {
+		return ""
+	}
+	return m.endpoint
+}
+
+// publishStrangerCapsule is the DJ side of the ENCRYPTED STRANGER transport (Stage 3): it
+// exports a SUMMARY-ONLY capsule (the redaction floor), signs it with the operator's existing
+// identity, seals it under the one-time code, and mints the ciphertext to the broker's
+// content-blind rendezvous. The broker never sees the code, the key, or the plaintext. The
+// RAW code is handed to the guest via the reference channel (env / operator_handoff), NEVER
+// inline bytes and NEVER on a frame field. client.PublishStrangerCapsule enforces the
+// redaction floor (a full capsule is refused). An empty ring publishes nothing.
+func (m *model) publishStrangerCapsule(broker, code string) error {
+	if len(m.ring) == 0 {
+		return nil
+	}
+	c, err := m.exportContextCapsule(true) // summary-only for a stranger (redaction invariant)
+	if err != nil {
+		return err
+	}
+	raw, err := c.Marshal()
+	if err != nil {
+		return err
+	}
+	return client.PublishStrangerCapsule(broker, code, raw)
+}
+
+// resolveStrangerRecall is the DJ side of the RETURN path: it resolves the guest's return
+// capsule from the broker under the FRESH recall code (no key reuse), opens it, and merges it
+// back into the ring append-only (verify-before-merge inside mergeReturnCapsule). It returns
+// the number of new turns added. A gone/expired/wrong-code recall is client.ErrCapsuleGone.
+func (m *model) resolveStrangerRecall(broker, recallCode string) (int, error) {
+	raw, err := client.FetchCapsule(broker, recallCode)
+	if err != nil {
+		return 0, err
+	}
+	return m.mergeReturnCapsule(raw)
+}
+
 // readRecallCapsule merges a guest's return capsule (if it left one under the workdir) back
 // into the ring append-only. It returns the number of turns added (0 when no return file
 // exists - the common case), or an error the caller narrates. A missing file is not an

--- a/internal/tui/context_capsule_stranger_test.go
+++ b/internal/tui/context_capsule_stranger_test.go
@@ -1,0 +1,164 @@
+package tui
+
+// context_capsule_stranger_test.go exercises the TUI side of the encrypted stranger transport
+// (Stage 3): publish a SUMMARY-ONLY sealed capsule to a content-blind rendezvous stub, resolve
+// + merge a fresh-code recall, and the ratification gate. REAL crypto via client/capsule; the
+// stub stands in only for the broker store.
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/capsule"
+	"github.com/rogerai-fyi/roger/internal/client"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+)
+
+// strangerStub is a content-blind rendezvous: stores lookup -> base64 blob, delete-on-read.
+func strangerStub(t *testing.T) (*httptest.Server, map[string]string) {
+	t.Helper()
+	var mu sync.Mutex
+	store := map[string]string{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/capsule", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct{ Lookup, Blob string }
+		_ = json.Unmarshal(body, &req)
+		mu.Lock()
+		store[req.Lookup] = req.Blob
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	mux.HandleFunc("/capsule/resolve", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct{ Lookup string }
+		_ = json.Unmarshal(body, &req)
+		mu.Lock()
+		blob, ok := store[req.Lookup]
+		delete(store, req.Lookup)
+		mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"no such capsule"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"blob": blob})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, store
+}
+
+func TestPublishStrangerCapsuleSummaryOnly(t *testing.T) {
+	srv, store := strangerStub(t)
+	var m model
+	m.endpoint = srv.URL
+	m.recordTurn("user", "sensitive first turn", "user", nil, nil)
+	m.recordTurn("assistant", "SECRET-BODY-should-not-leave-plaintext", "roger", nil, nil)
+	m.recordTurn("user", "current turn", "user", nil, nil)
+
+	code, _, _ := protocol.NewRCLinkCode()
+	if err := m.publishStrangerCapsule(srv.URL, code); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	// content-blind: what landed is ciphertext, not the plaintext body.
+	stored, _ := base64.StdEncoding.DecodeString(store[capsule.TransportLookup(code)])
+	if len(stored) == 0 {
+		t.Fatal("nothing published under the lookup")
+	}
+	// the guest resolves + opens and gets a SUMMARY-ONLY capsule (redaction floor).
+	raw, err := client.FetchCapsule(srv.URL, code)
+	if err != nil {
+		t.Fatalf("guest fetch: %v", err)
+	}
+	c, err := capsule.Import(raw)
+	if err != nil {
+		t.Fatalf("guest import: %v", err)
+	}
+	if c.Redaction != "summary" {
+		t.Fatalf("stranger capsule redaction = %q, want summary", c.Redaction)
+	}
+	if len(c.Messages) != 1 {
+		t.Fatalf("stranger capsule carries %d turns, want 1 (current only)", len(c.Messages))
+	}
+	if c.Messages[0].Content != "current turn" {
+		t.Fatalf("stranger capsule current turn = %q", c.Messages[0].Content)
+	}
+}
+
+func TestResolveStrangerRecallMergesFreshCode(t *testing.T) {
+	srv, _ := strangerStub(t)
+	var m model
+	m.endpoint = srv.URL
+	m.recordTurn("user", "t0", "user", nil, nil)
+	m.recordTurn("assistant", "t1", "roger", nil, nil) // ringTurn now 2
+
+	// the guest builds a return capsule (adds turn 2) and publishes under a FRESH recall code.
+	_, gpriv, _ := ed25519.GenerateKey(nil)
+	ret := capsule.Capsule{
+		Capsule:  capsule.Version,
+		Thread:   capsule.Thread{BaseWatermark: 3},
+		Messages: []capsule.Message{{Role: "user", Content: "guest-added", XRoger: capsule.XRoger{Turn: 2, Agent: "user", TS: 1}}},
+	}
+	ret.Sign(gpriv)
+	retRaw, _ := ret.Marshal()
+	recallCode, _, _ := protocol.NewRCLinkCode()
+	if err := client.PublishStrangerCapsule(srv.URL, recallCode, retRaw); err == nil {
+		// the return capsule is summary? no - it is unredacted. PublishStrangerCapsule refuses
+		// a non-summary capsule, so the return path uses PublishCapsule (verify-before-merge is
+		// the return-side guard, not the redaction floor). Fall through to PublishCapsule.
+		t.Fatal("expected the non-summary return to be refused by the stranger-guard path")
+	}
+	if err := client.PublishCapsule(srv.URL, recallCode, retRaw); err != nil {
+		t.Fatalf("guest publish return: %v", err)
+	}
+
+	added, err := m.resolveStrangerRecall(srv.URL, recallCode)
+	if err != nil {
+		t.Fatalf("resolve recall: %v", err)
+	}
+	if added != 1 {
+		t.Fatalf("recall merged %d turns, want 1", added)
+	}
+	if m.ringTurn != 3 || m.ring[len(m.ring)-1].Content != "guest-added" {
+		t.Fatalf("recall did not append-only merge: ringTurn=%d last=%q", m.ringTurn, m.ring[len(m.ring)-1].Content)
+	}
+}
+
+func TestStrangerHandoffBrokerGate(t *testing.T) {
+	var m model
+	m.endpoint = "https://broker.example"
+	// default: OFF (no opt-in env) even with a known broker.
+	t.Setenv("ROGERAI_CAPSULE_STRANGER", "")
+	if got := m.strangerHandoffBroker(); got != "" {
+		t.Fatalf("stranger handoff must be OFF by default, got %q", got)
+	}
+	// opt-in + known broker -> enabled.
+	t.Setenv("ROGERAI_CAPSULE_STRANGER", "1")
+	if got := m.strangerHandoffBroker(); got != m.endpoint {
+		t.Fatalf("enabled gate must return the broker, got %q", got)
+	}
+	// opt-in but NO broker -> still off.
+	m.endpoint = ""
+	if got := m.strangerHandoffBroker(); got != "" {
+		t.Fatalf("no broker => off, got %q", got)
+	}
+}
+
+func TestPublishStrangerEmptyRingNoop(t *testing.T) {
+	srv, store := strangerStub(t)
+	var m model
+	code, _, _ := protocol.NewRCLinkCode()
+	if err := m.publishStrangerCapsule(srv.URL, code); err != nil {
+		t.Fatalf("empty-ring publish: %v", err)
+	}
+	if len(store) != 0 {
+		t.Fatal("an empty ring must publish nothing")
+	}
+}

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -13,6 +13,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/rogerai-fyi/roger/internal/client"
+	"github.com/rogerai-fyi/roger/internal/protocol"
 	"github.com/rogerai-fyi/roger/internal/glyphs"
 	"github.com/rogerai-fyi/roger/internal/operator"
 	"github.com/rogerai-fyi/roger/internal/pricetier"
@@ -909,14 +910,30 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 	}
 	// Same-owner LOCAL handoff (Stage 1): drop the conversation as a signed roger.context
 	// capsule the guest can import from its workdir (a REFERENCE it reads, not bytes on a
-	// frame). Best-effort - a write failure narrates but never aborts the handoff. The
-	// encrypted stranger transport is a follow-on (ruling Q3).
+	// frame). Best-effort - a write failure narrates but never aborts the handoff.
 	if path, err := m.writeHandoffCapsule(wd); err != nil {
 		m.rcNote("context capsule not handed off: " + err.Error())
 	} else if path != "" {
 		m.rcNote(fmt.Sprintf("handed the conversation to %s · %d turns", h.det.Guest.Name, m.ringTurn))
 	}
-	c := operator.Command(launch, h.det.Path, sess.Workdir, os.Environ())
+	// STRANGER handoff (Stage 3, ratification-gated): when the marketplace/stranger transport
+	// is enabled (ROGERAI_CAPSULE_STRANGER=1 + a known broker), publish a SUMMARY-ONLY, signed,
+	// SEALED capsule to the broker's content-blind rendezvous under a FRESH one-time code, and
+	// hand the guest the RAW code + broker via the ENV reference channel (never inline bytes,
+	// never a frame field). Best-effort: a publish failure narrates and falls back to the local
+	// file handoff above. See context_capsule.go / features/capsule/stranger_transport.feature.
+	env := os.Environ()
+	if broker := m.strangerHandoffBroker(); broker != "" {
+		code, _, _ := protocol.NewRCLinkCode() // fresh code; reuses the 40-bit band tail
+		if err := m.publishStrangerCapsule(broker, code); err != nil {
+			m.rcNote("stranger capsule not published: " + err.Error())
+		} else {
+			// the reference channel: the guest resolves the code from the broker itself.
+			env = append(env, "ROGERAI_CAPSULE_CODE="+code, "ROGERAI_CAPSULE_BROKER="+broker)
+			m.rcNote(fmt.Sprintf("published a summary capsule for %s · one-time code handed off", h.det.Guest.Name))
+		}
+	}
+	c := operator.Command(launch, h.det.Path, sess.Workdir, env)
 	return m, operatorExec(c, func(err error) tea.Msg { return operatorDoneMsg{err: err} })
 }
 

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -13,10 +13,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/rogerai-fyi/roger/internal/client"
-	"github.com/rogerai-fyi/roger/internal/protocol"
 	"github.com/rogerai-fyi/roger/internal/glyphs"
 	"github.com/rogerai-fyi/roger/internal/operator"
 	"github.com/rogerai-fyi/roger/internal/pricetier"
+	"github.com/rogerai-fyi/roger/internal/protocol"
 )
 
 // operator.go is the TUI glue for Guest Operators Phase 2 (THE DESK): the /operator
@@ -908,20 +908,18 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 		m.rcEmit(client.OperatorStatusFrame(h.det.Guest.Name, opts.Model, m.proxyHolder.Spent()))
 		m.rcBridge.Park(h.det.Guest.Name, m.agentTranscriptText(), opts.Model, m.proxyHolder.Spent)
 	}
-	// Same-owner LOCAL handoff (Stage 1): drop the conversation as a signed roger.context
-	// capsule the guest can import from its workdir (a REFERENCE it reads, not bytes on a
-	// frame). Best-effort - a write failure narrates but never aborts the handoff.
-	if path, err := m.writeHandoffCapsule(wd); err != nil {
-		m.rcNote("context capsule not handed off: " + err.Error())
-	} else if path != "" {
-		m.rcNote(fmt.Sprintf("handed the conversation to %s · %d turns", h.det.Guest.Name, m.ringTurn))
-	}
-	// STRANGER handoff (Stage 3, ratification-gated): when the marketplace/stranger transport
-	// is enabled (ROGERAI_CAPSULE_STRANGER=1 + a known broker), publish a SUMMARY-ONLY, signed,
-	// SEALED capsule to the broker's content-blind rendezvous under a FRESH one-time code, and
-	// hand the guest the RAW code + broker via the ENV reference channel (never inline bytes,
-	// never a frame field). Best-effort: a publish failure narrates and falls back to the local
-	// file handoff above. See context_capsule.go / features/capsule/stranger_transport.feature.
+	// Context handoff. Two MUTUALLY-EXCLUSIVE paths (a stranger must never also get the full
+	// local file - that would sidestep the redaction floor):
+	//
+	//   STRANGER (Stage 3, ratification-gated: ROGERAI_CAPSULE_STRANGER=1 + a known broker):
+	//   publish a SUMMARY-ONLY, signed, SEALED capsule to the broker's content-blind rendezvous
+	//   under a FRESH one-time code, and hand the guest the RAW code + broker via the ENV
+	//   reference channel (never inline bytes, never a frame field, and NO full local file).
+	//
+	//   SAME-OWNER LOCAL (Stage 1, the default): drop the conversation as a signed roger.context
+	//   capsule the guest imports from its workdir (a REFERENCE it reads, not bytes on a frame).
+	//
+	// Both are best-effort - a failure narrates but never aborts the handoff.
 	env := os.Environ()
 	if broker := m.strangerHandoffBroker(); broker != "" {
 		code, _, _ := protocol.NewRCLinkCode() // fresh code; reuses the 40-bit band tail
@@ -932,6 +930,10 @@ func (m model) onOperatorExec() (tea.Model, tea.Cmd) {
 			env = append(env, "ROGERAI_CAPSULE_CODE="+code, "ROGERAI_CAPSULE_BROKER="+broker)
 			m.rcNote(fmt.Sprintf("published a summary capsule for %s · one-time code handed off", h.det.Guest.Name))
 		}
+	} else if path, err := m.writeHandoffCapsule(wd); err != nil {
+		m.rcNote("context capsule not handed off: " + err.Error())
+	} else if path != "" {
+		m.rcNote(fmt.Sprintf("handed the conversation to %s · %d turns", h.det.Guest.Name, m.ringTurn))
 	}
 	c := operator.Command(launch, h.det.Path, sess.Workdir, env)
 	return m, operatorExec(c, func(err error) tea.Msg { return operatorDoneMsg{err: err} })


### PR DESCRIPTION
**BUILD-AND-HOLD - do not merge.** This ships the client crypto + broker + wiring for the encrypted stranger/marketplace transport of a context capsule (roger.context.v1 Stage 3). It folds in and FIXES #64, so #64 can be closed in favor of this. Merge auto-deploys the broker.

## Three crypto choices adopted - FOR-FOUNDER-RATIFICATION

1. **HKDF-SHA256 key, domain-separated from the sha256 lookup.** The encryption key and the broker lookup both derive from the one-time code, but are separated so the broker cannot decrypt what it stores:
   - `lookup = BandCodeHash(code) = sha256(canonical tail)` (sent to the broker)
   - `key = HKDF-SHA256(ikm=CanonicalBandTail(code), salt="rogerai-capsule-transport-v1", info=BandCodeHash(code))[:32]` (never leaves the client)
   - AES-256-GCM, random 12-byte nonce prepended, AAD = the lookup (anti-splice), mirroring `report.go` encryptCSAM.
2. **Reused 40-bit RC/band code** (`protocol.NewRCLinkCode`) - no new code format invented.
3. **Fresh-code recall** - the return capsule rides back under a NEW code (no key reuse).

## Content-blind by construction

The broker stores ONLY `{lookup, ciphertext}` - never the code, the key, or the plaintext. This is the whole security claim and it is proven by an explicit test asserting **key != lookup** and that from `{lookup, ciphertext}` alone the plaintext is unrecoverable without the raw code:

- `internal/capsule/transport_test.go::TestKeyIsDomainSeparatedFromLookup` (key != lookup in every representation; the lookup does not open the blob; empty code does not open it).
- `cmd/rogerai-broker/capsule_multiinstance_test.go::TestCapsuleBrokerContentBlind` (inspects the raw stored value: equals the ciphertext, contains neither plaintext nor code; only the raw code recovers the plaintext).

## Fixes #64: shared-store, multi-instance

#64's capsule store was a per-instance in-memory map - a mint on broker A would not resolve on B. This moves the blob store to the SHARED store (Valkey `SET` + atomic one-time `GETDEL`, keyed `rogerai:cap:<lookup>`), so a mint on A resolves on B and exactly one of N concurrent resolves wins. The per-instance map remains the single-instance / no-Valkey fallback (never split-brain: a present-but-erroring shared backend sheds the mint rather than writing local). Proven by `TestCapsuleMultiInstanceMintAResolveB` + `TestCapsuleMultiInstanceRaceOneWinner`.

## What's here

- `internal/capsule/transport.go` - `SealForCode` / `OpenWithCode` / `SealForStranger` (redaction floor) + `TransportLookup`.
- `cmd/rogerai-broker/{capsule.go,sharedstore.go}` - shared-first content-blind rendezvous, `putCapsule`/`takeCapsule`.
- `internal/client/capsule.go` - `PublishCapsule` / `PublishStrangerCapsule` / `FetchCapsule`.
- `internal/tui/{context_capsule.go,operator.go}` - stranger publish/recall; the raw code rides the reference channel (env), never inline bytes, never a frame field. Ratification-gated (`ROGERAI_CAPSULE_STRANGER`, default OFF - the same-owner LOCAL handoff is unchanged).
- `cmd/rogerai/context.go` - `roger context publish|resolve`.
- Executable specs: `features/capsule/{stranger_transport,broker_rendezvous}.feature`.

Invariants held: verify-before-merge + append-only survive the decrypt path; the redaction floor refuses a full capsule for a stranger; no plaintext/code/key is logged or persisted; money/relay paths untouched.

## RED -> GREEN evidence

RED (crypto undefined):
```
internal/capsule/transport_test.go:58:9: undefined: transportKey
internal/capsule/transport_test.go:59:12: undefined: TransportLookup
internal/capsule/transport_test.go:32:15: undefined: SealForCode
```
GREEN: `go build/vet ./...` clean; `go test ./internal/capsule ./internal/client ./internal/tui ./cmd/rogerai ./cmd/rogerai-broker` pass (godog strict); `-race` clean on the touched paths; `make cover-gate` PASS (every package >=90%, total 92.3%; internal/capsule 97.8%).

## MERGE-BLOCK

Founder to review + ratify the three crypto choices above before merge. Merge auto-deploys the broker.
