### PR TITLE
agent: thought-only finals, budget exhaustion notice, transcript readability

### DIFF
--- a/internal/harness/broker.go
+++ b/internal/harness/broker.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rogerai-fyi/roger/internal/client"
@@ -144,11 +145,17 @@ func parseCompletion(raw []byte, status int) (Message, error) {
 	var d struct {
 		Choices []struct {
 			Message struct {
-				Role      string     `json:"role"`
-				Content   string     `json:"content"`
-				Reasoning string     `json:"reasoning"`
-				ToolCalls []ToolCall `json:"tool_calls"`
+				Role    string `json:"role"`
+				Content string `json:"content"`
+				// Thinking models return their reasoning under either key depending
+				// on the backend: llama.cpp's reasoning-format emits
+				// `reasoning_content` (DeepSeek/Qwen style), others use `reasoning`.
+				// Missing the first one made thought-only replies read as empty.
+				Reasoning        string     `json:"reasoning"`
+				ReasoningContent string     `json:"reasoning_content"`
+				ToolCalls        []ToolCall `json:"tool_calls"`
 			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
 		} `json:"choices"`
 		Error struct {
 			Message string `json:"message"`
@@ -173,11 +180,22 @@ func parseCompletion(raw []byte, status int) (Message, error) {
 		return Message{}, fmt.Errorf("the station sent an empty response (status %d)", status)
 	}
 	c := d.Choices[0].Message
-	content := c.Content
-	if content == "" && len(c.ToolCalls) == 0 {
-		content = c.Reasoning
+	msg := Message{
+		Role:      "assistant",
+		Content:   c.Content,
+		ToolCalls: c.ToolCalls,
+		Truncated: d.Choices[0].FinishReason == "length",
 	}
-	return Message{Role: "assistant", Content: content, ToolCalls: c.ToolCalls}, nil
+	if msg.Content == "" && len(c.ToolCalls) == 0 {
+		// Keep the reasoning OUT of Content: the loop surfaces it as a marked Thought
+		// (thinking aloud), never as a spoken answer fed back into the conversation.
+		if t := strings.TrimSpace(c.ReasoningContent); t != "" {
+			msg.Thought = t
+		} else {
+			msg.Thought = strings.TrimSpace(c.Reasoning)
+		}
+	}
+	return msg, nil
 }
 
 // bytesTrim trims ASCII whitespace from a byte slice (small local helper to avoid an

--- a/internal/harness/cov_test.go
+++ b/internal/harness/cov_test.go
@@ -150,10 +150,11 @@ func TestParseCompletion(t *testing.T) {
 		t.Fatalf("parseCompletion(plain) = %+v/%v", m, err)
 	}
 
-	// Reasoning-only content falls back to reasoning.
+	// Reasoning-only content surfaces as Thought (never dressed up as Content - the
+	// loop renders it as thinking aloud; see thought_test.go for both backend keys).
 	reasoning := `{"choices":[{"message":{"role":"assistant","reasoning":"because"}}]}`
-	if m, _ := parseCompletion([]byte(reasoning), 200); m.Content != "because" {
-		t.Errorf("parseCompletion(reasoning) content = %q, want because", m.Content)
+	if m, _ := parseCompletion([]byte(reasoning), 200); m.Content != "" || m.Thought != "because" {
+		t.Errorf("parseCompletion(reasoning) = Content %q / Thought %q, want empty / because", m.Content, m.Thought)
 	}
 
 	// Provider error body -> surfaced as an error.

--- a/internal/harness/loop.go
+++ b/internal/harness/loop.go
@@ -17,6 +17,13 @@ type Message struct {
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string     `json:"tool_call_id,omitempty"`
 	Name       string     `json:"name,omitempty"`
+	// Thought is the model's reasoning text when the visible content came back empty
+	// (a thinking model that wrapped up inside its reasoning channel and never spoke).
+	// Local-only: never serialized back to the API.
+	Thought string `json:"-"`
+	// Truncated marks a finish_reason=length reply: the completion budget ran out
+	// (often mid-reasoning, which is one way content arrives empty). Local-only.
+	Truncated bool `json:"-"`
 }
 
 // ToolCall is one OpenAI tool_call: an id, the function name, and the JSON-string
@@ -55,6 +62,13 @@ type Event struct {
 	Result  string         // tool result text (ToolResult)
 	IsError bool           // the tool result is an error / a denied confirm
 	Denied  bool           // a confirm was denied (ToolResult)
+	// Thought marks an EventFinal whose Text is the model's REASONING, surfaced
+	// because the spoken answer came back empty - the UI should render it as
+	// thinking aloud, not as a normal answer.
+	Thought bool
+	// Truncated marks an EventFinal cut off by the completion budget
+	// (finish_reason=length), so the UI can say WHY there is little or no text.
+	Truncated bool
 }
 
 // EventKind tags an Event.
@@ -157,7 +171,15 @@ func (l *Loop) Send(ctx context.Context, userText string, emit func(Event)) (str
 		if len(msg.ToolCalls) == 0 {
 			// Final answer (or a plain-chat model that ignored the tools).
 			final := strings.TrimSpace(msg.Content)
-			emit(Event{Kind: EventFinal, Text: final})
+			if final == "" && msg.Thought != "" {
+				// A thinking model that never spoke: surface the reasoning, marked as
+				// thought so the UI renders it as thinking aloud (the founder's "the
+				// agent finished with no text" dead end had the words sitting right
+				// here in reasoning_content).
+				emit(Event{Kind: EventFinal, Text: msg.Thought, Thought: true, Truncated: msg.Truncated})
+				return msg.Thought, nil
+			}
+			emit(Event{Kind: EventFinal, Text: final, Truncated: msg.Truncated})
 			return final, nil
 		}
 

--- a/internal/harness/thought_test.go
+++ b/internal/harness/thought_test.go
@@ -1,0 +1,73 @@
+package harness
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestParseCompletionReasoningContent: a thought-only reply (llama.cpp's
+// `reasoning_content`, DeepSeek style) surfaces as Thought, never as Content, and
+// finish_reason=length sets Truncated. This was the founder's "the agent finished
+// with no text": the words were in reasoning_content and the parser read `reasoning`.
+func TestParseCompletionReasoningContent(t *testing.T) {
+	raw := []byte(`{"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"","reasoning_content":"the repo has 22 agentic runs"}}]}`)
+	msg, err := parseCompletion(raw, 200)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if msg.Content != "" {
+		t.Errorf("reasoning must not masquerade as Content, got %q", msg.Content)
+	}
+	if msg.Thought != "the repo has 22 agentic runs" {
+		t.Errorf("Thought = %q", msg.Thought)
+	}
+	if msg.Truncated {
+		t.Error("stop finish must not read as truncated")
+	}
+
+	// The other backend key still works.
+	raw = []byte(`{"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"","reasoning":"alt key"}}]}`)
+	msg, _ = parseCompletion(raw, 200)
+	if msg.Thought != "alt key" {
+		t.Errorf("legacy reasoning key Thought = %q", msg.Thought)
+	}
+
+	// Budget exhaustion is marked.
+	raw = []byte(`{"choices":[{"finish_reason":"length","message":{"role":"assistant","content":"","reasoning_content":"half a think"}}]}`)
+	msg, _ = parseCompletion(raw, 200)
+	if !msg.Truncated || msg.Thought != "half a think" {
+		t.Errorf("length finish: Truncated=%v Thought=%q", msg.Truncated, msg.Thought)
+	}
+
+	// A spoken answer never picks up a Thought.
+	raw = []byte(`{"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"spoken","reasoning_content":"hidden"}}]}`)
+	msg, _ = parseCompletion(raw, 200)
+	if msg.Content != "spoken" || msg.Thought != "" {
+		t.Errorf("spoken reply: Content=%q Thought=%q", msg.Content, msg.Thought)
+	}
+}
+
+// TestLoopSurfacesThoughtFinal: the loop marks a thought-only final so the UI can
+// render it as thinking aloud (Thought=true rides the EventFinal).
+func TestLoopSurfacesThoughtFinal(t *testing.T) {
+	completer := func(_ context.Context, _ []Message, _ []map[string]any) (Message, error) {
+		return Message{Role: "assistant", Thought: "wrapped up inside the think", Truncated: true}, nil
+	}
+	l := NewLoop(t.TempDir(), "persona", completer, func(string, map[string]any) bool { return false })
+	var final Event
+	_, err := l.Send(context.Background(), "hi", func(e Event) {
+		if e.Kind == EventFinal {
+			final = e
+		}
+	})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if !final.Thought || !final.Truncated {
+		t.Errorf("final should carry Thought+Truncated, got %+v", final)
+	}
+	if !strings.Contains(final.Text, "wrapped up") {
+		t.Errorf("final text should be the reasoning, got %q", final.Text)
+	}
+}

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -798,7 +798,7 @@ func (m model) submitAgentPrompt(q queuedPrompt) (model, tea.Cmd) {
 	// REMOTE-drained prompt is NEVER parked (it must resolve as a chat turn immediately -
 	// the busy-queue remote-handoff guard); only locally-typed asks park.
 	if m.agent != nil && m.agent.model == "" && !q.remote {
-		m.agentLines = append(m.agentLines, stSelText.Render("▸ ")+p)
+		m.agentLines = append(m.agentLines, m.agentAskLines(p)...)
 		m.agentPending = append(m.agentPending, q)
 		if !m.autoTuning {
 			m.autoTuning = true
@@ -811,7 +811,7 @@ func (m model) submitAgentPrompt(q queuedPrompt) (model, tea.Cmd) {
 	if !q.echoed {
 		// Skip the echo for a prompt already shown at park time (drainPendingPrompts requeued
 		// it); otherwise echo the ask now.
-		m.agentLines = append(m.agentLines, stSelText.Render("▸ ")+p)
+		m.agentLines = append(m.agentLines, m.agentAskLines(p)...)
 	}
 	// Re-resolve to the currently open channel so a model tuned in mid-session is used; if
 	// still nothing is tuned in, the turn fails into the same actionable hint rather than
@@ -1140,7 +1140,7 @@ func (m model) onAgentEvent(e agentEventMsg) (tea.Model, tea.Cmd) {
 	case harness.EventAssistant:
 		m.agentTurnState = poseStreaming
 		if t := strings.TrimSpace(e.Text); t != "" {
-			m.agentLines = append(m.agentLines, stLive.Render("◂ ")+t)
+			m.agentLines = append(m.agentLines, agentAnswerBlock(t)...)
 		}
 	case harness.EventToolCall:
 		m.agentTurnState = poseTool
@@ -1169,12 +1169,18 @@ func (m model) onAgentEvent(e agentEventMsg) (tea.Model, tea.Cmd) {
 	case harness.EventFinal:
 		m.agentTurnState = poseStreaming
 		t := strings.TrimSpace(e.Text)
-		if t == "" {
-			t = stDim.Render("(the agent finished with no text)")
-		} else {
-			t = stLive.Render("◂ ") + t
+		switch {
+		case t == "" && e.Truncated:
+			// Honest, actionable: the completion budget ran out (usually eaten by a
+			// long think) - name the cause instead of the old dead-end "(no text)".
+			m.agentLines = append(m.agentLines, stEmber.Render("(the answer budget ran out mid-thought - ask again, or ask narrower)"))
+		case t == "":
+			m.agentLines = append(m.agentLines, stDim.Render("(the agent finished with no text)"))
+		case e.Thought:
+			m.agentLines = append(m.agentLines, agentThoughtBlock(t, e.Truncated)...)
+		default:
+			m.agentLines = append(m.agentLines, agentAnswerBlock(t)...)
 		}
-		m.agentLines = append(m.agentLines, t)
 		// Per-turn session footer: the honest running ↑in ↓out (broker billed re-count) + cost,
 		// via the SHARED sessionFooter so the AGENT + CHANNEL money surfaces never drift.
 		if f := sessionFooter(m.agentTokensIn, m.agentTokensOut, m.agentCost); f != "" {
@@ -1556,6 +1562,58 @@ func (m model) agentView(w int) string {
 		b.WriteString(truncVisible("  "+stDim.Render(help), w) + "\n")
 	}
 	return b.String()
+}
+
+// agentAskLines echoes one sent ask. From the second ask on, a dim time-stamped rule
+// precedes it, chunking the transcript into visibly separate turns - the difference
+// between a wall of interleaved tool output and a session you can scan.
+func (m model) agentAskLines(p string) []string {
+	ask := stSelText.Render("▸ ") + p
+	if len(m.agentLines) == 0 {
+		return []string{ask}
+	}
+	rule := stDim.Render("── " + time.Now().Format("15:04") + " " + strings.Repeat("─", 24))
+	return []string{"", rule, ask}
+}
+
+// agentAnswerBlock renders the model's prose with a left gutter on every line ("◂" on
+// the first, a quiet bar on the rest), so a multi-line answer reads as ONE block
+// against the surrounding tool chatter instead of dissolving into it.
+func agentAnswerBlock(t string) []string {
+	lines := strings.Split(t, "\n")
+	out := make([]string, 0, len(lines))
+	for i, l := range lines {
+		g := "▏ "
+		if i == 0 {
+			g = "◂ "
+		}
+		out = append(out, stLive.Render(g)+l)
+	}
+	return out
+}
+
+// agentThoughtClip bounds a surfaced thought to its ENDING - the wrap-up is where a
+// thinking model that never spoke actually concluded (the start is preamble).
+const agentThoughtClip = 10
+
+// agentThoughtBlock renders a thought-only final: the model reasoned to an end but
+// never produced a spoken answer, so show the TAIL of the reasoning, dimmed and
+// labeled, never dressed up as a normal reply.
+func agentThoughtBlock(t string, truncated bool) []string {
+	label := "thought aloud, no spoken answer:"
+	if truncated {
+		label = "ran out of answer budget while thinking - the thought so far:"
+	}
+	out := []string{stDim.Render("◂ (" + label + ")")}
+	lines := strings.Split(t, "\n")
+	if len(lines) > agentThoughtClip {
+		out = append(out, stDim.Render(fmt.Sprintf("▏ … (+%d earlier thought lines)", len(lines)-agentThoughtClip)))
+		lines = lines[len(lines)-agentThoughtClip:]
+	}
+	for _, l := range lines {
+		out = append(out, stDim.Render("▏ "+l))
+	}
+	return out
 }
 
 // agentStallSec is how long the turn may go with NO event from the STATION before the

--- a/internal/tui/agent_final_render_test.go
+++ b/internal/tui/agent_final_render_test.go
@@ -1,0 +1,96 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/harness"
+)
+
+// lastAgentLines returns the transcript entries appended after n existing ones,
+// ANSI-stripped, for readable assertions.
+func lastAgentLines(m model, n int) []string {
+	out := make([]string, 0, len(m.agentLines)-n)
+	for _, l := range m.agentLines[n:] {
+		out = append(out, stripANSI(l))
+	}
+	return out
+}
+
+// TestAgentFinalRenderShapes locks the EventFinal render contract: a spoken answer
+// gets the block gutter, a thought-only final is labeled + dimmed + tail-clipped, a
+// truncated empty final names the budget, and a plain empty final keeps the old line.
+func TestAgentFinalRenderShapes(t *testing.T) {
+	base := browseSeed(120)
+
+	// Spoken multi-line answer: "◂" on the first line, the quiet bar on the rest.
+	m := base
+	n := len(m.agentLines)
+	nm, _ := m.Update(agentEventMsg{Kind: harness.EventFinal, Text: "first\nsecond"})
+	got := lastAgentLines(asModel(nm), n)
+	if len(got) < 2 || !strings.HasPrefix(got[0], "◂ first") || !strings.HasPrefix(got[1], "▏ second") {
+		t.Errorf("answer block = %q", got)
+	}
+
+	// Thought-only final: labeled as thinking aloud, gutters dimmed, tail clipped.
+	long := strings.Repeat("preamble\n", agentThoughtClip+5) + "the actual conclusion"
+	m = base
+	n = len(m.agentLines)
+	nm, _ = m.Update(agentEventMsg{Kind: harness.EventFinal, Text: long, Thought: true})
+	joined := strings.Join(lastAgentLines(asModel(nm), n), "\n")
+	if !strings.Contains(joined, "thought aloud, no spoken answer") {
+		t.Errorf("thought final missing label:\n%s", joined)
+	}
+	if !strings.Contains(joined, "earlier thought lines") || !strings.Contains(joined, "the actual conclusion") {
+		t.Errorf("thought final should clip to the tail and keep the conclusion:\n%s", joined)
+	}
+
+	// Truncated thought names the budget in the label.
+	m = base
+	n = len(m.agentLines)
+	nm, _ = m.Update(agentEventMsg{Kind: harness.EventFinal, Text: "half a think", Thought: true, Truncated: true})
+	joined = strings.Join(lastAgentLines(asModel(nm), n), "\n")
+	if !strings.Contains(joined, "ran out of answer budget") {
+		t.Errorf("truncated thought should name the budget:\n%s", joined)
+	}
+
+	// Empty + truncated: the actionable budget message, not the dead-end "(no text)".
+	m = base
+	n = len(m.agentLines)
+	nm, _ = m.Update(agentEventMsg{Kind: harness.EventFinal, Text: "", Truncated: true})
+	joined = strings.Join(lastAgentLines(asModel(nm), n), "\n")
+	if !strings.Contains(joined, "answer budget ran out") {
+		t.Errorf("empty truncated final should explain the budget:\n%s", joined)
+	}
+
+	// Plain empty final keeps the honest fallback.
+	m = base
+	n = len(m.agentLines)
+	nm, _ = m.Update(agentEventMsg{Kind: harness.EventFinal, Text: ""})
+	joined = strings.Join(lastAgentLines(asModel(nm), n), "\n")
+	if !strings.Contains(joined, "finished with no text") {
+		t.Errorf("plain empty final = %q", joined)
+	}
+}
+
+// TestAgentAskSeparator: the first ask echoes bare; later asks are preceded by the
+// dim time-stamped rule that chunks the transcript into turns.
+func TestAgentAskSeparator(t *testing.T) {
+	m := browseSeed(120)
+	m.agentLines = nil
+	first := m.agentAskLines("one")
+	if len(first) != 1 || !strings.Contains(stripANSI(first[0]), "▸ one") {
+		t.Errorf("first ask should echo bare, got %q", first)
+	}
+	m.agentLines = append(m.agentLines, first...)
+	second := m.agentAskLines("two")
+	if len(second) != 3 {
+		t.Fatalf("later asks should carry blank+rule+ask, got %q", second)
+	}
+	if !strings.Contains(stripANSI(second[1]), "──") {
+		t.Errorf("separator rule missing, got %q", stripANSI(second[1]))
+	}
+	if !strings.Contains(stripANSI(second[2]), "▸ two") {
+		t.Errorf("ask line missing, got %q", second)
+	}
+}


### PR DESCRIPTION
Fixes '(the agent finished with no text)': thinking models returning reasoning_content now surface their thought (labeled, dimmed, tail-clipped) instead of reading as empty, and finish_reason=length gets an actionable budget message. Plus a readability pass: answer gutter blocks and time-stamped turn separators. Full suite + vet green; new unit + render tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)