### PR TITLE
tui: arrows always scroll transcripts; history recall on ctrl+p/ctrl+n

### DIFF
--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -650,31 +650,39 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.agentVP.HalfPageDown()
 		return m, nil
 	case "up":
-		// Shell-style recall on the AGENT prompt: Up walks to an OLDER sent prompt
-		// (stashing the live draft on the first Up). Distinct from the chat's history.
-		// The /model picker (which uses up/k) returns earlier, so this only fires while
-		// the prompt itself is focused. With nothing to recall (or while a turn streams,
-		// when edits are ignored) Up scrolls the transcript up a line instead.
+		// Up/Down ALWAYS scroll the transcript. Terminals translate the mouse wheel
+		// into arrow keys while mouse capture is off (alternate scroll), so any recall
+		// behavior here made the wheel "type" old prompts instead of scrolling the
+		// responses (the founder's "I can't scroll and see the responses"). Prompt
+		// recall lives on ctrl+p / ctrl+n, shell-style.
+		m.agentVP.ScrollUp(1)
+		return m, nil
+	case "down":
+		m.agentVP.ScrollDown(1)
+		return m, nil
+	case "end":
+		// Jump back to the live tail (advertised by the scrolled marker).
+		m.agentVP.GotoBottom()
+		return m, nil
+	case "ctrl+p":
+		// Shell-style recall: an OLDER sent prompt (stashing the live draft on the
+		// first press). Distinct from the chat's history. Ignored mid-turn, when
+		// edits to the in-flight prompt would be lost anyway.
 		if !m.agentBusy {
 			if v, ok := m.agentHist.prev(m.agentIn.Value()); ok {
 				m.agentIn.SetValue(v)
 				m.agentIn.CursorEnd()
-				return m, nil
 			}
 		}
-		m.agentVP.ScrollUp(1)
 		return m, nil
-	case "down":
-		// Down walks to a NEWER sent prompt; past the newest it restores the draft. With
-		// nothing to recall (or while busy) it scrolls the transcript down a line.
+	case "ctrl+n":
+		// Recall a NEWER sent prompt; past the newest it restores the stashed draft.
 		if !m.agentBusy {
 			if v, ok := m.agentHist.next(); ok {
 				m.agentIn.SetValue(v)
 				m.agentIn.CursorEnd()
-				return m, nil
 			}
 		}
-		m.agentVP.ScrollDown(1)
 		return m, nil
 	case "tab":
 		// PAST-CAP GRANT: while a model call has outlived the soft cap (the working
