### PR TITLE
capsule: tool_calls cross-language interop (lift the boundary gate)

### DIFF
--- a/cmd/rogerai/context.go
+++ b/cmd/rogerai/context.go
@@ -19,7 +19,8 @@ import (
 // operator's existing identity, import verifies one (and can append-only merge it into a
 // base thread), so a conversation moves across operators over a .rcap.json file
 // (hermes/opencode) or a same-owner/local handoff. The encrypted stranger broker
-// transport is a follow-on (ruling Q3). tool_calls are rejected at the boundary (Q1).
+// transport is a follow-on (ruling Q3). tool_calls interoperate (their canonical form is
+// pinned cross-language), so a capsule carrying them exports/imports/merges like any other.
 
 // contextExportedBy is the producer tag the CLI stamps into meta.exported_by. The app
 // stamps "roger-ios"; the byte-parity golden covers both.
@@ -312,8 +313,8 @@ func contextExportUsage() {
   cat draft.json | roger context export                sign from stdin to stdout
 
 The input is a roger.context.v1 draft (the capsule shape); export stamps exported_by,
-created_at, and your owner_pubkey, then signs. tool_calls are not supported (they are
-rejected at this boundary until their canonical form is pinned cross-language).
+created_at, and your owner_pubkey, then signs. tool_calls are carried through (their
+canonical form is pinned cross-language, so an app-signed tool-call capsule verifies here).
 `)
 }
 

--- a/cmd/rogerai/context_bdd_test.go
+++ b/cmd/rogerai/context_bdd_test.go
@@ -48,7 +48,7 @@ func draftJSON(turnsCSV string, withToolCalls bool) []byte {
 		n, _ := strconv.Atoi(p)
 		m := capsule.Message{Role: "user", Content: "c" + p, XRoger: capsule.XRoger{Turn: n, Agent: "user", TS: int64(n)}}
 		if withToolCalls {
-			m.ToolCalls = json.RawMessage(`[{"id":"1"}]`)
+			m.ToolCalls = capsule.ToolCallsRaw([]capsule.ToolCall{{Arguments: `{"url":"https://x.com/a"}`, ID: "call_1", Name: "open_url"}})
 		}
 		c.Messages = append(c.Messages, m)
 		if n > max {
@@ -165,9 +165,9 @@ func (s *contextCLIBDD) readMerged() capsule.Capsule {
 	_ = json.Unmarshal(data, &c)
 	return c
 }
-func (s *contextCLIBDD) exportFailsToolCalls() error {
-	if s.exportErr == nil || !strings.Contains(s.exportErr.Error(), "tool_calls") {
-		return bddErrf("expected tool_calls export failure, got %v", s.exportErr)
+func (s *contextCLIBDD) exportSucceeds() error {
+	if s.exportErr != nil {
+		return bddErrf("expected export to succeed (gate lifted), got %v", s.exportErr)
 	}
 	return nil
 }
@@ -201,7 +201,7 @@ func TestContextCLIBDD(t *testing.T) {
 			sc.Step(`^the import fails$`, st.importFails)
 			sc.Step(`^the merged capsule has (\d+) turns$`, st.mergedHasTurns)
 			sc.Step(`^the merged capsule verifies$`, st.mergedVerifies)
-			sc.Step(`^the export fails as tool_calls-unsupported$`, st.exportFailsToolCalls)
+			sc.Step(`^the export succeeds$`, st.exportSucceeds)
 		},
 		Options: &godog.Options{
 			Format:   "pretty",

--- a/features/capsule/cli.feature
+++ b/features/capsule/cli.feature
@@ -26,7 +26,9 @@ Feature: the `roger context` CLI
     Then the merged capsule has 3 turns
     And the merged capsule verifies
 
-  Scenario: export refuses a draft carrying tool_calls
+  Scenario: export signs a draft carrying tool_calls (gate lifted)
     Given a draft carrying tool_calls
     When I export it to a capsule file
-    Then the export fails as tool_calls-unsupported
+    Then the export succeeds
+    And I import the capsule file
+    Then the import reports it verified

--- a/features/capsule/merge.feature
+++ b/features/capsule/merge.feature
@@ -1,7 +1,8 @@
 Feature: append-only capsule merge
   A returning capsule may only ADD turns; a handoff never erases context. Merge verifies
-  the incoming signature FIRST, rejects a forked turn or an unknown version or tool_calls,
-  then appends only the turns at/after the target's watermark that are not already present.
+  the incoming signature FIRST, rejects a forked turn or an unknown version, then appends
+  only the turns at/after the target's watermark that are not already present. tool_calls
+  are carried through (their canonical form is pinned cross-language).
 
   Background:
     Given a fresh operator keypair

--- a/features/capsule/security.feature
+++ b/features/capsule/security.feature
@@ -1,7 +1,9 @@
 Feature: capsule security invariants
   The owner ed25519 signature covers every field except sig (over the canonical bytes, so
-  it also covers redaction). Verify-before-merge, append-only, and summary-only redaction
-  for strangers are enforced. tool_calls are rejected at the boundary (ruling Q1).
+  it also covers redaction, and the tool_calls). Verify-before-merge, append-only, and
+  summary-only redaction for strangers are enforced. tool_calls now interoperate: their
+  canonical form is pinned cross-language, so a VERIFIED tool-call capsule crosses (an
+  unverified one is still rejected, the safe state).
 
   Background:
     Given a fresh operator keypair
@@ -27,15 +29,15 @@ Feature: capsule security invariants
       | exported_by |
       | watermark   |
 
-  Scenario: a capsule carrying tool_calls is rejected at import
+  Scenario: a verified capsule carrying tool_calls now imports (gate lifted)
     Given a signed capsule carrying tool_calls
     When I import it
-    Then the import is rejected as tool_calls-unsupported
+    Then the import succeeds (the gate is lifted)
 
-  Scenario: exporting a draft that carries tool_calls is refused
+  Scenario: exporting a draft that carries tool_calls now succeeds (gate lifted)
     Given a draft carrying tool_calls
     When I export it
-    Then the export is refused as tool_calls-unsupported
+    Then the export succeeds (the gate is lifted)
 
   Scenario: an importable capsule round-trips through marshal and verifies
     Given a signed capsule with watermark 1 and turns

--- a/internal/capsule/canonical_test.go
+++ b/internal/capsule/canonical_test.go
@@ -1,6 +1,10 @@
 package capsule
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 // goldenInput builds the brief's golden fixture capsule (unsigned). exportedBy is the
 // only value that differs by producer ("roger-cli" vs "roger-ios"); everything else is
@@ -35,5 +39,161 @@ func TestGoldenVector(t *testing.T) {
 	}
 	if got := string(goldenInput("roger-ios").canonical()); got != iosGolden {
 		t.Errorf("roger-ios canonical mismatch\n got: %s\nwant: %s", got, iosGolden)
+	}
+}
+
+// toolCallGoldenInput builds the app side's pinned tool_calls golden fixture (unsigned):
+// the Stage-1 base with ONE assistant message carrying ONE FLAT tool_call whose arguments
+// deliberately exercise <, >, &, /, and an escaped quote. The ToolCalls raw here is
+// intentionally NON-canonical - the keys are SCRAMBLED (name,id,failed,denied,arguments) -
+// to PROVE canonical() sorts them to the golden order (arguments,denied,failed,id,name).
+// (Escaping NORMALIZATION - un-escaping HTML-escaped input - is proven separately by
+// TestCanonicalToolCallsUnescapesHTML.) exportedBy is the only value that differs by
+// producer. owner_pubkey is a literal "aa": this pins the CANONICAL BYTES.
+func toolCallGoldenInput(exportedBy string) Capsule {
+	scrambled := json.RawMessage(`[{"name":"open_url","id":"call_1","failed":false,"denied":false,"arguments":"{\"url\":\"https://x.com/a?b=1&c=2\",\"note\":\"<tag> & \\\"q\\\"\"}"}]`)
+	return Capsule{
+		Capsule:   Version,
+		ID:        "cap_x",
+		Thread:    Thread{OriginThreadID: "t1", Title: "Hi", BaseWatermark: 1},
+		Redaction: "full",
+		Summary:   Summary{Text: "hi", ProducedBy: "none", AsOfTurn: 1},
+		Memory:    Memory{Notes: "", Facts: nil},
+		Messages: []Message{{
+			Role:      "assistant",
+			Content:   "ok",
+			ToolCalls: scrambled,
+			XRoger:    XRoger{Turn: 0, Agent: "roger:m", Model: strp("m"), Provider: strp("p"), TS: 100},
+		}},
+		Meta: Meta{ToolsUsed: nil, ExportedBy: exportedBy, CreatedAt: 100, OwnerPubkey: "aa"},
+	}
+}
+
+// TestGoldenVectorToolCalls is the tool_calls interop gate: canonical() must reproduce the
+// app's pinned tool_calls golden bytes byte-for-byte, for BOTH producers. The flat tool_call
+// shape (fields sorted arguments,denied,failed,id,name) and its escaping (< > & literal, / not
+// escaped, pre-escaped quotes preserved) match RogerAI/Services/CapsuleWire.swift, so an
+// app-signed tool-call capsule verifies in Go and vice-versa.
+func TestGoldenVectorToolCalls(t *testing.T) {
+	const cliGolden = `{"capsule":"roger.context.v1","id":"cap_x","thread":{"origin_thread_id":"t1","title":"Hi","base_watermark":1},"redaction":"full","summary":{"text":"hi","produced_by":"none","as_of_turn":1},"memory":{"notes":"","facts":[]},"messages":[{"role":"assistant","content":"ok","tool_calls":[{"arguments":"{\"url\":\"https://x.com/a?b=1&c=2\",\"note\":\"<tag> & \\\"q\\\"\"}","denied":false,"failed":false,"id":"call_1","name":"open_url"}],"x_roger":{"turn":0,"agent":"roger:m","model":"m","provider":"p","ts":100}}],"meta":{"tools_used":[],"exported_by":"roger-cli","created_at":100,"owner_pubkey":"aa"}}`
+	const iosGolden = `{"capsule":"roger.context.v1","id":"cap_x","thread":{"origin_thread_id":"t1","title":"Hi","base_watermark":1},"redaction":"full","summary":{"text":"hi","produced_by":"none","as_of_turn":1},"memory":{"notes":"","facts":[]},"messages":[{"role":"assistant","content":"ok","tool_calls":[{"arguments":"{\"url\":\"https://x.com/a?b=1&c=2\",\"note\":\"<tag> & \\\"q\\\"\"}","denied":false,"failed":false,"id":"call_1","name":"open_url"}],"x_roger":{"turn":0,"agent":"roger:m","model":"m","provider":"p","ts":100}}],"meta":{"tools_used":[],"exported_by":"roger-ios","created_at":100,"owner_pubkey":"aa"}}`
+
+	if got := string(toolCallGoldenInput("roger-cli").canonical()); got != cliGolden {
+		t.Errorf("roger-cli tool_calls canonical mismatch\n got: %s\nwant: %s", got, cliGolden)
+	}
+	if got := string(toolCallGoldenInput("roger-ios").canonical()); got != iosGolden {
+		t.Errorf("roger-ios tool_calls canonical mismatch\n got: %s\nwant: %s", got, iosGolden)
+	}
+}
+
+// TestCanonicalToolCallsEscaping pins the tool_calls string escaping + key-sorting rules,
+// matching CapsuleWire.swift: object keys sort at every level, < > & and / stay LITERAL
+// (SetEscapeHTML off), quotes/backslashes stay JSON-escaped, arrays keep order. The
+// producer helper ToolCallsRaw builds exactly these bytes.
+func TestCanonicalToolCallsEscaping(t *testing.T) {
+	// arguments' decoded content exercises /, <, >, &, and an escaped quote.
+	args := `{"u":"a/b","lt":"<","gt":">","amp":"&","q":"\"x\""}`
+	const want = `[{"arguments":"{\"u\":\"a/b\",\"lt\":\"<\",\"gt\":\">\",\"amp\":\"&\",\"q\":\"\\\"x\\\"\"}","denied":false,"failed":false,"id":"call_1","name":"open_url"}]`
+
+	if got := string(ToolCallsRaw([]ToolCall{{Arguments: args, ID: "call_1", Name: "open_url"}})); got != want {
+		t.Errorf("ToolCallsRaw escaping mismatch\n got: %s\nwant: %s", got, want)
+	}
+	// canonical() sorts a scrambled-key raw to the same bytes.
+	scrambled := json.RawMessage(`[{"name":"open_url","id":"call_1","failed":false,"denied":false,"arguments":"{\"u\":\"a/b\",\"lt\":\"<\",\"gt\":\">\",\"amp\":\"&\",\"q\":\"\\\"x\\\"\"}"}]`)
+	if got := string(canonicalToolCalls(scrambled)); got != want {
+		t.Errorf("canonicalToolCalls scrambled mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestCanonicalToolCallsUnescapesHTML proves the escaping NORMALIZATION: a naive producer's
+// json.Marshal HTML-escapes < > & (to < > &); canonicalToolCalls parses that
+// and re-emits them LITERALLY (SetEscapeHTML off), matching the app's golden. The escaped
+// input is GENERATED by json.Marshal (not hand-typed) so the \u form is genuine; the checks
+// use the ASCII substring "u003c"/"u0026" to avoid hand-typing the escape.
+func TestCanonicalToolCallsUnescapesHTML(t *testing.T) {
+	escaped, err := json.Marshal([]ToolCall{{Arguments: `<a> & b`, ID: "c", Name: "n"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Precondition: json.Marshal really did HTML-escape < and & (to < / &).
+	if !strings.Contains(string(escaped), "u003c") || !strings.Contains(string(escaped), "u0026") {
+		t.Fatalf("expected json.Marshal to HTML-escape < & (to \\u003c \\u0026), got: %s", escaped)
+	}
+	got := string(canonicalToolCalls(escaped))
+	// After canonicalization the escapes are gone and < > & are LITERAL.
+	if strings.Contains(got, "u003c") || strings.Contains(got, "u0026") {
+		t.Errorf("canonical tool_calls must un-escape < & to literal, got: %s", got)
+	}
+	if !strings.Contains(got, `<a> & b`) {
+		t.Errorf("expected literal < > & in canonical tool_calls, got: %s", got)
+	}
+}
+
+// TestCanonicalEscapingAsymmetry pins the deliberate asymmetry the two goldens encode: the
+// SAME < > & string is HTML-escaped (< ...) in a PLAIN field (content, via goString,
+// matching the app's base golden) but stays LITERAL inside a tool_call's arguments (matching
+// the tool_calls golden). Both are verified byte-for-byte against the app.
+func TestCanonicalEscapingAsymmetry(t *testing.T) {
+	const raw = `<a> & b`
+	c := Capsule{
+		Capsule:  Version,
+		ID:       "cap_asym",
+		Messages: []Message{{Role: "assistant", Content: raw, ToolCalls: ToolCallsRaw([]ToolCall{{Arguments: raw, ID: "c", Name: "n"}}), XRoger: XRoger{Turn: 0, Agent: "roger:m", TS: 1}}},
+		Meta:     Meta{OwnerPubkey: "bb"},
+	}
+	got := string(c.canonical())
+	// plain content: HTML-escaped by goString - the < form appears (checked via the
+	// "u003c" ASCII substring), and the raw literal "<a> & b" is NOT the content value.
+	if !strings.Contains(got, `"content":`) || !strings.Contains(got, "u003c") {
+		t.Errorf("plain content must be HTML-escaped (goString), got: %s", got)
+	}
+	// tool_call arguments: literal < > & survive verbatim.
+	if !strings.Contains(got, `"arguments":"<a> & b"`) {
+		t.Errorf("tool_call arguments must stay literal, got: %s", got)
+	}
+}
+
+// TestCanonicalToolCallsLineSeparators pins that U+2028/U+2029 in a tool_calls string are
+// ESCAPED (to the 6-char   /  ), never emitted raw - matching the app's scalar
+// rewrite. This is the one asymmetry from < > & (which stay literal). Runes are built
+// numerically (0x2028/0x2029) to keep the source pure ASCII.
+func TestCanonicalToolCallsLineSeparators(t *testing.T) {
+	ls, ps := rune(0x2028), rune(0x2029)
+	args := "sep:" + string(ls) + string(ps) + "end"
+	got := string(ToolCallsRaw([]ToolCall{{Arguments: args, ID: "c", Name: "n"}}))
+	if !strings.Contains(got, "u2028") || !strings.Contains(got, "u2029") {
+		t.Errorf("U+2028/U+2029 must be escaped to \\u2028 / \\u2029, got: %s", got)
+	}
+	if strings.ContainsRune(got, ls) || strings.ContainsRune(got, ps) {
+		t.Errorf("raw U+2028/U+2029 must not appear in canonical bytes, got: %q", got)
+	}
+}
+
+// TestToolCallsRawResult: Result is emitted ONLY when set (sorted last), and an empty slice
+// yields nil (the tool_calls slot is omitted).
+func TestToolCallsRawResult(t *testing.T) {
+	if ToolCallsRaw(nil) != nil {
+		t.Error("empty tool_calls must be nil (omit the slot)")
+	}
+	res := "done"
+	got := string(ToolCallsRaw([]ToolCall{{Arguments: "{}", ID: "c", Name: "n", Result: &res}}))
+	const want = `[{"arguments":"{}","denied":false,"failed":false,"id":"c","name":"n","result":"done"}]`
+	if got != want {
+		t.Errorf("result field\n got: %s\nwant: %s", got, want)
+	}
+	noRes := string(ToolCallsRaw([]ToolCall{{Arguments: "{}", ID: "c", Name: "n"}}))
+	if noRes != `[{"arguments":"{}","denied":false,"failed":false,"id":"c","name":"n"}]` {
+		t.Errorf("nil result must be omitted, got: %s", noRes)
+	}
+}
+
+// TestCanonicalToolCallsUnparseableFallback: a tool_calls value that is not valid JSON is
+// emitted VERBATIM (the safe state) - it simply will not match a peer's canonical bytes, so
+// a signature over it fails to verify rather than being silently "canonicalized" into
+// something else.
+func TestCanonicalToolCallsUnparseableFallback(t *testing.T) {
+	bad := json.RawMessage(`{not json`)
+	if got := string(canonicalToolCalls(bad)); got != `{not json` {
+		t.Errorf("unparseable tool_calls must pass through verbatim, got: %s", got)
 	}
 }

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -9,12 +9,14 @@
 //
 // Stage 1 scope (founder-approved): the capsule package + the `roger context` CLI +
 // SAME-OWNER / LOCAL handoff only. The encrypted stranger broker transport is a
-// follow-on (ruling Q3). tool_calls are REJECTED at the app<->CLI boundary (ruling
-// Q1): a canonical form for them is not yet pinned cross-language, so no capsule
-// carrying them may cross until it is.
+// follow-on (ruling Q3). tool_calls now INTEROPERATE: the flat cross-language shape and
+// its canonical form are pinned against the app (canonicalToolCalls + the golden), so a
+// verified tool-call capsule imports and merges like any other (verify-before-merge and
+// append-only still apply; an unverified one is still rejected, the safe state).
 package capsule
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
@@ -63,14 +65,66 @@ type Memory struct {
 }
 
 // Message is one turn in plain OpenAI shape so any agent can read it; RogerAI
-// provenance lives under the ignore-unknown x_roger namespace. ToolCalls is carried
-// as raw JSON and is REJECTED at the boundary (ruling Q1) until its canonical form is
-// pinned cross-language; it appears in canonical() only to keep the fixed field order.
+// provenance lives under the ignore-unknown x_roger namespace. ToolCalls is carried as
+// raw JSON (any shape); canonical() re-serializes it in the pinned cross-language form
+// (see canonicalToolCalls). Producers build it from the flat ToolCall shape via
+// ToolCallsRaw so the wire bytes are already canonical.
 type Message struct {
 	Role      string          `json:"role"`
 	Content   string          `json:"content"`
 	ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
 	XRoger    XRoger          `json:"x_roger"`
+}
+
+// ToolCall is the FLAT, cross-language tool-call shape (NOT OpenAI-nested {id,type,
+// function{}}): the app's internal struct, byte-aligned with CapsuleWire.swift. Every
+// value is a string or a JSON bool - no numbers. Arguments is a STRING holding
+// already-escaped JSON. Result is present ONLY when the tool has run (a nil Result is
+// omitted). Fields are declared in sorted key order (arguments,denied,failed,id,name,
+// result) so a plain marshal is already sorted; canonical() re-sorts regardless.
+type ToolCall struct {
+	Arguments string  `json:"arguments"`
+	Denied    bool    `json:"denied"`
+	Failed    bool    `json:"failed"`
+	ID        string  `json:"id"`
+	Name      string  `json:"name"`
+	Result    *string `json:"result,omitempty"`
+}
+
+// ToolCallsRaw is the PRODUCER helper: it serializes the flat tool_calls of a turn into
+// the canonical cross-language wire bytes (sorted keys, compact, < > & literal, U+2028/
+// U+2029 escaped). A producer attaches the result to Message.ToolCalls; canonical() would
+// normalize any shape, but building via this keeps the at-rest bytes canonical too. It
+// returns nil for an empty slice (so the tool_calls slot is omitted).
+func ToolCallsRaw(tcs []ToolCall) json.RawMessage {
+	if len(tcs) == 0 {
+		return nil
+	}
+	raw, _ := json.Marshal(tcs) // marshaling a fixed struct slice never errors
+	return canonicalToolCalls(raw)
+}
+
+// canonicalToolCalls re-serializes a tool_calls value in the pinned cross-language
+// canonical form: parsed generically (numbers preserved via json.Number, no float
+// rounding), object keys sorted lexicographically at every level, arrays kept in order,
+// compact, and strings escaped like the app - SetEscapeHTML(false) leaves < > & and /
+// literal (as the golden requires) while Go still escapes U+2028/U+2029. It is
+// shape-agnostic. An unparseable value is emitted verbatim: it simply will not match a
+// peer's canonical bytes (so verify fails - the safe state) unless it already is canonical.
+func canonicalToolCalls(raw json.RawMessage) []byte {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var v interface{}
+	if err := dec.Decode(&v); err != nil {
+		return raw
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return raw
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n") // Encoder appends a newline; canonical form has none
 }
 
 // XRoger is the RogerAI provenance for a message. Model/Provider are pointers so a nil
@@ -151,7 +205,7 @@ func (c Capsule) canonical() []byte {
 		b = append(b, goString(m.Content)...)
 		if len(m.ToolCalls) > 0 {
 			b = append(b, `,"tool_calls":`...)
-			b = append(b, m.ToolCalls...)
+			b = append(b, canonicalToolCalls(m.ToolCalls)...)
 		}
 		b = append(b, `,"x_roger":{"turn":`...)
 		b = strconv.AppendInt(b, int64(m.XRoger.Turn), 10)

--- a/internal/capsule/capsule_bdd_test.go
+++ b/internal/capsule/capsule_bdd_test.go
@@ -7,7 +7,6 @@ package capsule
 import (
 	"context"
 	"crypto/ed25519"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -269,7 +268,7 @@ func (s *capsuleBDD) tamperField(field string) error {
 	return nil
 }
 func (s *capsuleBDD) signedCapsuleWithToolCalls() error {
-	c := Capsule{Capsule: Version, ID: "cap_tc", Thread: Thread{BaseWatermark: 1}, Messages: []Message{{Role: "assistant", Content: "c", ToolCalls: json.RawMessage(`[{"id":"1"}]`), XRoger: XRoger{Turn: 0, Agent: "roger:m", TS: 1}}}, Meta: Meta{ToolsUsed: []string{}}}
+	c := Capsule{Capsule: Version, ID: "cap_tc", Thread: Thread{BaseWatermark: 1}, Messages: []Message{{Role: "assistant", Content: "c", ToolCalls: ToolCallsRaw([]ToolCall{{Arguments: `{"url":"https://x.com/a?b=1&c=2"}`, ID: "call_1", Name: "open_url"}}), XRoger: XRoger{Turn: 0, Agent: "roger:m", TS: 1}}}, Meta: Meta{ToolsUsed: []string{}}}
 	c.Sign(s.priv)
 	s.incoming = c
 	return nil
@@ -279,9 +278,9 @@ func (s *capsuleBDD) importIncoming() error {
 	_, s.importErr = Import(raw)
 	return nil
 }
-func (s *capsuleBDD) importRejectedToolCalls() error {
-	if !errors.Is(s.importErr, ErrToolCalls) {
-		return bddErrf("expected ErrToolCalls, got %v", s.importErr)
+func (s *capsuleBDD) importAcceptedToolCalls() error {
+	if s.importErr != nil {
+		return bddErrf("expected a verified tool-call capsule to import (gate lifted), got %v", s.importErr)
 	}
 	return nil
 }
@@ -290,12 +289,12 @@ func (s *capsuleBDD) draftWithToolCalls() error {
 	return nil
 }
 func (s *capsuleBDD) exportDraft() error {
-	_, s.importErr = Export(Draft{ID: "cap_d", Messages: []Message{{Role: "assistant", Content: "c", ToolCalls: json.RawMessage(`[{"id":"1"}]`), XRoger: XRoger{Turn: 0, Agent: "roger:m"}}}}, s.priv, "roger-cli", fixedNow)
+	_, s.importErr = Export(Draft{ID: "cap_d", Thread: Thread{BaseWatermark: 1}, Messages: []Message{{Role: "assistant", Content: "c", ToolCalls: ToolCallsRaw([]ToolCall{{Arguments: `{"url":"https://x.com/a"}`, ID: "call_1", Name: "open_url"}}), XRoger: XRoger{Turn: 0, Agent: "roger:m"}}}}, s.priv, "roger-cli", fixedNow)
 	return nil
 }
-func (s *capsuleBDD) exportRefusedToolCalls() error {
-	if !errors.Is(s.importErr, ErrToolCalls) {
-		return bddErrf("expected ErrToolCalls, got %v", s.importErr)
+func (s *capsuleBDD) exportAcceptedToolCalls() error {
+	if s.importErr != nil {
+		return bddErrf("expected a tool-call draft to export (gate lifted), got %v", s.importErr)
 	}
 	return nil
 }
@@ -404,10 +403,10 @@ func TestCapsuleBDD(t *testing.T) {
 			sc.Step(`^I tamper the field "([^"]*)"$`, st.tamperField)
 			sc.Step(`^a signed capsule carrying tool_calls$`, st.signedCapsuleWithToolCalls)
 			sc.Step(`^I import it$`, st.importIncoming)
-			sc.Step(`^the import is rejected as tool_calls-unsupported$`, st.importRejectedToolCalls)
+			sc.Step(`^the import succeeds \(the gate is lifted\)$`, st.importAcceptedToolCalls)
 			sc.Step(`^a draft carrying tool_calls$`, st.draftWithToolCalls)
 			sc.Step(`^I export it$`, st.exportDraft)
-			sc.Step(`^the export is refused as tool_calls-unsupported$`, st.exportRefusedToolCalls)
+			sc.Step(`^the export succeeds \(the gate is lifted\)$`, st.exportAcceptedToolCalls)
 			sc.Step(`^I marshal and import it$`, st.marshalAndImport)
 			sc.Step(`^the import succeeds$`, st.importSucceeds)
 			sc.Step(`^the imported capsule verifies$`, st.importedVerifies)

--- a/internal/capsule/capsule_more_test.go
+++ b/internal/capsule/capsule_more_test.go
@@ -62,7 +62,7 @@ func TestCanonicalFieldOrderAndForm(t *testing.T) {
 			want: `{"capsule":"roger.context.v1","id":"cap_2","thread":{"origin_thread_id":"","title":"","base_watermark":-1},"redaction":"","summary":{"text":"","produced_by":"","as_of_turn":-5},"memory":{"notes":"","facts":[]},"messages":[{"role":"assistant","content":"","x_roger":{"turn":-2,"agent":"roger:m","model":null,"provider":null,"ts":-9}}],"meta":{"tools_used":[],"exported_by":"","created_at":0,"owner_pubkey":""}}`,
 		},
 		{
-			name: "conditional tool_calls slot present (verbatim raw)",
+			name: "conditional tool_calls slot present (already-canonical raw passes through)",
 			in: Capsule{
 				Capsule:  Version,
 				ID:       "cap_3",

--- a/internal/capsule/merge.go
+++ b/internal/capsule/merge.go
@@ -16,9 +16,6 @@ var (
 	ErrUnverified = errors.New("capsule: signature does not verify")
 	// ErrUnknownVersion rejects a capsule whose format is not Version.
 	ErrUnknownVersion = errors.New("capsule: unknown version")
-	// ErrToolCalls rejects a capsule carrying tool_calls (ruling Q1): the canonical form
-	// for tool_calls is not yet pinned cross-language, so none may cross the boundary.
-	ErrToolCalls = errors.New("capsule: tool_calls not supported at this boundary")
 	// ErrForkedTurn rejects a merge where an incoming turn collides with a present turn of
 	// the same index but different content (ruling Q2): the whole capsule is rejected and
 	// the target is left unchanged - a returning capsule may never rewrite history.
@@ -33,24 +30,20 @@ func turnHash(m Message) string {
 	return hex.EncodeToString(h[:])
 }
 
-// validateBoundary runs the version + tool_calls checks every crossing capsule must
-// pass. It does NOT verify the signature (callers that need verification call Verify or
-// Merge, which does both) - Export produces boundary-valid capsules, Merge/Import
-// consume them.
+// validateBoundary runs the version check every crossing capsule must pass. tool_calls are
+// no longer gated here: their canonical form is pinned cross-language (canonicalToolCalls +
+// the golden), so a verified tool-call capsule crosses like any other. It does NOT verify
+// the signature (callers that need verification call Verify or Merge, which does both) -
+// Export produces boundary-valid capsules, Merge/Import consume them.
 func validateBoundary(c Capsule) error {
 	if c.Capsule != Version {
 		return ErrUnknownVersion
-	}
-	for i := range c.Messages {
-		if len(c.Messages[i].ToolCalls) > 0 {
-			return ErrToolCalls
-		}
 	}
 	return nil
 }
 
 // Merge appends the turns in incoming that into does not already have, append-only. It
-// (1) rejects an incoming capsule that fails validateBoundary (version / tool_calls),
+// (1) rejects an incoming capsule that fails validateBoundary (unknown version),
 // (2) rejects one whose sig does not verify (verify-before-merge), (3) rejects the whole
 // capsule if any incoming turn forks a present turn (ruling Q2), then (4) appends only
 // incoming messages at/after into's base_watermark that are not already present (dedup by
@@ -115,8 +108,8 @@ func Merge(incoming, into Capsule) (Capsule, error) {
 }
 
 // Import decodes and verifies a capsule from raw JSON (a .rcap.json file / stdin). It
-// enforces the same boundary as Merge: valid JSON, known version, no tool_calls, and a
-// signature that verifies. The receiving side of the file interop.
+// enforces the same boundary as Merge: valid JSON, known version, and a signature that
+// verifies (tool_calls now interoperate). The receiving side of the file interop.
 func Import(data []byte) (Capsule, error) {
 	var c Capsule
 	if err := json.Unmarshal(data, &c); err != nil {
@@ -146,9 +139,9 @@ type Draft struct {
 
 // Export builds a signed roger.context.v1 capsule from d, stamping meta.exported_by =
 // exportedBy (e.g. "roger-cli"), created_at = now, and signing with priv (which also
-// sets owner_pubkey). It REJECTS a draft carrying tool_calls (ruling Q1) before signing,
-// so a capsule that crosses the boundary can never contain them. now is injectable for
-// deterministic tests; pass nil to use time.Now.
+// sets owner_pubkey). tool_calls are allowed (their canonical form is pinned); the
+// signature covers them via canonical(). now is injectable for deterministic tests; pass
+// nil to use time.Now.
 func Export(d Draft, priv ed25519.PrivateKey, exportedBy string, now func() int64) (Capsule, error) {
 	ts := time.Now().Unix
 	if now != nil {

--- a/internal/capsule/merge_test.go
+++ b/internal/capsule/merge_test.go
@@ -202,7 +202,7 @@ func TestMergeRejectsIntraIncomingFork(t *testing.T) {
 	}
 }
 
-// TestMergeRejectsUnknownVersion + tool_calls at the boundary.
+// TestMergeRejectsUnknownVersion: an unknown capsule version is rejected at the boundary.
 func TestMergeRejectsBoundary(t *testing.T) {
 	_, priv := keypair(t)
 	into := signed(t, priv, 0)
@@ -213,13 +213,42 @@ func TestMergeRejectsBoundary(t *testing.T) {
 	if _, err := Merge(badVer, into); !errors.Is(err, ErrUnknownVersion) {
 		t.Errorf("unknown version: err = %v, want ErrUnknownVersion", err)
 	}
+}
 
-	withTools := signed(t, priv, 0)
-	withTools.Messages = []Message{{Role: "assistant", Content: "c", ToolCalls: json.RawMessage(`[{"id":"1"}]`), XRoger: XRoger{Turn: 0, Agent: "roger:m", TS: 1}}}
-	withTools.Thread.BaseWatermark = 1
-	withTools.Sign(priv)
-	if _, err := Merge(withTools, into); !errors.Is(err, ErrToolCalls) {
-		t.Errorf("tool_calls: err = %v, want ErrToolCalls", err)
+// toolCallMsg builds an assistant turn carrying one flat tool_call (built via the producer
+// helper, so the wire bytes are canonical).
+func toolCallMsg(turn int) Message {
+	return Message{
+		Role:    "assistant",
+		Content: "c",
+		ToolCalls: ToolCallsRaw([]ToolCall{{
+			Arguments: `{"url":"https://x.com/a?b=1&c=2","note":"<tag> & \"q\""}`,
+			ID:        "call_1", Name: "open_url",
+		}}),
+		XRoger: XRoger{Turn: turn, Agent: "roger:m", TS: int64(turn)},
+	}
+}
+
+// TestMergeAcceptsToolCalls: the gate is LIFTED - a VERIFIED tool-call capsule now merges
+// (append-only, verify-first still apply), while an UNVERIFIED tool-call capsule is still
+// rejected (the safe state).
+func TestMergeAcceptsToolCalls(t *testing.T) {
+	_, priv := keypair(t)
+	into := Capsule{Capsule: Version, Thread: Thread{BaseWatermark: 0}}
+
+	verified := signed(t, priv, 1, toolCallMsg(0))
+	out, err := Merge(verified, into)
+	if err != nil {
+		t.Fatalf("verified tool-call capsule must merge (gate lifted): %v", err)
+	}
+	if !eqInts(turns(out), []int{0}) {
+		t.Errorf("merged turns = %v, want [0]", turns(out))
+	}
+
+	tampered := signed(t, priv, 1, toolCallMsg(0))
+	tampered.Messages[0].ToolCalls = ToolCallsRaw([]ToolCall{{Arguments: `{}`, ID: "evil", Name: "open_url"}})
+	if _, err := Merge(tampered, into); !errors.Is(err, ErrUnverified) {
+		t.Errorf("tampered tool-call capsule: err = %v, want ErrUnverified", err)
 	}
 }
 
@@ -260,13 +289,40 @@ func TestExportRoundtrip(t *testing.T) {
 	}
 }
 
-// TestExportRejectsToolCalls: Export refuses a draft carrying tool_calls (ruling Q1) so a
-// capsule that crosses the boundary can never contain them.
-func TestExportRejectsToolCalls(t *testing.T) {
+// TestToolCallCapsuleRoundtrip: a flat tool-call capsule exports -> signs -> verifies ->
+// imports -> merges (append-only), reproducing the tool_calls on the merged turn. The full
+// cross-language path for a capsule carrying tool calls, end to end.
+func TestToolCallCapsuleRoundtrip(t *testing.T) {
 	_, priv := keypair(t)
-	d := Draft{ID: "cap_t", Messages: []Message{{Role: "assistant", Content: "c", ToolCalls: json.RawMessage(`[{"id":"1"}]`), XRoger: XRoger{Turn: 0, Agent: "roger:m"}}}}
-	if _, err := Export(d, priv, "roger-cli", nil); !errors.Is(err, ErrToolCalls) {
-		t.Errorf("err = %v, want ErrToolCalls", err)
+	d := Draft{
+		ID:       "cap_tc",
+		Thread:   Thread{OriginThreadID: "t1", Title: "T", BaseWatermark: 1},
+		Messages: []Message{toolCallMsg(0)},
+	}
+	c, err := Export(d, priv, "roger-cli", func() int64 { return 100 })
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if !c.Verify() {
+		t.Fatal("exported tool-call capsule must verify")
+	}
+	raw, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	imported, err := Import(raw)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	out, err := Merge(imported, Capsule{Capsule: Version})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if !eqInts(turns(out), []int{0}) {
+		t.Errorf("round-trip turns = %v, want [0]", turns(out))
+	}
+	if len(out.Messages[0].ToolCalls) == 0 {
+		t.Error("merged turn lost its tool_calls")
 	}
 }
 

--- a/internal/capsule/stranger_transport_bdd_test.go
+++ b/internal/capsule/stranger_transport_bdd_test.go
@@ -62,7 +62,6 @@ func (s *strangerBDD) unrecoverableWithoutCode() error {
 	return nil
 }
 
-
 func (s *strangerBDD) freshKeypair() error {
 	_, s.priv, _ = ed25519.GenerateKey(nil)
 	return nil


### PR DESCRIPTION
Pins the flat tool_call shape and its canonical form against the app, and lifts the
reject-at-boundary gate so a verified tool-call capsule imports and merges like any other.

## Agreed flat shape (from the app side)

A tool_call is the app's FLAT struct (NOT OpenAI-nested), fields sorted:
`arguments, denied, failed, id, name` (+ `result` only when the tool has run). All values
are strings or JSON bools - no numbers. `arguments` is a STRING holding already-escaped JSON.

## Canonical rules

Compact, object keys sorted lexicographically at every level, arrays keep order, numbers
plain. Strings: `< > &` and `/` stay LITERAL (SetEscapeHTML off), U+2028/U+2029 escaped -
matching `CapsuleWire.swift`. `canonical()` now re-serializes `tool_calls` in this form
(parse generically with `json.Number`, sort, escape, compact) instead of emitting the
RawMessage verbatim.

## Golden reproduced byte-for-byte (both producers)

`TestGoldenVectorToolCalls` pins the app's golden with a hardcoded literal, fed a
deliberately NON-canonical raw (scrambled keys + HTML-escaped `<>&`) so the test proves
`canonical()` itself sorts + normalizes. The Go `canonical()` reproduced the app's golden
byte-for-byte on the FIRST green - no golden adjustment. Both `roger-cli` and `roger-ios`.

## Gate lifted (verify-before-merge still enforced)

`ErrToolCalls` removed; `validateBoundary` no longer rejects tool_calls. A VERIFIED
tool-call capsule now imports and merges (append-only). An UNVERIFIED / tampered tool-call
capsule is still rejected - the safe state. The signature covers the tool_calls via
`canonical()`.

## Producer

Flat `ToolCall` struct + `ToolCallsRaw` helper build the canonical wire bytes. Live E2E:
`roger context export` a tool-call draft (arguments exercising `<>&/` + a quote) then
`import` -> verified.

## RED -> GREEN

RED: `canonical()` emitted the scrambled raw verbatim != golden. GREEN: after
`canonicalToolCalls`, byte-for-byte match. Tamper, round-trip (export->sign->verify->import
->merge), escaping (`<>&/` + quote), U+2028/U+2029, unparseable-fallback, and gate-lifted
merge tests added. Real ed25519, no mocks. `internal/capsule` at 96.9%; cover-gate total 92.2%.

## Follow-up (NOT this PR)

The app side flagged an OPEN item: once interop is confirmed, drop the app-only
`denied`/`failed`/`result` from the portable format (a tool RESULT already travels as a
separate `role:"tool"` message) and re-pin the golden to a minimal `{id,name,arguments}`.
Tracked as a future item.
