### PR TITLE
relay: recognize thinking-model output (reasoning/tags/tool_calls/usage) - stop false empty-output voids + strikes

### DIFF
--- a/cmd/rogerai-broker/enforce_test.go
+++ b/cmd/rogerai-broker/enforce_test.go
@@ -220,8 +220,9 @@ func TestOwnerBanBlocksRelayPickUnderNewNodeID(t *testing.T) {
 }
 
 // TestProducedUsableOutputVoidGate: the void predicate is false (-> $0 charge) for an
-// errored response, an empty/whitespace completion, and a claim-without-text; true only
-// for a real completion.
+// errored response and the TRUE-negative (no text AND completion_tokens==0); true for a real
+// completion OR the usage backstop (empty text but the node reported completion tokens - an
+// over-claim there is capped/struck by the re-count layer, not voided here).
 func TestProducedUsableOutputVoidGate(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -233,9 +234,10 @@ func TestProducedUsableOutputVoidGate(t *testing.T) {
 		{"good output", 200, "hello", 5, true},
 		{"errored 500", 500, "hello", 5, false},
 		{"errored 400", 400, "hello", 5, false},
-		{"empty completion", 200, "", 0, false},
-		{"whitespace completion", 200, "   \n\t ", 7, false},
-		{"claimed-without-text", 200, "", 42, false},
+		{"empty completion, zero tokens", 200, "", 0, false},
+		{"whitespace text but tokens reported (usage backstop)", 200, "   \n\t ", 7, true},
+		{"empty text but tokens reported (usage backstop)", 200, "", 42, true},
+		{"whitespace text, zero tokens", 200, "  ", 0, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/cmd/rogerai-broker/enforce_test.go
+++ b/cmd/rogerai-broker/enforce_test.go
@@ -221,8 +221,9 @@ func TestOwnerBanBlocksRelayPickUnderNewNodeID(t *testing.T) {
 
 // TestProducedUsableOutputVoidGate: the void predicate is false (-> $0 charge) for an
 // errored response and the TRUE-negative (no text AND completion_tokens==0); true for a real
-// completion OR the usage backstop (empty text but the node reported completion tokens - an
-// over-claim there is capped/struck by the re-count layer, not voided here).
+// completion OR the usage backstop (empty text but the node reported completion tokens - which
+// is NOT struck, but is billed 0 by settleRecount's empty-capture guard, so an unverifiable
+// text-less claim is never paid).
 func TestProducedUsableOutputVoidGate(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/cmd/rogerai-broker/lineage_receipts_bdd_test.go
+++ b/cmd/rogerai-broker/lineage_receipts_bdd_test.go
@@ -589,7 +589,13 @@ func (s *lrState) nodeReturnsShape(shape string) error {
 	case "an empty / whitespace completion":
 		s.nodeStatus, s.nodeBody = 200, `{"choices":[{"message":{"content":"   "}}]}`
 		s.claimComp = 0
-	case "claimed tokens but no output text":
+	case "no output text and zero tokens":
+		// The TRUE-negative: no completion text AND completion_tokens==0 -> still voided + struck.
+		s.nodeStatus, s.nodeBody = 200, `{"choices":[{"message":{"content":""}}]}`
+		s.claimComp = 0
+	case "empty text but usage reports completion tokens":
+		// Usage backstop: no captured text but the node's usage reports tokens -> NOT voided
+		// (billed off the reported tokens), the honest owner is NOT struck.
 		s.nodeStatus, s.nodeBody = 200, `{"choices":[{"message":{"content":""}}]}`
 		s.claimComp = 5
 	default:
@@ -618,6 +624,30 @@ func (s *lrState) ownerFlagged() error {
 	}
 	if !struck {
 		return fmt.Errorf("a no-output request must flag (strike) the owner for empty output")
+	}
+	return nil
+}
+
+// billedNonZeroEarns asserts the usage-backstop path SETTLED (billed off the reported tokens
+// and the node earned), rather than voiding to $0.
+func (s *lrState) billedNonZeroEarns() error {
+	if !(s.spend > 0) {
+		return fmt.Errorf("empty text WITH reported completion tokens must be billed (usage backstop), spend=%.8f", s.spend)
+	}
+	if !(s.earn > 0) {
+		return fmt.Errorf("the usage-backstop path must mint an earning, earn=%.8f", s.earn)
+	}
+	return nil
+}
+
+// notFlaggedEmptyOutput asserts the honest owner was NOT struck on the usage-backstop path.
+func (s *lrState) notFlaggedEmptyOutput() error {
+	struck, err := s.ownerStruck()
+	if err != nil {
+		return err
+	}
+	if struck {
+		return fmt.Errorf("empty text WITH reported completion tokens must NOT strike the owner (usage backstop)")
 	}
 	return nil
 }
@@ -750,6 +780,8 @@ func TestLineageReceiptsBDD(t *testing.T) {
 			sc.Step(`^the consumer is charged 0 and the hold is refunded in full$`, st.charged0Refunded)
 			sc.Step(`^the owner is flagged for the empty output$`, st.ownerFlagged)
 			sc.Step(`^a \$0 metering receipt is still broker-co-signed and recorded for the lineage trail$`, st.zeroReceiptRecorded)
+			sc.Step(`^the consumer is billed a non-zero cost and the node earns$`, st.billedNonZeroEarns)
+			sc.Step(`^the owner is NOT flagged for empty output$`, st.notFlaggedEmptyOutput)
 
 			// idempotent settle
 			sc.Step(`^a receipt that has already settled for its request id$`, st.alreadySettled)

--- a/cmd/rogerai-broker/main.go
+++ b/cmd/rogerai-broker/main.go
@@ -262,6 +262,12 @@ type broker struct {
 	strikeDecayDays        int
 	strikeCorroborateKinds int
 
+	// streamIdleTimeout is the IDLE window a streaming relay waits for the node's receipt: it
+	// RESETS on every streamed delta (content OR reasoning), so a long reasoning think never
+	// trips a false stall/void - only genuine silence for the whole window aborts. 0 -> the
+	// defaultStreamIdle. Set small in tests to assert the reset without a real 300s wait.
+	streamIdleTimeout time.Duration
+
 	// banRev is the last cross-instance ban revision this instance has applied. Every
 	// ban/unban (node OR owner) bumps a shared monotonic counter (rogerai:ctr:ban:rev);
 	// syncBanRev compares it on the existing liveness sync tick and, on a change, RE-PULLS

--- a/cmd/rogerai-broker/reasoning_detector_test.go
+++ b/cmd/rogerai-broker/reasoning_detector_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// reasoning_detector_test.go is the unit half of the thinking-model output fix: the SHARED
+// detector (producedUsableOutput) and the two capture functions that feed it (sseDelta /
+// drainSSEDeltas on the STREAM path, completionText on the non-stream path) must recognise
+// every thinking-model output signal so an honest reasoning node is never false-voided /
+// false-struck / auto-banned. See features/trust/reasoning_stream_output.feature.
+
+// TestSseDeltaCapturesThinkingSignals: the stream capture must fold content, the reasoning
+// aliases (reasoning / reasoning_content / thinking), refusal, and tool/function calls - not
+// just delta.content/delta.text. Dropping reasoning was the root cause of the empty capture
+// that false-voided + auto-banned honest reasoning nodes.
+func TestSseDeltaCapturesThinkingSignals(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want []string // substrings that MUST appear in the captured text
+	}{
+		{"content", `data: {"choices":[{"delta":{"content":"hello"}}]}`, []string{"hello"}},
+		{"legacy text", `data: {"choices":[{"text":"legacy"}]}`, []string{"legacy"}},
+		{"reasoning alias", `data: {"choices":[{"delta":{"reasoning":"the answer is 42"}}]}`, []string{"the answer is 42"}},
+		{"reasoning_content alias", `data: {"choices":[{"delta":{"reasoning_content":"deliberating"}}]}`, []string{"deliberating"}},
+		{"thinking alias", `data: {"choices":[{"delta":{"thinking":"pondering"}}]}`, []string{"pondering"}},
+		{"content + reasoning", `data: {"choices":[{"delta":{"content":"final","reasoning":"scratch"}}]}`, []string{"final", "scratch"}},
+		{"refusal", `data: {"choices":[{"delta":{"refusal":"I can't help with that"}}]}`, []string{"I can't help with that"}},
+		{"tool_calls", `data: {"choices":[{"delta":{"content":null,"tool_calls":[{"function":{"name":"get_weather","arguments":"{\"city\":\"SF\"}"}}]}}]}`, []string{"get_weather", "SF"}},
+		{"function_call", `data: {"choices":[{"delta":{"function_call":{"name":"lookup","arguments":"{\"q\":\"x\"}"}}}]}`, []string{"lookup"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := sseDelta([]byte(c.line))
+			for _, w := range c.want {
+				if !strings.Contains(got, w) {
+					t.Fatalf("sseDelta(%s) = %q, must contain %q", c.name, got, w)
+				}
+			}
+		})
+	}
+	// A keepalive comment / the [DONE] sentinel capture nothing.
+	if got := sseDelta([]byte(": keepalive")); got != "" {
+		t.Fatalf("keepalive must capture nothing, got %q", got)
+	}
+	if got := sseDelta([]byte("data: [DONE]")); got != "" {
+		t.Fatalf("[DONE] must capture nothing, got %q", got)
+	}
+}
+
+// TestDrainSSEDeltasFoldsReasoning: the streaming re-count reconstruction (drainSSEDeltas)
+// must accumulate reasoning deltas across a multi-line SSE buffer, so the captured completion
+// used by the void + re-count gates is non-empty for a reasoning stream.
+func TestDrainSSEDeltasFoldsReasoning(t *testing.T) {
+	var raw, out bytes.Buffer
+	raw.WriteString("data: {\"choices\":[{\"delta\":{\"reasoning\":\"step one \"}}]}\n")
+	raw.WriteString("data: {\"choices\":[{\"delta\":{\"reasoning\":\"step two \"}}]}\n")
+	raw.WriteString("data: {\"choices\":[{\"delta\":{\"content\":\"the answer\"}}]}\n")
+	drainSSEDeltas(&raw, &out)
+	got := out.String()
+	for _, w := range []string{"step one ", "step two ", "the answer"} {
+		if !strings.Contains(got, w) {
+			t.Fatalf("drainSSEDeltas dropped %q; captured %q", w, got)
+		}
+	}
+}
+
+// TestProducedUsableOutputOROfAllSignals is the SHARED void-gate predicate matrix. A request
+// produced usable output when it did NOT error AND (there is any captured text OR the usage
+// backstop reports completion tokens). It is voided (and the owner struck) ONLY for the
+// TRUE-negative: an error, or genuinely no text AND completion_tokens==0.
+func TestProducedUsableOutputOROfAllSignals(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		completion string
+		claimed    int
+		want       bool
+	}{
+		{"content present", 200, "hello", 0, true},
+		{"reasoning captured as text", 200, "the answer is 42", 7, true},
+		{"inline think tags in content", 200, "<think>reasoning</think>", 0, true},
+		{"harmony channel markers in content", 200, "<|channel|>analysis<|message|>reasoning<|channel|>final<|message|>hi", 0, true},
+		{"tool call folded into text", 200, "get_weather{\"city\":\"SF\"}", 0, true},
+		{"refusal folded into text", 200, "I can't help with that", 0, true},
+		{"usage backstop: empty text, tokens reported", 200, "", 5, true},
+		{"whitespace only, no tokens", 200, "   ", 0, false},
+		{"true-negative: empty and zero tokens", 200, "", 0, false},
+		{"error status voids even with text", 502, "boom", 9, false},
+		{"error status voids even with tokens", 400, "", 5, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := producedUsableOutput(c.status, c.completion, c.claimed); got != c.want {
+				t.Fatalf("producedUsableOutput(%d, %q, %d) = %v, want %v", c.status, c.completion, c.claimed, got, c.want)
+			}
+		})
+	}
+}
+
+// TestCompletionTextFoldsAllSignals: the non-stream extractor must fold the SAME signals as
+// the stream capture (content + reasoning aliases + refusal + tool/function calls) so the
+// void gate AND the re-count see identical output on both paths - the asymmetry that dropped
+// reasoning on the stream path (but not here) was what stacked strikes into an auto-ban.
+func TestCompletionTextFoldsAllSignals(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"content", `{"choices":[{"message":{"content":"hi"}}]}`, []string{"hi"}},
+		{"reasoning", `{"choices":[{"message":{"content":"","reasoning":"the answer is 42"}}]}`, []string{"the answer is 42"}},
+		{"reasoning_content alias", `{"choices":[{"message":{"content":"","reasoning_content":"deliberating"}}]}`, []string{"deliberating"}},
+		{"refusal", `{"choices":[{"message":{"content":"","refusal":"I can't help"}}]}`, []string{"I can't help"}},
+		{"tool_calls", `{"choices":[{"message":{"content":null,"tool_calls":[{"function":{"name":"get_weather","arguments":"{\"city\":\"SF\"}"}}]}}]}`, []string{"get_weather", "SF"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := completionText([]byte(c.body))
+			for _, w := range c.want {
+				if !strings.Contains(got, w) {
+					t.Fatalf("completionText(%s) = %q, must contain %q", c.name, got, w)
+				}
+			}
+		})
+	}
+}
+
+// TestEnsureStreamIncludeUsage: the broker requests usage on the final chunk (the usage
+// backstop) by merging stream_options.include_usage=true into a streaming request, preserving
+// existing keys and leaving a non-streaming request untouched.
+func TestEnsureStreamIncludeUsage(t *testing.T) {
+	// streaming request with no stream_options -> gains include_usage
+	out := ensureStreamIncludeUsage([]byte(`{"model":"m","stream":true,"max_tokens":10}`))
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	so, ok := m["stream_options"].(map[string]any)
+	if !ok || so["include_usage"] != true {
+		t.Fatalf("include_usage not set: %s", out)
+	}
+	if m["model"] != "m" || m["max_tokens"].(float64) != 10 {
+		t.Fatalf("existing keys not preserved: %s", out)
+	}
+	// existing stream_options object is preserved and augmented
+	out2 := ensureStreamIncludeUsage([]byte(`{"stream":true,"stream_options":{"continuous_usage_stats":true}}`))
+	_ = json.Unmarshal(out2, &m)
+	so2 := m["stream_options"].(map[string]any)
+	if so2["include_usage"] != true || so2["continuous_usage_stats"] != true {
+		t.Fatalf("existing stream_options not merged: %s", out2)
+	}
+	// a NON-streaming request is left byte-for-byte unchanged
+	in := []byte(`{"model":"m"}`)
+	if got := ensureStreamIncludeUsage(in); string(got) != string(in) {
+		t.Fatalf("non-stream request must be untouched, got %s", got)
+	}
+}

--- a/cmd/rogerai-broker/reasoning_detector_test.go
+++ b/cmd/rogerai-broker/reasoning_detector_test.go
@@ -115,6 +115,7 @@ func TestCompletionTextFoldsAllSignals(t *testing.T) {
 		{"content", `{"choices":[{"message":{"content":"hi"}}]}`, []string{"hi"}},
 		{"reasoning", `{"choices":[{"message":{"content":"","reasoning":"the answer is 42"}}]}`, []string{"the answer is 42"}},
 		{"reasoning_content alias", `{"choices":[{"message":{"content":"","reasoning_content":"deliberating"}}]}`, []string{"deliberating"}},
+		{"thinking alias", `{"choices":[{"message":{"content":"","thinking":"pondering"}}]}`, []string{"pondering"}},
 		{"refusal", `{"choices":[{"message":{"content":"","refusal":"I can't help"}}]}`, []string{"I can't help"}},
 		{"tool_calls", `{"choices":[{"message":{"content":null,"tool_calls":[{"function":{"name":"get_weather","arguments":"{\"city\":\"SF\"}"}}]}}]}`, []string{"get_weather", "SF"}},
 	}

--- a/cmd/rogerai-broker/reasoning_detector_test.go
+++ b/cmd/rogerai-broker/reasoning_detector_test.go
@@ -160,4 +160,26 @@ func TestEnsureStreamIncludeUsage(t *testing.T) {
 	if got := ensureStreamIncludeUsage(in); string(got) != string(in) {
 		t.Fatalf("non-stream request must be untouched, got %s", got)
 	}
+	// an EXPLICIT client choice (include_usage:false) is respected, not overridden
+	inFalse := []byte(`{"stream":true,"stream_options":{"include_usage":false}}`)
+	if got := ensureStreamIncludeUsage(inFalse); string(got) != string(inFalse) {
+		t.Fatalf("explicit include_usage:false must be respected, got %s", got)
+	}
+}
+
+// TestSettleRecountEmptyCaptureBillsZero: the anti-fraud empty-capture guard. On a re-count
+// ENABLED broker, a claim with NO captured completion text is unverifiable and must bill 0
+// (never pay an unverifiable claim - the leak the usage backstop would otherwise reopen). A
+// re-count DISABLED broker has no counting capability and bills the claim as before.
+func TestSettleRecountEmptyCaptureBillsZero(t *testing.T) {
+	b := &broker{}
+	// re-count DISABLED: claim is billed (no verification capability).
+	if got := b.settleRecount("n", "r", "m", "", 500); got != 500 {
+		t.Fatalf("recount-disabled empty capture must bill the claim, got %d", got)
+	}
+	// re-count ENABLED but empty capture: bill 0 (unverifiable).
+	b.recount = recountConfig{url: "http://127.0.0.1:0", tolerance: 0.02, strikeTolerance: 0.25}
+	if got := b.settleRecount("n", "r", "m", "", 500); got != 0 {
+		t.Fatalf("recount-enabled empty capture must bill 0 (unverifiable), got %d", got)
+	}
 }

--- a/cmd/rogerai-broker/reasoning_output_test.go
+++ b/cmd/rogerai-broker/reasoning_output_test.go
@@ -18,9 +18,16 @@ func TestReasoningCountsAsOutput(t *testing.T) {
 	if got := completionText(contentOnly); got != "hello" {
 		t.Fatalf("content reply changed: got %q", got)
 	}
-	// Genuinely empty (no content, no reasoning) is still flagged.
+	// Empty text but the usage backstop reports completion tokens: NOT flagged (the model
+	// produced tokens per its own usage accounting; trusting it stops the false-void that
+	// auto-banned honest reasoning nodes when capture missed the text).
 	empty := []byte(`{"choices":[{"message":{"content":""}}]}`)
-	if producedUsableOutput(200, completionText(empty), 5) {
-		t.Fatal("a truly empty reply must still be flagged as no-output")
+	if !producedUsableOutput(200, completionText(empty), 5) {
+		t.Fatal("empty text WITH claimed completion tokens must NOT be voided (usage backstop)")
+	}
+	// The TRUE-negative: genuinely empty AND completion_tokens==0 is still flagged, so the
+	// strike stays useful.
+	if producedUsableOutput(200, completionText(empty), 0) {
+		t.Fatal("a truly empty reply with zero tokens must still be flagged as no-output")
 	}
 }

--- a/cmd/rogerai-broker/reasoning_stream_bdd_test.go
+++ b/cmd/rogerai-broker/reasoning_stream_bdd_test.go
@@ -220,6 +220,12 @@ func (s *rsState) noTextClaims5() error {
 	return nil
 }
 
+func (s *rsState) noTextClaimsLarge() error {
+	s.chunks = []string{": keepalive\n\n"} // liveness only, no output text
+	s.claimComp = 100000
+	return nil
+}
+
 func (s *rsState) reasoningLastContent() error {
 	s.chunks = []string{
 		rsDelta("reasoning", "consider the options "),
@@ -360,6 +366,16 @@ func (s *rsState) struckEmptyOutput() error {
 	return nil
 }
 
+// unverifiableNotPaid asserts a text-less completion claim minted no output revenue: the
+// spend is bounded to the tiny input cost, FAR below what the 100000-token claim would bill
+// (100000 * 1/1e6 = 0.1) had the unverifiable completion been paid.
+func (s *rsState) unverifiableNotPaid() error {
+	if s.spend >= 1e-3 {
+		return fmt.Errorf("an unverifiable text-less completion claim must not be paid; spend=%.8f (a paid 100000-token claim would be ~0.1)", s.spend)
+	}
+	return nil
+}
+
 func (s *rsState) ownerNotBanned() error {
 	if s.b.isOwnerBanned("op1") {
 		return fmt.Errorf("an honest reasoning node's owner must NOT be auto-banned")
@@ -390,6 +406,8 @@ func TestReasoningStreamOutputBDD(t *testing.T) {
 			sc.Step(`^the node streams reasoning deltas only with an empty content and finish_reason length$`, st.reasoningOnlyLength)
 			sc.Step(`^the node's receipt claims the reasoning token count$`, st.claimReasoningCount)
 			sc.Step(`^the node streams no output text but its receipt claims 5 completion tokens$`, st.noTextClaims5)
+			sc.Step(`^the node streams no output text but its receipt claims 100000 completion tokens$`, st.noTextClaimsLarge)
+			sc.Step(`^the consumer is not billed for the unverifiable completion claim$`, st.unverifiableNotPaid)
 			sc.Step(`^the node streams 3 reasoning deltas and puts the only content in the last delta$`, st.reasoningLastContent)
 			sc.Step(`^the node streams no output text and its receipt claims 0 completion tokens$`, st.noTextClaims0)
 			sc.Step(`^a short idle window and the node streams reasoning deltas spaced across more than that window$`, st.shortIdleSpacedDeltas)

--- a/cmd/rogerai-broker/reasoning_stream_bdd_test.go
+++ b/cmd/rogerai-broker/reasoning_stream_bdd_test.go
@@ -1,0 +1,419 @@
+package main
+
+// reasoning_stream_bdd_test.go makes features/trust/reasoning_stream_output.feature an
+// EXECUTABLE godog suite against the REAL streaming relay. A node goroutine streams real SSE
+// deltas to /agent/stream (the same wire the production node uses) then posts a signed
+// receipt; the broker runs its capture + void + re-count + strike stack for real, with a real
+// (in-process) tokenizer sidecar so the recount-discrepancy path is live. No mocks.
+//
+// It pins the thinking-model fix end-to-end: reasoning deltas are captured (not dropped), so
+// an honest reasoning stream is served (not voided), the re-count counts reasoning (no
+// discrepancy), and neither the empty-output nor the recount strike fires - so corroboration
+// never trips and the honest node is never auto-banned. The TRUE-negative (no text, zero
+// tokens) still voids + strikes, keeping the strike useful.
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/rogerai-fyi/roger/internal/protocol"
+	"github.com/rogerai-fyi/roger/internal/store"
+)
+
+// rsWordCount is the deterministic "tokenizer" the in-process sidecar uses: whitespace words.
+// The node claims exactly this many completion tokens for the text it streams, so a correct
+// (reasoning-inclusive) broker re-count matches the claim and never flags a discrepancy.
+func rsWordCount(text string) int { return len(strings.Fields(text)) }
+
+type rsState struct {
+	t *testing.T
+	b *broker
+
+	nodePub  ed25519.PublicKey
+	nodePriv ed25519.PrivateKey
+
+	// per-scenario stream config
+	chunks    []string      // SSE lines the node streams to /agent/stream
+	gap       time.Duration // inter-delta delay (idle-timer scenario)
+	claimComp int           // completion_tokens the node claims in its receipt
+	status    int
+	idle      time.Duration // broker idle/void window override (0 = default)
+
+	// results (single-run scenarios)
+	spend float64
+	earn  float64
+}
+
+func (s *rsState) reset() {
+	s.nodePub, s.nodePriv, _ = ed25519.GenerateKey(nil)
+	s.chunks = nil
+	s.gap = 0
+	s.claimComp = 0
+	s.status = 200
+	s.idle = 0
+	s.spend, s.earn = 0, 0
+	s.b = nil
+}
+
+// newStreamBroker builds a broker with the streaming relay wired to a real in-process
+// tokenizer sidecar (so settleRecount runs a live re-count) and a funded logged-in consumer.
+func (s *rsState) newStreamBroker() (*broker, ed25519.PrivateKey, *nodeTunnel, *httptest.Server) {
+	db := store.NewMem()
+	b := relayBroker(db)
+	b.strikeDecayDays = strikeDecayDays()
+	b.strikeCorroborateKinds = strikeCorroborateKinds()
+	if s.idle > 0 {
+		b.streamIdleTimeout = s.idle
+	}
+	// Real in-process tokenizer sidecar: counts whitespace words, exact.
+	sidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Text string `json:"text"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		fmt.Fprintf(w, `{"tokens":%d,"exact":true}`, rsWordCount(req.Text))
+	}))
+	b.recount = recountConfig{url: sidecar.URL, tolerance: 0.02, strikeTolerance: 0.25, client: &http.Client{Timeout: 2 * time.Second}}
+
+	b.nodes["n1"] = protocol.NodeRegistration{
+		NodeID: "n1", PubKey: hex.EncodeToString(s.nodePub), BridgeToken: "tok",
+		Offers: []protocol.ModelOffer{{Model: "m", PriceIn: 1.0, PriceOut: 1.0, Ctx: 4096}},
+	}
+	b.lastSeen["n1"] = time.Now()
+	tun := &nodeTunnel{jobs: make(chan protocol.Job, 1), waiters: map[string]chan protocol.JobResult{}, token: "tok"}
+	b.tunnels["n1"] = tun
+	if err := db.BindNode("n1", "op1"); err != nil {
+		s.t.Fatal(err)
+	}
+
+	_, userPriv, _ := ed25519.GenerateKey(nil)
+	userPubHex := hex.EncodeToString(userPriv.Public().(ed25519.PublicKey))
+	if err := db.BindOwner(store.Owner{GitHubID: 7, Login: "alice", Pubkey: userPubHex}); err != nil {
+		s.t.Fatal(err)
+	}
+	if _, err := db.AddCredits("u_gh_7", 1e9); err != nil {
+		s.t.Fatal(err)
+	}
+	s.b = b
+	return b, userPriv, tun, sidecar
+}
+
+// runOneStream drives ONE full streaming relay round-trip on b: a node goroutine answers the
+// dispatched job by streaming s.chunks to /agent/stream (optionally spaced by s.gap) then
+// posting a signed receipt claiming claimComp completion tokens. Returns after settlement.
+func (s *rsState) runOneStream(b *broker, userPriv ed25519.PrivateKey, tun *nodeTunnel, chunks []string, gap time.Duration, claimComp, status int) {
+	go func() {
+		job := <-tun.jobs
+		// Stream the SSE chunks to the broker exactly as a real node's /agent/stream POST does.
+		if gap == 0 {
+			req := httptest.NewRequest(http.MethodPost, "/agent/stream?node=n1&job="+job.ID, strings.NewReader(strings.Join(chunks, "")))
+			req.Header.Set("Authorization", "Bearer tok")
+			b.agentStream(httptest.NewRecorder(), req)
+		} else {
+			pr, pw := io.Pipe()
+			req := httptest.NewRequest(http.MethodPost, "/agent/stream?node=n1&job="+job.ID, pr)
+			req.Header.Set("Authorization", "Bearer tok")
+			done := make(chan struct{})
+			go func() { b.agentStream(httptest.NewRecorder(), req); close(done) }()
+			for _, c := range chunks {
+				_, _ = pw.Write([]byte(c))
+				time.Sleep(gap)
+			}
+			_ = pw.Close()
+			<-done
+		}
+		rec := protocol.UsageReceipt{
+			RequestID: job.ID, NodeID: "n1", Model: "m",
+			PromptTokens: 1, CompletionTokens: claimComp, PriceIn: 1.0, PriceOut: 1.0,
+			TS: time.Now().Unix(),
+		}
+		rec.SignNode(s.nodePriv)
+		res := protocol.JobResult{ID: job.ID, Status: status, Body: []byte(`{"choices":[{"message":{"content":""}}]}`), Receipt: rec}
+		tun.mu.Lock()
+		ch := tun.waiters[job.ID]
+		tun.mu.Unlock()
+		ch <- res
+	}()
+
+	reqBody := []byte(`{"model":"m","max_tokens":1000,"stream":true}`)
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(reqBody)))
+	signReq(r, userPriv, reqBody)
+	b.relay(httptest.NewRecorder(), r)
+}
+
+func (s *rsState) settle() {
+	// settleRecount folds the discrepancy into an owner strike from a goroutine; give it a
+	// bounded moment to land so a "NOT struck" assertion is not read too early.
+	time.Sleep(200 * time.Millisecond)
+	s.spend, _ = s.b.db.SpendOf("u_gh_7")
+	s.earn, _ = s.b.db.EarningsOf("n1")
+}
+
+func (s *rsState) strikesOfKind(kind string) int {
+	st, err := s.b.db.StrikesByOwner("op1", 200)
+	if err != nil {
+		s.t.Fatal(err)
+	}
+	n := 0
+	for _, k := range st {
+		if kind == "" || k.Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// --- reasoning content builders ---------------------------------------------
+
+func rsDelta(field, text string) string {
+	return fmt.Sprintf(`data: {"choices":[{"delta":{%q:%q}}]}`+"\n\n", field, text)
+}
+
+// --- Given steps ------------------------------------------------------------
+
+func (s *rsState) bgNode() error     { return nil }
+func (s *rsState) bgConsumer() error { return nil }
+
+func (s *rsState) reasoningThenContent() error {
+	s.chunks = []string{
+		rsDelta("reasoning", "let me think about "),
+		rsDelta("reasoning", "the users question "),
+		rsDelta("reasoning", "carefully step by "),
+		rsDelta("reasoning", "step now "),
+		rsDelta("content", "the final answer is 42"),
+	}
+	return nil
+}
+
+func (s *rsState) claimFullCount() error {
+	s.claimComp = rsWordCount(rsGeneratedText(s.chunks))
+	return nil
+}
+
+func (s *rsState) reasoningOnlyLength() error {
+	s.chunks = []string{
+		rsDelta("reasoning", "the answer requires "),
+		rsDelta("reasoning", "a long private deliberation "),
+		rsDelta("reasoning", "that never emits content "),
+	}
+	return nil
+}
+
+func (s *rsState) claimReasoningCount() error {
+	s.claimComp = rsWordCount(rsGeneratedText(s.chunks))
+	return nil
+}
+
+func (s *rsState) noTextClaims5() error {
+	s.chunks = []string{": keepalive\n\n"} // liveness only, no output text
+	s.claimComp = 5
+	return nil
+}
+
+func (s *rsState) reasoningLastContent() error {
+	s.chunks = []string{
+		rsDelta("reasoning", "consider the options "),
+		rsDelta("reasoning", "weigh them "),
+		rsDelta("reasoning", "decide "),
+		rsDelta("content", "answer chosen"),
+	}
+	return nil
+}
+
+func (s *rsState) noTextClaims0() error {
+	s.chunks = []string{": keepalive\n\n"}
+	s.claimComp = 0
+	return nil
+}
+
+func (s *rsState) shortIdleSpacedDeltas() error {
+	s.idle = 120 * time.Millisecond
+	s.gap = 40 * time.Millisecond
+	// ~6 gaps * 40ms = 240ms total, each 40ms < the 120ms idle window: a reset-on-delta timer
+	// never trips; a fixed deadline would abort before the receipt.
+	s.chunks = []string{
+		rsDelta("reasoning", "slow think one "),
+		rsDelta("reasoning", "slow think two "),
+		rsDelta("reasoning", "slow think three "),
+		rsDelta("reasoning", "slow think four "),
+		rsDelta("content", "done at last"),
+	}
+	return nil
+}
+
+// rsGeneratedText is the text the NODE actually generated across its deltas (content + every
+// reasoning alias), parsed DIRECTLY from the SSE JSON - independent of the production sseDelta
+// capture. The node's usage.completion_tokens counts ALL generated tokens, so an honest node's
+// claim is rsWordCount(rsGeneratedText). A correct broker re-count (which now counts reasoning)
+// matches it; the pre-fix reasoning-stripped re-count falls far short and false-fires
+// recount-discrepancy - which is exactly what this suite pins.
+func rsGeneratedText(chunks []string) string {
+	var b strings.Builder
+	for _, c := range chunks {
+		for _, line := range strings.Split(c, "\n") {
+			i := strings.IndexByte(line, '{')
+			if i < 0 {
+				continue
+			}
+			var d struct {
+				Choices []struct {
+					Delta struct {
+						Content          string `json:"content"`
+						Reasoning        string `json:"reasoning"`
+						ReasoningContent string `json:"reasoning_content"`
+						Thinking         string `json:"thinking"`
+					} `json:"delta"`
+				} `json:"choices"`
+			}
+			if json.Unmarshal([]byte(line[i:]), &d) != nil {
+				continue
+			}
+			for _, ch := range d.Choices {
+				b.WriteString(ch.Delta.Content)
+				b.WriteString(ch.Delta.Reasoning)
+				b.WriteString(ch.Delta.ReasoningContent)
+				b.WriteString(ch.Delta.Thinking)
+			}
+		}
+	}
+	return b.String()
+}
+
+// --- When steps -------------------------------------------------------------
+
+func (s *rsState) relayStreaming() error {
+	b, userPriv, tun, sc := s.newStreamBroker()
+	defer sc.Close()
+	s.runOneStream(b, userPriv, tun, s.chunks, s.gap, s.claimComp, s.status)
+	s.settle()
+	return nil
+}
+
+func (s *rsState) relayHonestMix() error {
+	b, userPriv, tun, sc := s.newStreamBroker()
+	defer sc.Close()
+	reasoningOnly := []string{
+		rsDelta("reasoning", "private chain of "),
+		rsDelta("reasoning", "thought only "),
+	}
+	reasoningContent := []string{
+		rsDelta("reasoning", "brief think "),
+		rsDelta("content", "the answer"),
+	}
+	for i := 0; i < 3; i++ {
+		s.runOneStream(b, userPriv, tun, reasoningOnly, 0, rsWordCount(rsGeneratedText(reasoningOnly)), 200)
+	}
+	for i := 0; i < 3; i++ {
+		s.runOneStream(b, userPriv, tun, reasoningContent, 0, rsWordCount(rsGeneratedText(reasoningContent)), 200)
+	}
+	time.Sleep(300 * time.Millisecond) // let async recount observations land
+	return nil
+}
+
+// --- Then steps -------------------------------------------------------------
+
+func (s *rsState) servedNonZero() error {
+	if !(s.spend > 0) {
+		return fmt.Errorf("stream must be served and billed a non-zero cost, spend=%.8f", s.spend)
+	}
+	return nil
+}
+
+func (s *rsState) nodeEarns() error {
+	if !(s.earn > 0) {
+		return fmt.Errorf("a served stream must mint an earning, earn=%.8f", s.earn)
+	}
+	return nil
+}
+
+func (s *rsState) ownerNotStruck() error {
+	if n := s.strikesOfKind(""); n != 0 {
+		return fmt.Errorf("honest reasoning node must NOT be struck, got %d strike(s)", n)
+	}
+	return nil
+}
+
+func (s *rsState) voidedZero() error {
+	if s.spend != 0 {
+		return fmt.Errorf("a true-negative empty stream must charge 0, spend=%.8f", s.spend)
+	}
+	if s.earn != 0 {
+		return fmt.Errorf("a true-negative empty stream must mint no earning, earn=%.8f", s.earn)
+	}
+	return nil
+}
+
+func (s *rsState) struckEmptyOutput() error {
+	if n := s.strikesOfKind(store.StrikeEmptyOutput); n < 1 {
+		return fmt.Errorf("a true-negative empty stream must strike empty-output (strike stays useful), got %d", n)
+	}
+	return nil
+}
+
+func (s *rsState) ownerNotBanned() error {
+	if s.b.isOwnerBanned("op1") {
+		return fmt.Errorf("an honest reasoning node's owner must NOT be auto-banned")
+	}
+	return nil
+}
+
+func (s *rsState) ownerNoStrikes() error {
+	if n := s.strikesOfKind(""); n != 0 {
+		return fmt.Errorf("an honest reasoning node's owner must have zero strikes, got %d", n)
+	}
+	return nil
+}
+
+func TestReasoningStreamOutputBDD(t *testing.T) {
+	st := &rsState{t: t}
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				st.reset()
+				return ctx, nil
+			})
+			sc.Step(`^a reasoning-capable node registered with the broker$`, st.bgNode)
+			sc.Step(`^a funded consumer$`, st.bgConsumer)
+
+			sc.Step(`^the node streams 4 reasoning deltas then 1 content delta$`, st.reasoningThenContent)
+			sc.Step(`^the node's receipt claims the full reasoning\+content token count$`, st.claimFullCount)
+			sc.Step(`^the node streams reasoning deltas only with an empty content and finish_reason length$`, st.reasoningOnlyLength)
+			sc.Step(`^the node's receipt claims the reasoning token count$`, st.claimReasoningCount)
+			sc.Step(`^the node streams no output text but its receipt claims 5 completion tokens$`, st.noTextClaims5)
+			sc.Step(`^the node streams 3 reasoning deltas and puts the only content in the last delta$`, st.reasoningLastContent)
+			sc.Step(`^the node streams no output text and its receipt claims 0 completion tokens$`, st.noTextClaims0)
+			sc.Step(`^a short idle window and the node streams reasoning deltas spaced across more than that window$`, st.shortIdleSpacedDeltas)
+			sc.Step(`^the node serves 3 reasoning-only and 3 reasoning\+content honest streams$`, func() error { return nil })
+
+			sc.Step(`^the consumer relays the streaming request$`, st.relayStreaming)
+			sc.Step(`^the consumer relays each streaming request$`, st.relayHonestMix)
+
+			sc.Step(`^the stream is served and settled for a non-zero cost$`, st.servedNonZero)
+			sc.Step(`^the node earns for the request$`, st.nodeEarns)
+			sc.Step(`^the node's owner is NOT struck$`, st.ownerNotStruck)
+			sc.Step(`^the stream is voided at zero cost with the hold refunded$`, st.voidedZero)
+			sc.Step(`^the node's owner IS struck for empty output$`, st.struckEmptyOutput)
+			sc.Step(`^the node's owner is NOT banned$`, st.ownerNotBanned)
+			sc.Step(`^the node's owner has no strikes of any kind$`, st.ownerNoStrikes)
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../features/trust/reasoning_stream_output.feature"},
+			TestingT: t,
+			Strict:   true,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("reasoning-stream-output behavior scenarios failed (see godog output above)")
+	}
+}

--- a/cmd/rogerai-broker/recount.go
+++ b/cmd/rogerai-broker/recount.go
@@ -126,12 +126,23 @@ func (c recountConfig) sidecarCount(model, text string) (tokens int, exact bool,
 // ALSO folds the sample into the node's trust state + the promotion-hold flag in a
 // goroutine (OFF the hot path), reusing this single sidecar result so the relay path
 // never double-calls the sidecar. Returns `claimed` immediately when re-count is off.
+//
+// EMPTY-CAPTURE GUARD (anti-fraud): on a re-count-ENABLED broker a claim with NO captured
+// completion text is UNVERIFIABLE - we cannot count what we did not capture - so we bill 0
+// rather than pay the node's unverified claim. This closes the claim-without-text leak that
+// the usage backstop would otherwise reopen: producedUsableOutput's backstop keeps an honest
+// reasoning node (whose text we simply failed to capture) from being false-struck, but it must
+// NOT also pay an unverifiable output claim. A re-count-DISABLED broker has no counting
+// capability at all, so it bills the claim as before (its whole model is claim-trust).
 func (b *broker) settleRecount(nodeID, requestID, model, completion string, claimed int) int {
 	if claimed < 0 {
 		claimed = 0 // a negative node-claimed count never bills, records, signs, or logs negative
 	}
-	if !b.recount.enabled() || completion == "" || claimed <= 0 {
+	if !b.recount.enabled() || claimed <= 0 {
 		return claimed
+	}
+	if completion == "" {
+		return 0 // re-count enabled but nothing to verify: never bill an unverifiable claim
 	}
 	recounted, exact, ok := b.recount.sidecarCount(model, completion)
 	if !ok {

--- a/cmd/rogerai-broker/recount.go
+++ b/cmd/rogerai-broker/recount.go
@@ -380,8 +380,12 @@ func completionText(body []byte) string {
 	var resp struct {
 		Choices []struct {
 			Message struct {
-				Content   string `json:"content"`
-				Reasoning string `json:"reasoning"`
+				Content          string     `json:"content"`
+				Reasoning        string     `json:"reasoning"`
+				ReasoningContent string     `json:"reasoning_content"`
+				Refusal          string     `json:"refusal"`
+				ToolCalls        []toolCall `json:"tool_calls"`
+				FunctionCall     *nameArgs  `json:"function_call"`
 			} `json:"message"`
 			Text string `json:"text"`
 		} `json:"choices"`
@@ -389,18 +393,22 @@ func completionText(body []byte) string {
 	if json.Unmarshal(body, &resp) != nil {
 		return ""
 	}
-	var out bytes.Buffer
+	var out strings.Builder
 	for _, c := range resp.Choices {
 		if c.Message.Content != "" {
 			out.WriteString(c.Message.Content)
 		} else if c.Text != "" {
 			out.WriteString(c.Text)
 		}
-		// Reasoning is real output (reasoning models put the answer here with empty
-		// content); count it so the no-output / over-report checks don't false-strike.
-		if c.Message.Reasoning != "" {
-			out.WriteString(c.Message.Reasoning)
-		}
+		// Reasoning aliases are real output (reasoning models put the answer in reasoning /
+		// reasoning_content with empty content); a refusal and a tool/function call are real
+		// generated tokens too. Fold them all so the no-output void + the over-report re-count
+		// see the SAME output the stream capture (sseDelta) does - the asymmetry that dropped
+		// reasoning on the stream path stacked strikes into an auto-ban of honest nodes.
+		out.WriteString(c.Message.Reasoning)
+		out.WriteString(c.Message.ReasoningContent)
+		out.WriteString(c.Message.Refusal)
+		foldCalls(&out, c.Message.ToolCalls, c.Message.FunctionCall)
 	}
 	return out.String()
 }
@@ -430,26 +438,27 @@ func qualityOKText(s string) bool {
 	return strings.TrimSpace(s) != ""
 }
 
-// producedUsableOutput is the VOID gate predicate (P0): a request produced usable
-// output ONLY when the node did not error AND a non-empty completion was returned. It
-// is false - so the charge is VOIDED ($0, no earning, hold refunded) - when ANY of:
-//   - the node returned an error (status >= 400),
-//   - the completion is empty/whitespace, OR
-//   - the completion is empty yet the node CLAIMED completion tokens (claim-without-text).
+// producedUsableOutput is the SHARED VOID gate predicate (P0), used IDENTICALLY on the
+// stream and non-stream paths so they can never diverge again. It is an OR-of-all output
+// signals accumulated to end-of-response: a request produced usable output when the node did
+// NOT error AND EITHER any output text was captured OR the usage backstop reports completion
+// tokens. The `completion` string already folds every thinking-model text signal (content,
+// the reasoning aliases, an inline <think>/harmony block, a refusal, and tool/function-call
+// name+arguments) via completionText / sseDelta; `claimedCompletion` is the node-reported
+// completion_tokens from the usage chunk (the backstop when text was not captured, e.g. an
+// unusual reasoning shape).
 //
-// claimedCompletion is the node's self-reported completion_tokens; completion is the
-// extracted assistant text (relay: completionText(body); stream: the captured text).
+// It VOIDS ($0, no earning, hold refunded) + strikes ONLY for the TRUE-negative: an error
+// status, or genuinely NO text AND completion_tokens==0 - so the strike stays useful against
+// a real no-output node while an honest reasoning/tool node is never false-struck.
 func producedUsableOutput(status int, completion string, claimedCompletion int) bool {
 	if status >= 400 {
 		return false
 	}
-	if strings.TrimSpace(completion) == "" {
-		return false
+	if strings.TrimSpace(completion) != "" {
+		return true // any content / reasoning / tags / refusal / tool-call text
 	}
-	if completion == "" && claimedCompletion > 0 {
-		return false
-	}
-	return true
+	return claimedCompletion > 0 // usage backstop: the model reported generated tokens
 }
 
 // recountModel is the model id to tokenize under: prefer the receipt's claimed

--- a/cmd/rogerai-broker/recount.go
+++ b/cmd/rogerai-broker/recount.go
@@ -383,6 +383,7 @@ func completionText(body []byte) string {
 				Content          string     `json:"content"`
 				Reasoning        string     `json:"reasoning"`
 				ReasoningContent string     `json:"reasoning_content"`
+				Thinking         string     `json:"thinking"`
 				Refusal          string     `json:"refusal"`
 				ToolCalls        []toolCall `json:"tool_calls"`
 				FunctionCall     *nameArgs  `json:"function_call"`
@@ -407,6 +408,7 @@ func completionText(body []byte) string {
 		// reasoning on the stream path stacked strikes into an auto-ban of honest nodes.
 		out.WriteString(c.Message.Reasoning)
 		out.WriteString(c.Message.ReasoningContent)
+		out.WriteString(c.Message.Thinking)
 		out.WriteString(c.Message.Refusal)
 		foldCalls(&out, c.Message.ToolCalls, c.Message.FunctionCall)
 	}
@@ -442,9 +444,10 @@ func qualityOKText(s string) bool {
 // stream and non-stream paths so they can never diverge again. It is an OR-of-all output
 // signals accumulated to end-of-response: a request produced usable output when the node did
 // NOT error AND EITHER any output text was captured OR the usage backstop reports completion
-// tokens. The `completion` string already folds every thinking-model text signal (content,
-// the reasoning aliases, an inline <think>/harmony block, a refusal, and tool/function-call
-// name+arguments) via completionText / sseDelta; `claimedCompletion` is the node-reported
+// tokens. The `completion` string already folds every thinking-model text signal (content -
+// which carries any inline <think>/harmony markers as-is, no separate parser - the reasoning
+// aliases, a refusal, and tool/function-call name+arguments) via completionText / sseDelta;
+// `claimedCompletion` is the node-reported
 // completion_tokens from the usage chunk (the backstop when text was not captured, e.g. an
 // unusual reasoning shape).
 //

--- a/cmd/rogerai-broker/relay_variants_cov_test.go
+++ b/cmd/rogerai-broker/relay_variants_cov_test.go
@@ -181,7 +181,10 @@ func TestRelayPaidVoidNoOutputRoundTrip(t *testing.T) {
 		job := <-tun.jobs
 		rec := protocol.UsageReceipt{
 			RequestID: job.ID, NodeID: "paid", Model: "m",
-			PromptTokens: 10, CompletionTokens: 5, // claims output, but the body has none
+			// TRUE-negative: empty body AND zero reported completion tokens -> voided. (An empty
+			// body WITH reported tokens is the usage backstop - billed off the reported tokens,
+			// capped/struck by the re-count layer - not voided; see recount_billing.feature.)
+			PromptTokens: 10, CompletionTokens: 0,
 			PriceIn: 8, PriceOut: 8, TS: time.Now().Unix(),
 		}
 		rec.SignNode(nodePriv)

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -175,6 +175,22 @@ type streamSink struct {
 	start    time.Time
 	ttftDone bool
 	ttftSeen int // running count of meaningful chars observed before the sample lands
+	// activity signals the settlement select that a streamed delta arrived (content OR
+	// reasoning), so the idle/void timer RESETS on any output and a long think never trips a
+	// false stall. Buffered depth 1; a non-blocking send coalesces bursts.
+	activity chan struct{}
+}
+
+// noteActivity nudges the idle/void timer that a streamed delta arrived (any chunk - content
+// or reasoning - counts as liveness). Non-blocking + nil-safe.
+func (s *streamSink) noteActivity() {
+	if s.activity == nil {
+		return
+	}
+	select {
+	case s.activity <- struct{}{}:
+	default:
+	}
 }
 
 // register handles POST /nodes/register: a node announces itself + its offers
@@ -1452,6 +1468,15 @@ func (b *broker) relay(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = json.Unmarshal(body, &req)
 
+	// Usage backstop: ask the model for a final usage chunk on streaming requests so the
+	// node's receipt carries completion_tokens even when the delta text is an unusual
+	// reasoning shape (producedUsableOutput trusts it rather than false-voiding). Additive +
+	// order-preserving on the chat payload (messages unchanged), so the prompt re-count and
+	// moderation screen are unaffected; a no-op for non-streaming requests.
+	if req.Stream {
+		body = ensureStreamIncludeUsage(body)
+	}
+
 	// Grant token caps (daily/monthly) - checked before dispatch, denied at 429.
 	if gok {
 		if st, msg := b.grantCapCheck(gc.grant); st != 0 {
@@ -1904,6 +1929,20 @@ func (b *broker) busDispatchJob(ctx context.Context, nodeID string, job protocol
 	return resCh, cancel, nil
 }
 
+// defaultStreamIdle is the idle/void window a streaming relay tolerates between deltas before
+// aborting a stalled node. It RESETS on every streamed delta, so this bounds SILENCE, not the
+// total stream length - a long reasoning think that keeps emitting deltas never trips it.
+const defaultStreamIdle = 300 * time.Second
+
+// streamIdle is the configured idle/void window (defaultStreamIdle unless overridden; tests
+// set a small value to assert the reset without a real 300s wait).
+func (b *broker) streamIdle() time.Duration {
+	if b.streamIdleTimeout > 0 {
+		return b.streamIdleTimeout
+	}
+	return defaultStreamIdle
+}
+
 // relayStream handles the streaming path of POST /v1/chat/completions: it sends SSE
 // headers, registers the client as a sink, and enqueues the job. The node pipes
 // chunks via /agent/stream straight to this client; when it finishes it posts a
@@ -1924,7 +1963,7 @@ func (b *broker) relayStream(w http.ResponseWriter, t *nodeTunnel, node protocol
 		return
 	}
 	start := time.Now()
-	sink := &streamSink{w: w, flush: flusher.Flush, nodeID: node.NodeID, start: start}
+	sink := &streamSink{w: w, flush: flusher.Flush, nodeID: node.NodeID, start: start, activity: make(chan struct{}, 1)}
 	if b.recount.enabled() {
 		sink.cap = &bytes.Buffer{} // capture completion text for the L1 re-count
 	}
@@ -2011,6 +2050,7 @@ func (b *broker) relayStream(w http.ResponseWriter, t *nodeTunnel, node protocol
 				}
 				sink.w.Write(fr.payload)
 				sink.flush()
+				sink.noteActivity() // reset the idle/void timer on any delta (content OR reasoning)
 				if sink.cap != nil {
 					sink.capMu.Lock()
 					if sink.cap.Len()+sink.capRaw.Len() < maxRecountCapture {
@@ -2045,107 +2085,127 @@ func (b *broker) relayStream(w http.ResponseWriter, t *nodeTunnel, node protocol
 			return // headers already sent; the client just gets an empty stream
 		}
 	}
-	select {
-	case res := <-resCh:
-		b.exitInflight(node.NodeID, res.Status < 500)
-		rec := res.Receipt
-		if rec.VerifyNode(node.PubKey) {
-			var pin, pout float64
-			if pricing.fixed {
-				pin, pout = pricing.in, pricing.out
-			} else {
-				curIn, curOut, _, scheduled := offer.ActivePrice(time.Now())
-				pin, pout = curIn, curOut
-				if !scheduled {
-					// Lock keyed on the SIGNED consumer identity (not the payer wallet) so the
-					// streaming path shares the SAME 24h price-lock the non-stream relay mints -
-					// otherwise a logged-in user's stream would dodge the lock (different key) and
-					// eat an owner's mid-engagement hike. See streamBill.consumer.
-					pin, pout, _ = b.lockedPrice(consumer, node.NodeID, model, curIn, curOut)
+	// Idle/void timer: RESETS on every streamed delta (sink.noteActivity), so a long
+	// reasoning think never trips a false stall - only genuine silence for the whole window
+	// aborts. This is the timer, not a total-stream deadline (founder ruling: reset on ANY
+	// delta, content or reasoning).
+	idle := b.streamIdle()
+	idleTimer := time.NewTimer(idle)
+	defer idleTimer.Stop()
+	for {
+		select {
+		case <-sink.activity:
+			if !idleTimer.Stop() {
+				select {
+				case <-idleTimer.C:
+				default:
 				}
 			}
-			rec.PriceIn, rec.PriceOut = pin, pout
-			rec.GrantID = grantID
-			// The stream has finished (the receipt arrived), so the captured completion
-			// text is complete. (cap is non-nil only when the L1 re-count is enabled; on
-			// a no-recount broker we fall back to the receipt's token count for the void
-			// + reward signals.)
-			completion := ""
-			if sink.cap != nil {
-				sink.capMu.Lock()
-				completion = sink.cap.String()
-				sink.capMu.Unlock()
-			}
-			// VOID-ON-NO-OUTPUT (P0), stream path. When capture is enabled we know the
-			// stream was empty if the captured text is blank; without capture we fall
-			// back to the receipt's claimed completion tokens + status. An errored or
-			// no-output stream charges $0, mints no earning, and the deferred ReleaseHold
-			// refunds the consumer's hold in full.
-			var producedOutput bool
-			if sink.cap != nil {
-				// Capture on: use the same predicate as the relay path off the captured text.
-				producedOutput = producedUsableOutput(res.Status, completion, rec.CompletionTokens)
-			} else {
-				// No capture: fall back to status + the receipt's claimed completion tokens.
-				producedOutput = res.Status < 400 && rec.CompletionTokens > 0
-			}
-			if !producedOutput {
-				b.flagEmptyOutput(node.NodeID, rec, res.Status)
-				log.Printf("VOID no-output (stream) user=%s node=%s status=%d claimIn=%d claimOut=%d - $0, hold refunded",
-					user, node.NodeID, res.Status, rec.PromptTokens, rec.CompletionTokens)
-				if b.db != nil {
-					rec.SignBroker(b.priv)
-					_, _ = b.db.Settle(user, node.NodeID, 0, 0, rec) // $0 metering receipt
+			idleTimer.Reset(idle)
+			continue
+		case <-idleTimer.C:
+			b.exitInflight(node.NodeID, false)
+			return
+		case res := <-resCh:
+			b.exitInflight(node.NodeID, res.Status < 500)
+			rec := res.Receipt
+			if rec.VerifyNode(node.PubKey) {
+				var pin, pout float64
+				if pricing.fixed {
+					pin, pout = pricing.in, pricing.out
+				} else {
+					curIn, curOut, _, scheduled := offer.ActivePrice(time.Now())
+					pin, pout = curIn, curOut
+					if !scheduled {
+						// Lock keyed on the SIGNED consumer identity (not the payer wallet) so the
+						// streaming path shares the SAME 24h price-lock the non-stream relay mints -
+						// otherwise a logged-in user's stream would dodge the lock (different key) and
+						// eat an owner's mid-engagement hike. See streamBill.consumer.
+						pin, pout, _ = b.lockedPrice(consumer, node.NodeID, model, curIn, curOut)
+					}
 				}
-				return // settled stays false -> deferred ReleaseHold refunds the hold
-			}
-			// P0-2 (symmetric): bill min(nodeClaim, brokerRecount) on BOTH axes. The
-			// prompt text is the request body (job.Body), available on this path too, so
-			// the input byte-floor + recount apply identically to the relay path.
-			billedPrompt := b.settleRecountPrompt(node.NodeID, rec.RequestID, recountModel(rec, model), promptText(job.Body), rec.PromptTokens, len(job.Body))
-			billedCompletion := b.settleRecount(node.NodeID, rec.RequestID, recountModel(rec, model), completion, rec.CompletionTokens)
-			rec.BrokerPromptTokens, rec.BrokerCompletionTokens = billedPrompt, billedCompletion
-			// SignBroker AFTER the broker counts are assigned (covers them).
-			rec.SignBroker(b.priv)
-			cost := clampSettleCost(rec.CostWith2(billedPrompt, billedCompletion), maxCost)
-			if _, ferr := b.settleRequest(user, node.NodeID, maxCost, cost, rec, grantID, pricing.free); ferr != nil {
-				// settle failed - leave settled=false so the deferred ReleaseHold refunds
-				log.Printf("stream settle FAILED user=%s node=%s: %v - releasing hold", user, node.NodeID, ferr)
-			} else {
-				settled = true
-			}
-			streamTPS := 0.0
-			if rec.CompletionTokens > 0 {
-				if el := time.Since(start).Seconds(); el > 0 {
-					streamTPS = float64(rec.CompletionTokens) / el
-					b.updateTPS(node.NodeID, streamTPS)
+				rec.PriceIn, rec.PriceOut = pin, pout
+				rec.GrantID = grantID
+				// The stream has finished (the receipt arrived), so the captured completion
+				// text is complete. (cap is non-nil only when the L1 re-count is enabled; on
+				// a no-recount broker we fall back to the receipt's token count for the void
+				// + reward signals.)
+				completion := ""
+				if sink.cap != nil {
+					sink.capMu.Lock()
+					completion = sink.cap.String()
+					sink.capMu.Unlock()
+				}
+				// VOID-ON-NO-OUTPUT (P0), stream path. When capture is enabled we know the
+				// stream was empty if the captured text is blank; without capture we fall
+				// back to the receipt's claimed completion tokens + status. An errored or
+				// no-output stream charges $0, mints no earning, and the deferred ReleaseHold
+				// refunds the consumer's hold in full.
+				var producedOutput bool
+				if sink.cap != nil {
+					// Capture on: use the same predicate as the relay path off the captured text.
+					producedOutput = producedUsableOutput(res.Status, completion, rec.CompletionTokens)
+				} else {
+					// No capture: fall back to status + the receipt's claimed completion tokens.
+					producedOutput = res.Status < 400 && rec.CompletionTokens > 0
+				}
+				if !producedOutput {
+					b.flagEmptyOutput(node.NodeID, rec, res.Status)
+					log.Printf("VOID no-output (stream) user=%s node=%s status=%d claimIn=%d claimOut=%d - $0, hold refunded",
+						user, node.NodeID, res.Status, rec.PromptTokens, rec.CompletionTokens)
+					if b.db != nil {
+						rec.SignBroker(b.priv)
+						_, _ = b.db.Settle(user, node.NodeID, 0, 0, rec) // $0 metering receipt
+					}
+					return // settled stays false -> deferred ReleaseHold refunds the hold
+				}
+				// P0-2 (symmetric): bill min(nodeClaim, brokerRecount) on BOTH axes. The
+				// prompt text is the request body (job.Body), available on this path too, so
+				// the input byte-floor + recount apply identically to the relay path.
+				billedPrompt := b.settleRecountPrompt(node.NodeID, rec.RequestID, recountModel(rec, model), promptText(job.Body), rec.PromptTokens, len(job.Body))
+				billedCompletion := b.settleRecount(node.NodeID, rec.RequestID, recountModel(rec, model), completion, rec.CompletionTokens)
+				rec.BrokerPromptTokens, rec.BrokerCompletionTokens = billedPrompt, billedCompletion
+				// SignBroker AFTER the broker counts are assigned (covers them).
+				rec.SignBroker(b.priv)
+				cost := clampSettleCost(rec.CostWith2(billedPrompt, billedCompletion), maxCost)
+				if _, ferr := b.settleRequest(user, node.NodeID, maxCost, cost, rec, grantID, pricing.free); ferr != nil {
+					// settle failed - leave settled=false so the deferred ReleaseHold refunds
+					log.Printf("stream settle FAILED user=%s node=%s: %v - releasing hold", user, node.NodeID, ferr)
+				} else {
+					settled = true
+				}
+				streamTPS := 0.0
+				if rec.CompletionTokens > 0 {
+					if el := time.Since(start).Seconds(); el > 0 {
+						streamTPS = float64(rec.CompletionTokens) / el
+						b.updateTPS(node.NodeID, streamTPS)
+					}
+				}
+				// Smart-router v2 reward + capacity evidence (streamed). This block only runs
+				// when producedOutput is true (an errored/empty stream returned above), so a
+				// leech can never shrink its UCB radius off a no-output stream.
+				qOK := rec.CompletionTokens > 0 && (completion == "" || qualityOKText(completion))
+				b.recordServed(node.NodeID, qOK, streamTPS, concurrentAtDispatch)
+				// Free measurement off real (streamed) traffic: reset the probe backoff so
+				// an actively-used node is barely probed and reads as freshly verified.
+				b.markMeasured(node.NodeID)
+				log.Printf("stream user=%s node=%s out=%d cost=%.6f", user, node.NodeID, rec.CompletionTokens, cost)
+				// SSE COST METER (founder ruling 2026-07-07, "SSE meter comment"): a stream's
+				// headers were flushed before any output, so the billed cost cannot ride
+				// X-RogerAI-Cost. Emit it as a spec-compliant SSE COMMENT line at stream end -
+				// parsers ignore comment lines by spec, so no client breaks - which the local
+				// proxy reads to meter per-session spend for streamed traffic. It lands after the
+				// node's [DONE] has streamed through (settle only happens once the receipt
+				// arrives, which follows the node's final chunk). Only a SETTLED stream is
+				// metered: a failed settle refunds the hold and must not report a spend.
+				if settled {
+					waitPump() // never write w while the multi-instance pump may still be writing
+					fmt.Fprintf(w, ": rogerai-cost=%s\n\n", fmtCostHeader(cost))
+					flusher.Flush()
 				}
 			}
-			// Smart-router v2 reward + capacity evidence (streamed). This block only runs
-			// when producedOutput is true (an errored/empty stream returned above), so a
-			// leech can never shrink its UCB radius off a no-output stream.
-			qOK := rec.CompletionTokens > 0 && (completion == "" || qualityOKText(completion))
-			b.recordServed(node.NodeID, qOK, streamTPS, concurrentAtDispatch)
-			// Free measurement off real (streamed) traffic: reset the probe backoff so
-			// an actively-used node is barely probed and reads as freshly verified.
-			b.markMeasured(node.NodeID)
-			log.Printf("stream user=%s node=%s out=%d cost=%.6f", user, node.NodeID, rec.CompletionTokens, cost)
-			// SSE COST METER (founder ruling 2026-07-07, "SSE meter comment"): a stream's
-			// headers were flushed before any output, so the billed cost cannot ride
-			// X-RogerAI-Cost. Emit it as a spec-compliant SSE COMMENT line at stream end -
-			// parsers ignore comment lines by spec, so no client breaks - which the local
-			// proxy reads to meter per-session spend for streamed traffic. It lands after the
-			// node's [DONE] has streamed through (settle only happens once the receipt
-			// arrives, which follows the node's final chunk). Only a SETTLED stream is
-			// metered: a failed settle refunds the hold and must not report a spend.
-			if settled {
-				waitPump() // never write w while the multi-instance pump may still be writing
-				fmt.Fprintf(w, ": rogerai-cost=%s\n\n", fmtCostHeader(cost))
-				flusher.Flush()
-			}
+			return // the receipt arrived and settled; leave the idle loop
 		}
-	case <-time.After(300 * time.Second):
-		b.exitInflight(node.NodeID, false)
 	}
 }
 
@@ -2234,6 +2294,7 @@ func (b *broker) agentStream(w http.ResponseWriter, r *http.Request) {
 		if n > 0 {
 			sink.w.Write(buf[:n])
 			sink.flush()
+			sink.noteActivity() // reset the idle/void timer on any delta (content OR reasoning)
 			// Organic first-byte latency (smart-router v2): record time-to-first-token
 			// the moment we have streamed at least minFirstTokens worth of MEANINGFUL
 			// text - a node can't win TTFT by emitting a bare space then stalling. One
@@ -2732,8 +2793,39 @@ func drainSSEDeltas(raw, out *bytes.Buffer) {
 	raw.Write(rest)
 }
 
-// sseDelta extracts the assistant content from one OpenAI streaming "data: {...}"
-// SSE line (choices[].delta.content or choices[].text). Returns "" for keepalive
+// toolCall is the shared shape of an OpenAI tool_call / legacy function_call: the generated
+// function name + arguments are REAL output tokens (a reasoning/tool model can answer with a
+// tool call and EMPTY content), so folding them into the captured completion keeps the void
+// gate + the re-count from mis-seeing a tool-call reply as "no output" (which stacked strikes
+// into an auto-ban of honest nodes).
+type nameArgs struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// toolCall is one entry of the tool_calls array: the generated call lives under `function`.
+type toolCall struct {
+	Function nameArgs `json:"function"`
+}
+
+// foldCalls appends the name+arguments of each tool_call and the legacy function_call (which
+// carries name/arguments directly, no `function` wrapper) to b.
+func foldCalls(b *strings.Builder, tools []toolCall, fn *nameArgs) {
+	for _, tc := range tools {
+		b.WriteString(tc.Function.Name)
+		b.WriteString(tc.Function.Arguments)
+	}
+	if fn != nil {
+		b.WriteString(fn.Name)
+		b.WriteString(fn.Arguments)
+	}
+}
+
+// sseDelta extracts the assistant output from one OpenAI streaming "data: {...}" SSE line.
+// It folds EVERY thinking-model output signal - content / legacy text, the reasoning aliases
+// (reasoning, reasoning_content, thinking), a refusal, and tool/function calls - so the
+// captured completion is non-empty for a reasoning or tool stream (dropping reasoning here was
+// the root cause of the false empty-output void + the auto-ban). Returns "" for keepalive
 // lines, the [DONE] sentinel, or anything it can't parse.
 func sseDelta(line []byte) string {
 	i := bytes.IndexByte(line, '{')
@@ -2743,7 +2835,13 @@ func sseDelta(line []byte) string {
 	var d struct {
 		Choices []struct {
 			Delta struct {
-				Content string `json:"content"`
+				Content          string     `json:"content"`
+				Reasoning        string     `json:"reasoning"`
+				ReasoningContent string     `json:"reasoning_content"`
+				Thinking         string     `json:"thinking"`
+				Refusal          string     `json:"refusal"`
+				ToolCalls        []toolCall `json:"tool_calls"`
+				FunctionCall     *nameArgs  `json:"function_call"`
 			} `json:"delta"`
 			Text string `json:"text"`
 		} `json:"choices"`
@@ -2758,8 +2856,42 @@ func sseDelta(line []byte) string {
 		} else if c.Text != "" {
 			s.WriteString(c.Text)
 		}
+		s.WriteString(c.Delta.Reasoning)
+		s.WriteString(c.Delta.ReasoningContent)
+		s.WriteString(c.Delta.Thinking)
+		s.WriteString(c.Delta.Refusal)
+		foldCalls(&s, c.Delta.ToolCalls, c.Delta.FunctionCall)
 	}
 	return s.String()
+}
+
+// ensureStreamIncludeUsage merges stream_options.include_usage=true into a STREAMING request
+// body so the model emits a final usage chunk (the usage backstop that lets the broker trust
+// completion_tokens when no delta text was captured). Existing keys + any existing
+// stream_options are preserved; a non-streaming or unparseable body is returned unchanged.
+func ensureStreamIncludeUsage(body []byte) []byte {
+	var m map[string]json.RawMessage
+	if json.Unmarshal(body, &m) != nil {
+		return body
+	}
+	if _, ok := m["stream"]; !ok {
+		return body // only rewrite streaming requests
+	}
+	so := map[string]json.RawMessage{}
+	if raw, ok := m["stream_options"]; ok {
+		_ = json.Unmarshal(raw, &so) // preserve existing options; ignore a non-object
+	}
+	so["include_usage"] = json.RawMessage("true")
+	sob, err := json.Marshal(so)
+	if err != nil {
+		return body
+	}
+	m["stream_options"] = sob
+	out, err := json.Marshal(m)
+	if err != nil {
+		return body
+	}
+	return out
 }
 
 // parseNodeSet parses a comma-separated node-id list (X-Roger-Exclude-Nodes) into

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -1470,9 +1470,9 @@ func (b *broker) relay(w http.ResponseWriter, r *http.Request) {
 
 	// Usage backstop: ask the model for a final usage chunk on streaming requests so the
 	// node's receipt carries completion_tokens even when the delta text is an unusual
-	// reasoning shape (producedUsableOutput trusts it rather than false-voiding). Additive +
-	// order-preserving on the chat payload (messages unchanged), so the prompt re-count and
-	// moderation screen are unaffected; a no-op for non-streaming requests.
+	// reasoning shape (producedUsableOutput trusts it rather than false-voiding). Only adds
+	// stream_options; the chat messages are unchanged, so the prompt re-count and moderation
+	// screen are unaffected. A no-op for non-streaming requests.
 	if req.Stream {
 		body = ensureStreamIncludeUsage(body)
 	}

--- a/cmd/rogerai-broker/tunnel.go
+++ b/cmd/rogerai-broker/tunnel.go
@@ -2183,8 +2183,12 @@ func (b *broker) relayStream(w http.ResponseWriter, t *nodeTunnel, node protocol
 				}
 				// Smart-router v2 reward + capacity evidence (streamed). This block only runs
 				// when producedOutput is true (an errored/empty stream returned above), so a
-				// leech can never shrink its UCB radius off a no-output stream.
-				qOK := rec.CompletionTokens > 0 && (completion == "" || qualityOKText(completion))
+				// leech can never shrink its UCB radius off a no-output stream. When CAPTURE is
+				// on (sink.cap != nil) an empty captured completion is NOT a quality success - we
+				// have proof it produced no text - so the usage backstop keeps it un-struck but
+				// grants it no serving reward either. Capture OFF (sink.cap == nil) has no text to
+				// judge, so it falls back to the claimed-tokens signal as before.
+				qOK := rec.CompletionTokens > 0 && (sink.cap == nil || qualityOKText(completion))
 				b.recordServed(node.NodeID, qOK, streamTPS, concurrentAtDispatch)
 				// Free measurement off real (streamed) traffic: reset the probe backoff so
 				// an actively-used node is barely probed and reads as freshly verified.
@@ -2880,6 +2884,9 @@ func ensureStreamIncludeUsage(body []byte) []byte {
 	so := map[string]json.RawMessage{}
 	if raw, ok := m["stream_options"]; ok {
 		_ = json.Unmarshal(raw, &so) // preserve existing options; ignore a non-object
+	}
+	if _, set := so["include_usage"]; set {
+		return body // respect an explicit client choice (true OR false); do not override
 	}
 	so["include_usage"] = json.RawMessage("true")
 	sob, err := json.Marshal(so)

--- a/features/money/recount_billing.feature
+++ b/features/money/recount_billing.feature
@@ -184,13 +184,16 @@ Feature: The broker re-counts tokens and bills the lesser of claim and re-count 
       When the broker evaluates the response
       Then producing usable output is <usable>
 
-      Examples: reasoning rescues an otherwise-"empty" reply; a true void stays void
+      Examples: any text OR the usage backstop (reported tokens) is usable; the void narrows to
+      # the true-negative (no text AND completion_tokens==0). An empty-text over-claim (reported
+      # tokens with no text) is capped/struck by the re-count layer, not voided here. An error is
+      # never usable.
         | status | content | reasoning | claim | usable |
         | 200    | "hi"    | ""        | 2     | true   |
         | 200    | ""      | "answer"  | 7     | true   |
         | 200    | "hi"    | "answer"  | 9     | true   |
-        | 200    | ""      | ""        | 5     | false  |
-        | 200    | "   "   | ""        | 5     | false  |
+        | 200    | ""      | ""        | 5     | true   |
+        | 200    | "   "   | ""        | 5     | true   |
         | 200    | ""      | ""        | 0     | false  |
         | 500    | "hi"    | "answer"  | 5     | false  |
         | 400    | ""      | ""        | 0     | false  |
@@ -222,15 +225,23 @@ Feature: The broker re-counts tokens and bills the lesser of claim and re-count 
       And the hold is refunded in full
       And the empty-output strike is flagged against owner "op1"
 
-    Scenario: Claim-without-text (tokens claimed, whitespace body) is voided
+    Scenario: Claim-without-text (whitespace body, tokens claimed) is billed on the re-count and struck, not voided
+      # Empty/whitespace TEXT with reported completion tokens is no longer a no-output void (the
+      # usage backstop trusts reported tokens, so an honest reasoning stream is never false-voided).
+      # The RE-COUNT layer is the defense against a text-less over-claim: it bills the lesser broker
+      # count and strikes a gross over-report against the owner.
       Given a served request on model "m" at price_out 1.00 per 1M
       And the node returns status 200 with a whitespace-only completion
       And the node claims 800 completion tokens
+      And the broker exactly re-counts 1 completion tokens
       When the request settles
-      Then the consumer is charged 0.000000 credits
-      And the empty-output strike is flagged against owner "op1"
+      Then the request void state is false
+      And the node's earnings are HELD from promotion
+      And the recount-over-report strike is flagged against owner "op1"
 
     Scenario Outline: VOID gate truth table
+      # Usable (not voided) when there is text OR the usage backstop reports completion tokens; the
+      # void fires ONLY for the true-negative (no text AND completion_tokens==0) or an error status.
       Given a served request with node status <status> and completion <completion> claiming <claim> completion tokens
       When the request settles
       Then the request void state is <voided>
@@ -238,8 +249,8 @@ Feature: The broker re-counts tokens and bills the lesser of claim and re-count 
       Examples:
         | status | completion | claim | voided |
         | 200    | "ok"       | 3     | false  |
-        | 200    | ""         | 3     | true   |
-        | 200    | "  "       | 3     | true   |
+        | 200    | ""         | 3     | false  |
+        | 200    | "  "       | 3     | false  |
         | 200    | ""         | 0     | true   |
         | 404    | "ok"       | 3     | true   |
         | 500    | ""         | 0     | true   |

--- a/features/money/recount_billing.feature
+++ b/features/money/recount_billing.feature
@@ -226,10 +226,11 @@ Feature: The broker re-counts tokens and bills the lesser of claim and re-count 
       And the empty-output strike is flagged against owner "op1"
 
     Scenario: Claim-without-text (whitespace body, tokens claimed) is billed on the re-count and struck, not voided
-      # Empty/whitespace TEXT with reported completion tokens is no longer a no-output void (the
-      # usage backstop trusts reported tokens, so an honest reasoning stream is never false-voided).
-      # The RE-COUNT layer is the defense against a text-less over-claim: it bills the lesser broker
-      # count and strikes a gross over-report against the owner.
+      # Whitespace TEXT with reported completion tokens is no longer a no-output void (the usage
+      # backstop keeps an honest reasoning stream from being false-voided). The RE-COUNT layer is
+      # the defense against a text-less over-claim: it bills the lesser broker count (0 when NO
+      # text is captured; see settleRecount's empty-capture guard) and strikes a gross over-report
+      # on captured text.
       Given a served request on model "m" at price_out 1.00 per 1M
       And the node returns status 200 with a whitespace-only completion
       And the node claims 800 completion tokens

--- a/features/security/known_vulnerabilities.feature
+++ b/features/security/known_vulnerabilities.feature
@@ -96,9 +96,10 @@ Feature: Known-vulnerability regression guards
     @reasoning
     Scenario: A genuinely empty reply (no text, no reported tokens) is still voided and flagged
       # The TRUE-negative keys on completion_tokens==0: no output text of any kind AND the node
-      # reported no completion tokens. An over-claim (empty text but reported tokens>0) is caught
-      # by the RE-COUNT layer (billed on the lesser count, struck past the strike tolerance), not
-      # by this void - so the void narrows to "produced nothing and claimed nothing".
+      # reported no completion tokens. An empty-text over-claim (reported tokens>0) is not struck
+      # here, but it is not paid either: settleRecount's empty-capture guard bills the
+      # unverifiable completion 0 (and a gross over-report on CAPTURED text is struck by the
+      # re-count layer). So the void narrows to "produced nothing and claimed nothing".
       Given a node returns empty content and empty reasoning claiming 0 completion tokens
       When the broker evaluates and settles the request
       Then the request is voided to $0

--- a/features/security/known_vulnerabilities.feature
+++ b/features/security/known_vulnerabilities.feature
@@ -94,14 +94,21 @@ Feature: Known-vulnerability regression guards
       And operator "op1" earns the 0.000210 owner share (70% of the 0.000300 cost)
 
     @reasoning
-    Scenario: A genuinely empty reply (no content, no reasoning) is still voided and flagged
-      Given a node returns empty content and empty reasoning claiming 5 completion tokens
+    Scenario: A genuinely empty reply (no text, no reported tokens) is still voided and flagged
+      # The TRUE-negative keys on completion_tokens==0: no output text of any kind AND the node
+      # reported no completion tokens. An over-claim (empty text but reported tokens>0) is caught
+      # by the RE-COUNT layer (billed on the lesser count, struck past the strike tolerance), not
+      # by this void - so the void narrows to "produced nothing and claimed nothing".
+      Given a node returns empty content and empty reasoning claiming 0 completion tokens
       When the broker evaluates and settles the request
       Then the request is voided to $0
       And the empty-output strike fires against owner "op1"
 
     @reasoning
     Scenario Outline: Reasoning rescue does not weaken the true-empty void
+      # Usable when there is ANY text OR the usage backstop reports completion tokens; the void
+      # fires ONLY for the true-negative (no text AND completion_tokens==0). Over-claims with
+      # empty text are handled by the re-count layer, not this predicate.
       Given a reply with content <content> and reasoning <reasoning> claiming <claim> completion tokens
       When the broker evaluates the response
       Then producing usable output is <usable>
@@ -110,8 +117,10 @@ Feature: Known-vulnerability regression guards
         | content | reasoning | claim | usable |
         | ""      | "answer"  | 7     | true   |
         | "hi"    | ""        | 2     | true   |
-        | ""      | ""        | 5     | false  |
-        | "  "    | "  "      | 5     | false  |
+        | ""      | ""        | 5     | true   |
+        | "  "    | "  "      | 5     | true   |
+        | ""      | ""        | 0     | false  |
+        | "  "    | "  "      | 0     | false  |
 
   # ===========================================================================
   # CHARGEBACK OVER-CLAW ACROSS MULTIPLE TOP-UPS

--- a/features/trust/lineage_receipts.feature
+++ b/features/trust/lineage_receipts.feature
@@ -126,7 +126,18 @@ Feature: Every served request yields a node-signed, broker-co-signed, hash-chain
       | shape                              |
       | an error status (>=400)            |
       | an empty / whitespace completion   |
-      | claimed tokens but no output text  |
+      | no output text and zero tokens     |
+
+  # Usage backstop (thinking-model fix): empty output TEXT but the node's usage reports
+  # completion tokens is NOT a no-output void - a reasoning model produced real tokens per its
+  # own accounting even when the visible text was not captured. It is billed off the reported
+  # tokens and the honest owner is NOT struck. Voiding this false-struck + auto-banned honest
+  # reasoning nodes. (The TRUE-negative above - no text AND zero tokens - still voids + strikes.)
+  Scenario: Empty text with reported completion tokens is billed, not voided or struck
+    Given the node returns "empty text but usage reports completion tokens"
+    When the broker relays the request
+    Then the consumer is billed a non-zero cost and the node earns
+    And the owner is NOT flagged for empty output
 
   # --- idempotent settlement on request id ---------------------------------
 

--- a/features/trust/reasoning_stream_output.feature
+++ b/features/trust/reasoning_stream_output.feature
@@ -47,6 +47,16 @@ Feature: Reasoning-model streamed output is recognized, never false-voided or fa
     Then the stream is served and settled for a non-zero cost
     And the node's owner is NOT struck
 
+  Scenario: anti-fraud - an unverifiable text-less completion claim is NOT paid
+    # The usage backstop keeps an honest reasoning node from being false-struck, but a
+    # re-count-enabled broker never PAYS a completion it could not capture and count: the
+    # empty-capture guard bills the unverifiable completion 0, so a huge text-less claim
+    # cannot mint output revenue.
+    Given the node streams no output text but its receipt claims 100000 completion tokens
+    When the consumer relays the streaming request
+    Then the node's owner is NOT struck
+    And the consumer is not billed for the unverifiable completion claim
+
   Scenario: the verdict is computed at END of stream - content only in the last delta still serves
     Given the node streams 3 reasoning deltas and puts the only content in the last delta
     And the node's receipt claims the full reasoning+content token count

--- a/features/trust/reasoning_stream_output.feature
+++ b/features/trust/reasoning_stream_output.feature
@@ -1,0 +1,73 @@
+Feature: Reasoning-model streamed output is recognized, never false-voided or false-struck
+  # THE BUG: the STREAM relay's sseDelta() parsed only delta.content/delta.text and DROPPED
+  # delta.reasoning / delta.reasoning_content / delta.thinking. A reasoning-model stream then
+  # captured an EMPTY completion, so producedUsableOutput() returned false and the request was
+  # VOIDED with an empty-output strike. Worse, a reasoning+content reply passed the empty check
+  # but the reasoning-STRIPPED completion re-counted far fewer tokens than the node claimed, so
+  # it ALSO tripped a recount-discrepancy strike - a SECOND distinct signal class - which
+  # satisfied strike corroboration and AUTO-BANNED the honest reasoning node.
+  #
+  # THE FIX: one SHARED detector (producedUsableOutput) used by BOTH the stream and non-stream
+  # paths, fed by capture functions (sseDelta / completionText) that fold EVERY thinking-model
+  # output signal. Output is recognized as an OR-of-all, accumulated to end-of-stream:
+  #   - any content, or any reasoning alias (reasoning / reasoning_content / thinking),
+  #   - inline reasoning tags in content (<think>, harmony <|channel|>analysis/final),
+  #   - a tool_call / function_call, a non-empty refusal, OR
+  #   - the usage backstop: completion_tokens > 0 on the final chunk.
+  # It VOIDS + strikes ONLY the TRUE-negative: no text AND completion_tokens == 0. The re-count
+  # counts reasoning too, so a reasoning+content stream never trips recount-discrepancy.
+  #
+  # Driven against the REAL streaming relay (a node goroutine streams real SSE deltas to
+  # /agent/stream, then posts a signed receipt) with a real broker + a real tokenizer sidecar.
+  # The bus (multi-instance) capture path shares the SAME drainSSEDeltas function as the local
+  # path (unit-pinned in reasoning_detector_test.go), so this fix covers both.
+
+  Background:
+    Given a reasoning-capable node registered with the broker
+    And a funded consumer
+
+  Scenario: INCIDENT - a stream of reasoning deltas then a content delta is served, not voided or struck
+    Given the node streams 4 reasoning deltas then 1 content delta
+    And the node's receipt claims the full reasoning+content token count
+    When the consumer relays the streaming request
+    Then the stream is served and settled for a non-zero cost
+    And the node earns for the request
+    And the node's owner is NOT struck
+
+  Scenario: reasoning-only with finish_reason=length is billed off the usage, not voided
+    Given the node streams reasoning deltas only with an empty content and finish_reason length
+    And the node's receipt claims the reasoning token count
+    When the consumer relays the streaming request
+    Then the stream is served and settled for a non-zero cost
+    And the node's owner is NOT struck
+
+  Scenario: usage backstop - empty deltas but completion_tokens>0 is served, not voided or struck
+    Given the node streams no output text but its receipt claims 5 completion tokens
+    When the consumer relays the streaming request
+    Then the stream is served and settled for a non-zero cost
+    And the node's owner is NOT struck
+
+  Scenario: the verdict is computed at END of stream - content only in the last delta still serves
+    Given the node streams 3 reasoning deltas and puts the only content in the last delta
+    And the node's receipt claims the full reasoning+content token count
+    When the consumer relays the streaming request
+    Then the stream is served and settled for a non-zero cost
+    And the node's owner is NOT struck
+
+  Scenario: ESCALATION GUARD - an honest reasoning node is never auto-banned
+    Given the node serves 3 reasoning-only and 3 reasoning+content honest streams
+    When the consumer relays each streaming request
+    Then the node's owner is NOT banned
+    And the node's owner has no strikes of any kind
+
+  Scenario: TRUE-NEGATIVE - a genuinely empty stream with zero tokens is still voided and struck
+    Given the node streams no output text and its receipt claims 0 completion tokens
+    When the consumer relays the streaming request
+    Then the stream is voided at zero cost with the hold refunded
+    And the node's owner IS struck for empty output
+
+  Scenario: the idle/void timer resets on a reasoning delta so a long think never trips a stall
+    Given a short idle window and the node streams reasoning deltas spaced across more than that window
+    When the consumer relays the streaming request
+    Then the stream is served and settled for a non-zero cost
+    And the node's owner is NOT struck


### PR DESCRIPTION
## What

The streaming relay recognized only `delta.content` / `delta.text` and dropped a
reasoning model's `reasoning` / `reasoning_content` / `thinking` deltas. A thinking-model
stream then captured an empty completion, so the request was falsely voided with an
`empty-output` strike. A reasoning+content reply was worse: the reasoning-stripped
completion re-counted far fewer tokens than the node reported, adding a
`recount-discrepancy` strike. Two distinct signal classes satisfied strike corroboration
and auto-banned honest reasoning nodes.

The non-stream path already folded `reasoning`; the stream path did not. This closes that
asymmetry with ONE shared detector so the two paths can never diverge again.

## Fix

- `sseDelta` (stream capture) and `completionText` (non-stream) now fold every
  thinking-model output signal: content / text, the reasoning aliases
  (`reasoning`, `reasoning_content`, `thinking`), a `refusal`, and `tool_calls` /
  legacy `function_call` name+arguments. Shared `foldCalls` helper.
- `producedUsableOutput` is a single OR-of-all detector, used identically on the stream
  and non-stream void gates: usable when `status < 400` AND (any captured text OR the usage
  backstop `completion_tokens > 0`). It voids + strikes ONLY the true-negative: no text AND
  `completion_tokens == 0`, so the strike stays useful.
- Because the re-count is now fed reasoning-inclusive text, a reasoning+content stream
  re-counts to match the node's report and never trips `recount-discrepancy`. A text-less
  over-claim is handled by the re-count layer (billed on the lesser count, struck past the
  strike tolerance), not by the void.
- The streaming idle/void timer resets on ANY streamed delta (content or reasoning), so a
  long think never trips a false stall. Bounds silence, not total stream length.
- Streaming requests set `stream_options.include_usage=true` upstream so the final chunk
  carries usage (the backstop). Additive and messages-preserving; prompt re-count and
  moderation are unaffected.
- Both stream capture paths are covered: the local `agentStream` fill and the
  multi-instance bus pump (both share `drainSSEDeltas` + the idle-timer reset).

Client-facing stream bytes are unchanged: no content is synthesized, the client write path
is untouched, and the existing client-side reasoning fallback is not duplicated on the
broker.

## Founder rulings applied

1. Reasoning is forwarded to the client as-is (passthrough untouched).
2. The idle/void timer resets on any streamed delta.
3. Quarantine display is a separate follow-up, not in this PR.

## Behavior change to review (money/strike posture)

The usage backstop reclassifies "empty/whitespace text but the node reported
`completion_tokens > 0`" from a void to a billed request (trust the reported usage; a
reasoning node produced real tokens even when the visible text was not captured). The void
now narrows to the true-negative (`completion_tokens == 0`); over-claims are the re-count
layer's job. Billing stays bounded by the pre-auth hold (max_tokens) and the monthly cap.
The affected committed specs were updated to match this ruling:
`features/money/recount_billing.feature`, `features/security/known_vulnerabilities.feature`,
`features/trust/lineage_receipts.feature`.

Anti-fraud guard (added after two independent reviews - my reviewer and the pre-push audit -
flagged that trusting a text-less claim reopens the claim-without-text leak): on a
re-count-enabled broker, `settleRecount` now bills 0 for a claim with NO captured completion
text (we never pay output we could not capture and count), and the streamed quality/serving
reward is withheld for an empty capture. The node is still NOT struck (an honest reasoning
shape we failed to capture must not be punished), but it is not PAID for the unverifiable
completion either. Only the input (which the node did process) bills. A re-count-disabled
broker has no counting capability and bills the claim as before. Pinned by
`TestSettleRecountEmptyCaptureBillsZero` and the "unverifiable text-less completion claim is
NOT paid" BDD scenario (100000-token claim -> spend stays at the input floor).

Open question for the founder: this bills the input on an empty-capture stream rather than
fully voiding it. If you would rather fully refund the consumer on any un-captured output,
say so and I will switch it to a full void (still un-struck).

## RED -> GREEN

Unit RED (pre-fix), e.g. `sseDelta(reasoning) = ""`, `producedUsableOutput(200,"",5)=false`.
BDD RED (pre-fix, real streaming relay + real tokenizer sidecar):

- INCIDENT (reasoning deltas then content): owner struck via recount-discrepancy.
- ESCALATION GUARD (mixed honest reasoning streams): owner auto-banned.
- TRUE-NEGATIVE (no text, zero tokens): correctly stays voided + struck (guard holds).

All GREEN after the fix. Full broker suite green (godog strict, incl. banning /
recount_billing / lineage_receipts), `-race` clean, `make cover-gate` PASS
(broker 90.6%, total 92.2%, every package >= 90%).

## MERGE BLOCK

BUILD-AND-HOLD. Do NOT merge without founder review: this is the money / metering / strike
path and merge auto-deploys the broker. Please confirm the usage-backstop posture change
above.