@@ -1426,10 +1434,23 @@ func (m model) agentView(w int) string {
 	// budget); the persisted scroll position + auto-stick-to-bottom live in refreshScroll.
 	content := transcriptContent(m.agentLines)
 	m.agentVP.Width = w
-	m.agentVP.Height = clampRows(lineRows(content), m.agentTranscriptRows(cornerRows))
+	budget := m.agentTranscriptRows(cornerRows)
+	m.agentVP.Height = clampRows(lineRows(content), budget)
 	m.agentVP.SetContent(content)
+	// A visible seam between the scrollable transcript and the prompt: when the user
+	// has scrolled up, one reserved row shows how far they are and the way back down,
+	// so "can I scroll this?" is never a mystery (the opencode-style separation).
+	scrolledUp := lineRows(content) > budget && !m.agentVP.AtBottom()
+	if scrolledUp {
+		m.agentVP.Height--
+	}
 	if m.agentVP.Height > 0 {
 		b.WriteString(m.agentVP.View() + "\n")
+	}
+	if scrolledUp {
+		pct := int(m.agentVP.ScrollPercent() * 100)
+		marker := fmt.Sprintf("  ── scrolled · %d%% · ↓ more below · end / pgdn for live ──", pct)
+		b.WriteString(truncVisible(stDim.Render(marker), w) + "\n")
 	}
 	// The pre-launch plate (Phase 3): the ONE confirm between picking a guest and
 	// PATCHING YOU THROUGH - modal, so it renders instead of everything below.
@@ -1523,7 +1544,7 @@ func (m model) agentView(w int) string {
 	if !m.compact {
 		// Busy-aware help: while a turn streams, the one thing the user needs is how to
 		// STOP it (esc), so lead with that instead of the idle command list.
-		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  read/list auto · write/run confirm"
+		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  ⌃p history  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  read/list auto · write/run confirm"
 		switch {
 		case m.agentBusy && m.narrow():
 			help = "type queues · esc cancels (2× force)"

--- a/internal/tui/breadth2_cov_test.go
+++ b/internal/tui/breadth2_cov_test.go
@@ -159,8 +159,9 @@ func TestAgentModelPickerKeys(t *testing.T) {
 }
 
 // TestAgentKeyScrollAndRecall covers the non-text AGENT keys: pgup/pgdown/ctrl+u/ctrl+d
-// scroll the transcript, up/down recall sent prompts, esc (idle) leaves to BROWSE, and
-// esc (busy) cancels the in-flight turn instead of leaving.
+// scroll the transcript, ctrl+p/ctrl+n recall sent prompts (arrows scroll instead - the
+// wheel arrives as arrows), esc (idle) leaves to BROWSE, and esc (busy) cancels the
+// in-flight turn instead of leaving.
 func TestAgentKeyScrollAndRecall(t *testing.T) {
 	base := browseSeed(120)
 	base.connected = &offer{NodeID: "n", Model: "gpt-oss-20b", Online: true}
@@ -177,13 +178,18 @@ func TestAgentKeyScrollAndRecall(t *testing.T) {
 		}
 	}
 
-	// Up recalls the most recent sent prompt onto the input.
+	// Arrows scroll, never recall (the wheel arrives as arrows).
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
-	if v := asModel(m).agentIn.Value(); v != "second prompt" {
-		t.Errorf("up should recall the latest sent prompt, got %q", v)
+	if v := asModel(m).agentIn.Value(); v != "" {
+		t.Errorf("up must scroll, not recall; input became %q", v)
 	}
-	// Down walks newer / restores the draft.
-	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	// ctrl+p recalls the most recent sent prompt onto the input.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if v := asModel(m).agentIn.Value(); v != "second prompt" {
+		t.Errorf("ctrl+p should recall the latest sent prompt, got %q", v)
+	}
+	// ctrl+n walks newer / restores the draft.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
 
 	// esc while idle leaves AGENT for BROWSE.
 	im, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -9,9 +9,12 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// keyUp / keyDown are the shell-style recall keys.
-func keyUp() tea.KeyMsg   { return tea.KeyMsg{Type: tea.KeyUp} }
-func keyDown() tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyDown} }
+// keyUp / keyDown are the arrow keys: they SCROLL the transcripts (the mouse wheel
+// arrives as these under alternate scroll). Recall lives on ctrl+p / ctrl+n.
+func keyUp() tea.KeyMsg         { return tea.KeyMsg{Type: tea.KeyUp} }
+func keyDown() tea.KeyMsg       { return tea.KeyMsg{Type: tea.KeyDown} }
+func keyRecallPrev() tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyCtrlP} }
+func keyRecallNext() tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyCtrlN} }
 
 // --- the inputHistory store itself (unit level) -------------------------------
 
@@ -216,18 +219,23 @@ func TestChatInputUpDownRecall(t *testing.T) {
 		t.Fatalf("send not recorded in chatHist: %v", ents)
 	}
 
-	// Type a fresh draft, then Up should stash it and recall the sent line.
+	// Arrows must NOT recall (they scroll the transcript; the wheel arrives as arrows).
 	mm3 := asModel(m)
 	mm3.chatIn.SetValue("a draft")
 	m = mm3
 	m, _ = m.Update(keyUp())
-	if got := asModel(m).chatIn.Value(); got != "hello there" {
-		t.Fatalf("Up should recall the sent line, got %q", got)
-	}
-	// Down past the newest restores the stashed draft.
-	m, _ = m.Update(keyDown())
 	if got := asModel(m).chatIn.Value(); got != "a draft" {
-		t.Fatalf("Down should restore the draft, got %q", got)
+		t.Fatalf("Up must scroll, not recall; input became %q", got)
+	}
+	// ctrl+p stashes the draft and recalls the sent line.
+	m, _ = m.Update(keyRecallPrev())
+	if got := asModel(m).chatIn.Value(); got != "hello there" {
+		t.Fatalf("ctrl+p should recall the sent line, got %q", got)
+	}
+	// ctrl+n past the newest restores the stashed draft.
+	m, _ = m.Update(keyRecallNext())
+	if got := asModel(m).chatIn.Value(); got != "a draft" {
+		t.Fatalf("ctrl+n should restore the draft, got %q", got)
 	}
 }
 
@@ -254,10 +262,15 @@ func TestAgentPromptUpDownRecall(t *testing.T) {
 	if len(asModel(m).chatHist.entries) != 0 {
 		t.Fatalf("chat history bled from the agent: %v", asModel(m).chatHist.entries)
 	}
-	// Up recalls the agent's sent prompt.
+	// Arrows must NOT recall in AGENT either (they scroll the transcript).
 	m, _ = m.Update(keyUp())
+	if got := asModel(m).agentIn.Value(); got != "" {
+		t.Fatalf("Up in AGENT must scroll, not recall; input became %q", got)
+	}
+	// ctrl+p recalls the agent's sent prompt.
+	m, _ = m.Update(keyRecallPrev())
 	if got := asModel(m).agentIn.Value(); got != "/help" {
-		t.Fatalf("Up in AGENT should recall /help, got %q", got)
+		t.Fatalf("ctrl+p in AGENT should recall /help, got %q", got)
 	}
 }
 

