### PR TITLE
agent: extendable per-call cap (tab waits, esc stops, auto-stop grace)

### DIFF
--- a/internal/harness/broker.go
+++ b/internal/harness/broker.go
@@ -26,10 +26,13 @@ type CostFunc func(credits float64, tokensIn, tokensOut int, tps float64)
 // over a minute, and a tool-use turn is a normal completion under the hood.
 const brokerTimeout = 300 * time.Second
 
-// PerCallCap is the hard per-model-call timeout the agent relay enforces (the
-// BrokerCompleter HTTP timeout). It is exported so the TUI's working line can surface
-// the ceiling ("cap 300s") - so a slow turn reads as bounded, not bottomless, and the
-// "is it stuck?" question has a concrete deadline. Mirrors brokerTimeout exactly.
+// PerCallCap is the per-model-call cap the TUI surfaces ("cap 300s") - so a slow turn
+// reads as bounded, not bottomless, and the "is it stuck?" question has a concrete
+// deadline. It is a SOFT ceiling when the caller supplies its own ctx deadline: the
+// TUI threads an ExtendableTimeout so the user can grant a legitimately slow call more
+// time at the cap (tab in the working line) instead of it being hard-killed. Callers
+// that supply NO deadline still get the hard default (brokerHTTPTimeout), so every
+// non-interactive path stays bounded exactly as before. Mirrors brokerTimeout.
 const PerCallCap = brokerTimeout
 
 // agentMaxTokens is the per-turn completion budget for the agent. It is the SAME shared
