### PR TITLE
release: v5.3.1 prep (tool_calls capsule interop)

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -40,7 +40,7 @@ import (
 //
 // The default below is the fallback for a plain `go build`. Keep it in sync with
 // releases. Use semver, optionally with a prerelease suffix (e.g. 4.8.0-beta.1).
-var Version = "5.3.0"
+var Version = "5.3.1"
 
 // The production broker is the default - `rogerai` works out of the box, no config.
 // Override per-session with ROGER_BROKER=... or persist with `roger config set broker`.

--- a/web/src/manual.html
+++ b/web/src/manual.html
@@ -35,7 +35,7 @@
         </p>
         <div class="man-cover__meta">
           <span>Set: <b>rogerai</b></span>
-          <span>Version: <b data-cli-version>v5.3.0</b></span>
+          <span>Version: <b data-cli-version>v5.3.1</b></span>
           <span>Broker: <b>broker.rogerai.fyi</b></span>
           <span>Protocol: <b>OpenAI-compatible</b></span>
         </div>
@@ -921,7 +921,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
           <section class="man-sec" id="s9">
             <span class="man-sec__no">§9 · Command reference</span>
             <h2>Every command, every key</h2>
-            <p>The full surface as of <b data-cli-version>v5.3.0</b>: the top-level CLI
+            <p>The full surface as of <b data-cli-version>v5.3.1</b>: the top-level CLI
               commands with their key flags, then the in-app keys and slash commands grouped
               by context. Run any command with <code>--help</code> for its flags; advanced
               flags hide behind <code>--advanced</code>. Run <code>rogerai</code> with no
@@ -1201,6 +1201,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
               Newest first. The set self-updates - <code>roger upgrade</code> pulls the
               latest, <code>roger upgrade --check</code> just reports.</p>
             <div class="man-plate">
+              <div class="man-plate__row"><span class="man-plate__k">v5.3.1</span><span class="man-plate__v">Context capsules that include tool calls now hand off cleanly between <code>roger</code> and the app.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.3.0</span><span class="man-plate__v">Hand off the conversation, not just the mic - the new <code>roger context</code> command exports and imports a signed conversation capsule, and handing the mic to a guest operator now carries the chat with it. Plus share an Osaurus-served model on the band with <code>roger share</code>.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.2.2</span><span class="man-plate__v">A hardened share node - when you SHARE your GPU, the node now relays only to the chat and voice endpoints on your local backend, nothing else.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.2.1</span><span class="man-plate__v">The AGENT desk, refined - THE DESK now opens once per model per session (cursor on the DJ, just type to chat), guests show their brand plates, and <code>/operator</code> sits in the footer. Plus <code>roger use --raw</code> to keep raw model output.</span></div>


### PR DESCRIPTION
Patch release for the one commit since v5.3.0: #68 (tool_calls cross-language interop for the context capsule).

## Changes
- `cmd/rogerai/main.go`: `Version` 5.3.0 -> 5.3.1
- `web/src/manual.html`: both `data-cli-version` badges -> v5.3.1, plus a new v5.3.1 row atop Appendix C:

  > Context capsules that include tool calls now hand off cleanly between `roger` and the app.

## Verified
- `node web/build.mjs` OK (29 pages; new changelog row renders in dist)
- `go build ./cmd/rogerai` OK; built binary stamps `rogerai 5.3.1`
- `go test ./test/smoke` (link crawler) green
- `git grep 5.3.0` outside the changelog history is clean; homebrew-cask stub left untouched (refreshed post-tag from checksums.txt)
- pre-push claude-audit: PASS

## NOTE
HOLD - do not tag from this PR. Tagging happens after merge (the coordinator tags).