--- a/internal/tui/scroll_test.go
+++ b/internal/tui/scroll_test.go
@@ -172,16 +172,21 @@ func TestChatArrowScrollsWhenNoHistory(t *testing.T) {
 	}
 }
 
-// TestChatHistoryRecallStillWorks: Up-arrow command-history recall is preserved even
-// with the scrollable transcript in place (history takes priority over scroll).
+// TestChatHistoryRecallStillWorks: command-history recall is preserved on ctrl+p with
+// the scrollable transcript in place, and Up scrolls instead of recalling (the wheel
+// arrives as arrow keys, so arrows must never type old messages).
 func TestChatHistoryRecallStillWorks(t *testing.T) {
 	m := tallChat(t, 60)
 	mm := asModel(m)
 	mm.chatHist.add("recall me")
 	m = mm
 	m, _ = m.Update(keyUp())
+	if got := asModel(m).chatIn.Value(); got != "" {
+		t.Fatalf("Up must scroll, not recall; input became %q", got)
+	}
+	m, _ = m.Update(keyRecallPrev())
 	if got := asModel(m).chatIn.Value(); got != "recall me" {
-		t.Fatalf("Up should recall command history, got %q", got)
+		t.Fatalf("ctrl+p should recall command history, got %q", got)
 	}
 }
 
@@ -269,8 +274,8 @@ func TestAgentTypingAndHistoryStillWork(t *testing.T) {
 	mm.agentIn.SetValue("")
 	mm.agentHist.add("earlier prompt")
 	m = mm
-	m, _ = m.Update(keyUp())
+	m, _ = m.Update(keyRecallPrev())
 	if got := asModel(m).agentIn.Value(); got != "earlier prompt" {
-		t.Fatalf("Up should recall the agent history, got %q", got)
+		t.Fatalf("ctrl+p should recall the agent history, got %q", got)
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -611,7 +611,7 @@ type band struct {
 	// no tilde). Unlike vision it is verified-not-declared: the broker only emits "tools" on an
 	// offer after its tool-call canary passed, so a node can never fake it. Absence => inferred
 	// (⌁~), never a false "no tools". See features/trust/toolcall_probe.feature.
-	inFlight int     // active (in-flight) requests summed across online stations - the REAL
+	inFlight int // active (in-flight) requests summed across online stations - the REAL
 	// activity that animates the signal meter (idle band steady, busy band scans). Honest:
 	// it is the broker's live load, never a fabricated pulse.
 	all []offer // every station in this band (online first)
@@ -1808,26 +1808,30 @@ func (m model) onKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.chatVP.HalfPageDown()
 			return m, nil
 		case "up":
-			// Shell-style recall: Up walks to an OLDER sent message (stashing the live
-			// draft on the first Up). Guarded to modeChat (the input is focused here), so
-			// it never fires from BROWSE where up/down move the band cursor. With NO command
-			// history to recall, Up instead scrolls the transcript up a line (so the arrows
-			// reach the response area once the input has nothing to recall).
+			// Up/Down ALWAYS scroll the transcript (the wheel arrives as arrow keys
+			// while mouse capture is off, and it must never "type" old messages).
+			// Recall lives on ctrl+p / ctrl+n, shell-style - same split as AGENT.
+			m.chatVP.ScrollUp(1)
+			return m, nil
+		case "down":
+			m.chatVP.ScrollDown(1)
+			return m, nil
+		case "end":
+			m.chatVP.GotoBottom()
+			return m, nil
+		case "ctrl+p":
+			// Shell-style recall: an OLDER sent message (stashing the live draft on
+			// the first press). Guarded to modeChat (the input is focused here).
 			if v, ok := m.chatHist.prev(m.chatIn.Value()); ok {
 				m.chatIn.SetValue(v)
 				m.chatIn.CursorEnd()
-			} else {
-				m.chatVP.ScrollUp(1)
 			}
 			return m, nil
-		case "down":
-			// Down walks to a NEWER sent message; past the newest it restores the stashed
-			// draft. With nothing to recall it scrolls the transcript down a line.
+		case "ctrl+n":
+			// Recall a NEWER sent message; past the newest it restores the draft.
 			if v, ok := m.chatHist.next(); ok {
 				m.chatIn.SetValue(v)
 				m.chatIn.CursorEnd()
-			} else {
-				m.chatVP.ScrollDown(1)
 			}
 			return m, nil
 		case "ctrl+y":


### PR DESCRIPTION
Fixes 'scrolling the agent view walks prompt history instead of the responses': with mouse capture off, the wheel arrives as arrow keys, and recall had priority. Arrows now always scroll (both AGENT and chat), recall moves to ctrl+p/ctrl+n, end jumps to live, and a scrolled-position seam row makes the scrollable area obvious. Full tui suite + vet green; pinned tests updated to the new key split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)