@@ -65,8 +68,16 @@ var brokerHTTPTimeout = brokerTimeout
 // user's explicit opt-in. Without this an agent turn could silently bind to an
 // exorbitant band (the harness relay previously sent no max-out at all).
 func BrokerCompleter(broker, user, model string, confidential bool, maxOut float64, onCost CostFunc) Completer {
-	httpClient := &http.Client{Timeout: brokerHTTPTimeout}
+	// No client-level Timeout: the per-call bound rides on the ctx, so an interactive
+	// caller (the TUI) can extend it mid-call. A ctx that arrives with no deadline gets
+	// the hard default below - non-interactive paths stay bounded exactly as before.
+	httpClient := &http.Client{}
 	return func(ctx context.Context, messages []Message, tools []map[string]any) (Message, error) {
+		if _, has := ctx.Deadline(); !has {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, brokerHTTPTimeout)
+			defer cancel()
+		}
 		reqBody, _ := json.Marshal(map[string]any{
 			"model":    model,
 			"messages": messages,
@@ -92,11 +103,15 @@ func BrokerCompleter(broker, user, model string, confidential bool, maxOut float
 		req.Header.Set("X-Roger-Max-Price-Out", fmt.Sprintf("%g", client.EffectiveMaxOut(maxOut)))
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			// User aborted the turn (esc): a clean cancellation, not a network failure.
-			if errors.Is(err, context.Canceled) {
+			// User aborted the turn (esc): a clean cancellation, not a network failure. An
+			// ExtendableTimeout that expired cancels with cause DeadlineExceeded - that is
+			// a timeout, not an abort, so it falls through to the timeout branch below.
+			if errors.Is(err, context.Canceled) && !errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
 				return Message{}, fmt.Errorf("turn cancelled")
 			}
-			if ne, ok := err.(interface{ Timeout() bool }); ok && ne.Timeout() {
+			timedOut := errors.Is(err, context.DeadlineExceeded) ||
+				errors.Is(context.Cause(ctx), context.DeadlineExceeded)
+			if ne, ok := err.(interface{ Timeout() bool }); timedOut || (ok && ne.Timeout()) {
 				return Message{}, fmt.Errorf("no reply from the station within %s (it may be slow or offline) - try again or re-tune", brokerTimeout)
 			}
 			return Message{}, fmt.Errorf("could not reach the broker: %v", err)

--- a/internal/harness/extend.go
+++ b/internal/harness/extend.go
@@ -1,0 +1,69 @@
+package harness
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// extendableCtx is a cancellable context whose deadline can be pushed back while the
+// context is live. Deadline() reports the CURRENT deadline so downstream code that
+// checks "does this ctx already carry a deadline?" (BrokerCompleter's default-timeout
+// fallback) sees one and stays out of the way.
+type extendableCtx struct {
+	context.Context
+	mu       *sync.Mutex
+	deadline *time.Time
+}
+
+func (c *extendableCtx) Deadline() (time.Time, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return *c.deadline, true
+}
+
+// ExtendableTimeout is context.WithTimeout whose deadline can be extended while the
+// work is in flight. It exists for the agent's per-call cap: PerCallCap is surfaced
+// as a SOFT ceiling in the TUI, and the user can grant a legitimately slow call more
+// time (a big prompt on a spill-bound MoE station) instead of it being hard-killed at
+// a fixed deadline. Semantics:
+//
+//   - The context is cancelled with cause context.DeadlineExceeded once the deadline
+//     passes, so the caller's error surface reads as a timeout (not a user abort).
+//   - extend(d) pushes the CURRENT deadline back by d (not "d from now"), so repeated
+//     grants stack predictably.
+//   - cancel MUST be called on every exit path, like context.WithTimeout's CancelFunc;
+//     it cancels with context.Canceled (a user abort / normal completion).
+func ExtendableTimeout(parent context.Context, d time.Duration) (ctx context.Context, extend func(time.Duration), cancel context.CancelFunc) {
+	inner, cause := context.WithCancelCause(parent)
+	mu := &sync.Mutex{}
+	deadline := time.Now().Add(d)
+	ec := &extendableCtx{Context: inner, mu: mu, deadline: &deadline}
+	var timer *time.Timer
+	timer = time.AfterFunc(d, func() {
+		// An extend may have raced the timer: only expire when the deadline truly
+		// passed, otherwise re-arm for the remainder.
+		mu.Lock()
+		rem := time.Until(deadline)
+		mu.Unlock()
+		if rem > 0 {
+			timer.Reset(rem)
+			return
+		}
+		cause(context.DeadlineExceeded)
+	})
+	extend = func(delta time.Duration) {
+		mu.Lock()
+		deadline = deadline.Add(delta)
+		rem := time.Until(deadline)
+		mu.Unlock()
+		if rem > 0 {
+			timer.Reset(rem)
+		}
+	}
+	cancel = func() {
+		timer.Stop()
+		cause(context.Canceled)
+	}
+	return ec, extend, cancel
+}

--- a/internal/harness/extend_test.go
+++ b/internal/harness/extend_test.go
@@ -1,0 +1,60 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestExtendableTimeoutExpires proves the deadline fires with cause DeadlineExceeded
+// (a timeout, not an abort) and that Deadline() is reported so BrokerCompleter's
+// default-timeout fallback stays out of the way.
+func TestExtendableTimeoutExpires(t *testing.T) {
+	ctx, _, cancel := ExtendableTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	if _, has := ctx.Deadline(); !has {
+		t.Fatal("ExtendableTimeout ctx must report a deadline")
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("ctx did not expire")
+	}
+	if !errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
+		t.Fatalf("cause = %v, want DeadlineExceeded", context.Cause(ctx))
+	}
+}
+
+// TestExtendableTimeoutExtend proves a grant pushes the deadline back: the ctx
+// outlives its original deadline and only expires after the extension.
+func TestExtendableTimeoutExtend(t *testing.T) {
+	ctx, extend, cancel := ExtendableTimeout(context.Background(), 40*time.Millisecond)
+	defer cancel()
+	extend(150 * time.Millisecond)
+	select {
+	case <-ctx.Done():
+		t.Fatal("ctx expired at the ORIGINAL deadline despite the extension")
+	case <-time.After(90 * time.Millisecond):
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("ctx never expired after the extension ran out")
+	}
+}
+
+// TestExtendableTimeoutCancel proves cancel reads as an abort (cause Canceled), the
+// shape BrokerCompleter maps to "turn cancelled".
+func TestExtendableTimeoutCancel(t *testing.T) {
+	ctx, _, cancel := ExtendableTimeout(context.Background(), time.Hour)
+	cancel()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not stop the ctx")
+	}
+	if !errors.Is(context.Cause(ctx), context.Canceled) {
+		t.Fatalf("cause = %v, want Canceled", context.Cause(ctx))
+	}
+}

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -61,6 +62,64 @@ type agentRuntime struct {
 	// race two turns on one loop. Written by the goroutine, read on the UI goroutine, so it
 	// is atomic.
 	running atomic.Bool
+	// Per-model-call cap state (the founder's "what if something is legitimately taking
+	// longer?"). The completer stamps callStart/callSoft and parks an extend func here;
+	// the working line flips to a "past the cap · tab waits" prompt once now > callSoft,
+	// and tab pushes BOTH the soft mark and the underlying ExtendableTimeout deadline
+	// back by another PerCallCap. Left alone, the call auto-stops agentCapGrace after
+	// the soft mark, so an unattended session still reads as bounded. All four fields
+	// are written on the loop goroutine and read on the UI goroutine: callMu guards them.
+	callMu     sync.Mutex
+	callStart  time.Time // zero between model calls
+	callSoft   time.Time // when the past-cap prompt appears; +PerCallCap per tab
+	callExtend func(time.Duration)
+}
+
+// agentCapGrace is how long past the soft cap a model call keeps running while the
+// "tab waits / esc stops" prompt is showing, before it auto-stops. It keeps an
+// unattended agent bounded (nothing hangs forever waiting for a keypress) while giving
+// a present user a real window to grant more time.
+const agentCapGrace = 120 * time.Second
+
+// callState reports the in-flight model call's cap state for the working line:
+// whether a call is live, seconds since it started, whether it is past the soft cap,
+// and how long until the auto-stop. Zero-value safe: between calls (or in tests with
+// no runtime) it reports no live call.
+func (rt *agentRuntime) callState() (inCall bool, callSec int, pastCap bool, stopSec int) {
+	if rt == nil {
+		return false, 0, false, 0
+	}
+	rt.callMu.Lock()
+	defer rt.callMu.Unlock()
+	if rt.callStart.IsZero() {
+		return false, 0, false, 0
+	}
+	now := time.Now()
+	callSec = int(now.Sub(rt.callStart) / time.Second)
+	if now.After(rt.callSoft) {
+		pastCap = true
+		stopSec = int(rt.callSoft.Add(agentCapGrace).Sub(now) / time.Second)
+		if stopSec < 0 {
+			stopSec = 0
+		}
+	}
+	return true, callSec, pastCap, stopSec
+}
+
+// grantMoreTime pushes the in-flight call's soft cap and hard deadline back by
+// PerCallCap. Reports whether there was a live past-cap call to extend.
+func (rt *agentRuntime) grantMoreTime() bool {
+	if rt == nil {
+		return false
+	}
+	rt.callMu.Lock()
+	defer rt.callMu.Unlock()
+	if rt.callStart.IsZero() || rt.callExtend == nil || !time.Now().After(rt.callSoft) {
+		return false
+	}
+	rt.callSoft = rt.callSoft.Add(harness.PerCallCap)
+	rt.callExtend(harness.PerCallCap)
+	return true
 }
 
 // agentConfirm is one pending confirm for a side-effecting tool, surfaced as a y/N
@@ -325,7 +384,21 @@ func (m model) newAgentRuntime() *agentRuntime {
 		// Carry the user's explicit out-price cap for the live model (0 -> the default
 		// consumer cap applies broker-side); the agent relay is bounded like `use`/chat.
 		maxOut := m.limits.resolve(rt.model).MaxOut
-		return harness.BrokerCompleter(m.broker, m.user, rt.model, m.confidentialOnly, maxOut, costFn)(ctx, messages, tools)
+		// The call cap is SOFT: PerCallCap raises the "tab waits" prompt, and unattended
+		// it auto-stops agentCapGrace later. Tab (grantMoreTime) pushes both back.
+		cctx, extend, done := harness.ExtendableTimeout(ctx, harness.PerCallCap+agentCapGrace)
+		rt.callMu.Lock()
+		rt.callStart = time.Now()
+		rt.callSoft = rt.callStart.Add(harness.PerCallCap)
+		rt.callExtend = extend
+		rt.callMu.Unlock()
+		defer func() {
+			done()
+			rt.callMu.Lock()
+			rt.callStart, rt.callSoft, rt.callExtend = time.Time{}, time.Time{}, nil
+			rt.callMu.Unlock()
+		}()
+		return harness.BrokerCompleter(m.broker, m.user, rt.model, m.confidentialOnly, maxOut, costFn)(cctx, messages, tools)
 	}
 	confirmer := func(tool string, args map[string]any) bool {
 		c := agentConfirm{tool: tool, args: args, resp: make(chan bool, 1)}
@@ -604,6 +677,17 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.agentVP.ScrollDown(1)
 		return m, nil
 	case "tab":
+		// PAST-CAP GRANT: while a model call has outlived the soft cap (the working
+		// line is showing "tab waits"), tab grants it another PerCallCap instead of
+		// slash-completing. Only when the input is not a slash word, so completion
+		// keeps working even during a slow call.
+		if m.agentBusy && !strings.HasPrefix(strings.TrimSpace(m.agentIn.Value()), "/") {
+			if m.agent.grantMoreTime() {
+				capS := int(harness.PerCallCap / time.Second)
+				m.agentLines = append(m.agentLines, stDim.Render("· ")+stDim.Render(fmt.Sprintf("granted the call %ds more", capS)))
+				return m, nil
+			}
+		}
 		// Slash-command autocomplete (see agentCommands): a unique prefix match fills
 		// the input + a trailing space (word done - ready for args or enter); several
 		// matches CYCLE Minecraft-style on repeated Tab, completing against the
@@ -1508,6 +1592,16 @@ func (m model) agentWorkingLine(elapsedSec, sinceLastSec int) string {
 			line += stDim.Render(meta)
 		}
 		return line
+	}
+	// PAST THE CAP: the in-flight model call outlived the soft cap. Instead of the old
+	// hard kill, offer the choice (the founder's "ask the user if they want to continue
+	// to wait or skip"): tab grants another PerCallCap, esc stops, and left alone the
+	// call auto-stops when the grace window runs out. The sweep is dropped: the ONLY
+	// honest signal here is the countdown.
+	if inCall, callSec, pastCap, stopSec := m.agent.callState(); inCall && pastCap {
+		return spin + stEmber.Render(fmt.Sprintf("  slow call: %ds, past the %ds cap", callSec, capSec)) +
+			stDim.Render("  · ") + stKey.Render("tab") + stDim.Render(fmt.Sprintf(" waits +%ds · ", capSec)) +
+			stKey.Render("esc") + stDim.Render(fmt.Sprintf(" stops · auto-stop in %ds", stopSec))
 	}
 	// STALLED: no event from the station for a genuinely long time — flag it with the out
 	// and DROP the sweep (a moving bar must never imply liveness that isn't there). A tool

--- a/internal/tui/agent_cap_test.go
+++ b/internal/tui/agent_cap_test.go
@@ -1,0 +1,69 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rogerai-fyi/roger/internal/harness"
+)
+
+// TestAgentWorkingLineCapPrompt covers the soft-cap choice (the founder's "ask the
+// user if they want to continue to wait or skip"): a model call past PerCallCap flips
+// the working line to the tab-waits / esc-stops / auto-stop readout, and grantMoreTime
+// pushes the soft mark back so the prompt clears. It builds its OWN runtime and never
+// touches the shared seed's, so it cannot leak call state into other tests.
+func TestAgentWorkingLineCapPrompt(t *testing.T) {
+	m := browseSeed(120)
+	m.agentTurnState = poseThinking
+	rt := &agentRuntime{}
+	m.agent = rt
+
+	// A call within the cap: the normal working readout, no cap prompt.
+	granted := 0
+	rt.callMu.Lock()
+	rt.callStart = time.Now().Add(-10 * time.Second)
+	rt.callSoft = rt.callStart.Add(harness.PerCallCap)
+	rt.callExtend = func(time.Duration) { granted++ }
+	rt.callMu.Unlock()
+	line := stripANSI(m.agentWorkingLine(10, 10))
+	if strings.Contains(line, "slow call") {
+		t.Errorf("a call within the cap must not show the cap prompt, got %q", line)
+	}
+
+	// Past the cap: the choice line, with tab / esc / the auto-stop countdown.
+	rt.callMu.Lock()
+	rt.callStart = time.Now().Add(-harness.PerCallCap - 5*time.Second)
+	rt.callSoft = rt.callStart.Add(harness.PerCallCap)
+	rt.callMu.Unlock()
+	line = stripANSI(m.agentWorkingLine(310, 310))
+	for _, want := range []string{"slow call", "tab", "esc", "auto-stop"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("past-cap line should contain %q, got %q", want, line)
+		}
+	}
+
+	// grantMoreTime: extends the underlying deadline once and clears the prompt.
+	if !rt.grantMoreTime() {
+		t.Fatal("grantMoreTime should succeed on a live past-cap call")
+	}
+	if granted != 1 {
+		t.Fatalf("grantMoreTime should call the extend func once, got %d", granted)
+	}
+	line = stripANSI(m.agentWorkingLine(310, 310))
+	if strings.Contains(line, "slow call") {
+		t.Errorf("after a grant the prompt should clear until the next soft mark, got %q", line)
+	}
+	// Not past the (new) cap: a second grant is refused.
+	if rt.grantMoreTime() {
+		t.Error("grantMoreTime must refuse when the call is not past the soft cap")
+	}
+
+	// Between calls: zero-value state never prompts.
+	rt.callMu.Lock()
+	rt.callStart, rt.callSoft, rt.callExtend = time.Time{}, time.Time{}, nil
+	rt.callMu.Unlock()
+	if in, _, past, _ := rt.callState(); in || past {
+		t.Error("cleared call state must read as no live call")
+	}
+}


### PR DESCRIPTION
Implements the founder's ask: when a model call outlives the 300s cap but may legitimately need longer, ask the user instead of hard-killing.

- New harness.ExtendableTimeout primitive (unit-tested: expiry cause, extension, cancel cause).
- BrokerCompleter: per-call bound rides the ctx; callers without a deadline keep the old hard 300s.
- TUI: past-cap working line offers tab (grant +300s) / esc (stop) / auto-stop after a 120s grace; tab yields to slash-completion when the input is a /word.
- go vet + full test suite green; new render test isolates its own runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)