### PR TITLE
tui: AGENT pane focus (tab to transcript) + wheel-scroll capture by default

### DIFF
--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -572,6 +572,54 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.status = stDim.Render(djHasMicStatus)
 		}
 	}
+	// TRANSCRIPT focus (tab from the ask input): the response pane owns the keyboard.
+	// Scroll keys act on the viewport; esc / enter / tab hand the keyboard back to the
+	// input; any typed rune ALSO returns focus and types (the "just start typing" path),
+	// so the pane never traps the user. The past-cap tab grant still wins while busy
+	// (handled in the tab case below after focus returns - a grant needs the input).
+	if m.agentPaneFocus {
+		switch k.String() {
+		case "up", "k":
+			m.agentVP.ScrollUp(1)
+			return m, nil
+		case "down", "j":
+			m.agentVP.ScrollDown(1)
+			return m, nil
+		case "pgup":
+			m.agentVP.PageUp()
+			return m, nil
+		case "pgdown":
+			m.agentVP.PageDown()
+			return m, nil
+		case "ctrl+u":
+			m.agentVP.HalfPageUp()
+			return m, nil
+		case "ctrl+d":
+			m.agentVP.HalfPageDown()
+			return m, nil
+		case "home":
+			m.agentVP.GotoTop()
+			return m, nil
+		case "end":
+			m.agentVP.GotoBottom()
+			return m, nil
+		case "tab", "esc", "enter":
+			m.agentPaneFocus = false
+			m.agentIn.Focus()
+			m.status = stDim.Render("the mic is yours · type to ask")
+			return m, textinput.Blink
+		default:
+			if isPrintableKey(k) {
+				// Type-through: focus snaps back to the input and the rune lands there.
+				m.agentPaneFocus = false
+				m.agentIn.Focus()
+				var cmd tea.Cmd
+				m.agentIn, cmd = m.agentIn.Update(k)
+				return m, cmd
+			}
+			return m, nil
+		}
+	}
 	// Text-entry mode: enter submits (or QUEUES while a turn runs - see the enter case),
 	// esc cancels/leaves, the scroll/recall/copy keys below act, and everything else feeds
 	// the prompt input - typable even mid-turn so the next ask can be composed + queued.
@@ -650,14 +698,27 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.agentVP.HalfPageDown()
 		return m, nil
 	case "up":
-		// Up/Down ALWAYS scroll the transcript. Terminals translate the mouse wheel
-		// into arrow keys while mouse capture is off (alternate scroll), so any recall
-		// behavior here made the wheel "type" old prompts instead of scrolling the
-		// responses (the founder's "I can't scroll and see the responses"). Prompt
-		// recall lives on ctrl+p / ctrl+n, shell-style.
+		// The INPUT owns the keyboard here (transcript focus is intercepted above):
+		// arrows mean shell-style history again - the wheel scrolls as REAL mouse
+		// events now that capture is on, so the two no longer collide. With nothing
+		// to recall, fall through to a line of scroll.
+		if !m.agentBusy {
+			if v, ok := m.agentHist.prev(m.agentIn.Value()); ok {
+				m.agentIn.SetValue(v)
+				m.agentIn.CursorEnd()
+				return m, nil
+			}
+		}
 		m.agentVP.ScrollUp(1)
 		return m, nil
 	case "down":
+		if !m.agentBusy {
+			if v, ok := m.agentHist.next(); ok {
+				m.agentIn.SetValue(v)
+				m.agentIn.CursorEnd()
+				return m, nil
+			}
+		}
 		m.agentVP.ScrollDown(1)
 		return m, nil
 	case "end":
@@ -695,6 +756,15 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.agentLines = append(m.agentLines, stDim.Render("· ")+stDim.Render(fmt.Sprintf("granted the call %ds more", capS)))
 				return m, nil
 			}
+		}
+		// Outside a slash word, tab hands the keyboard to the TRANSCRIPT pane (the
+		// founder's "tab from the input to the answer and it should highlight"):
+		// arrows scroll there, the seam lights up, esc/enter/typing come back.
+		if !strings.HasPrefix(strings.TrimSpace(m.agentIn.Value()), "/") {
+			m.agentPaneFocus = true
+			m.agentIn.Blur()
+			m.status = stDim.Render("transcript focused · ↑↓ pgup/pgdn scroll · end jumps live · tab/esc back to ask")
+			return m, nil
 		}
 		// Slash-command autocomplete (see agentCommands): a unique prefix match fills
 		// the input + a trailing space (word done - ready for args or enter); several
@@ -1447,16 +1517,27 @@ func (m model) agentView(w int) string {
 	// has scrolled up, one reserved row shows how far they are and the way back down,
 	// so "can I scroll this?" is never a mystery (the opencode-style separation).
 	scrolledUp := lineRows(content) > budget && !m.agentVP.AtBottom()
-	if scrolledUp {
+	seam := scrolledUp || m.agentPaneFocus
+	if seam {
 		m.agentVP.Height--
 	}
 	if m.agentVP.Height > 0 {
 		b.WriteString(m.agentVP.View() + "\n")
 	}
-	if scrolledUp {
-		pct := int(m.agentVP.ScrollPercent() * 100)
-		marker := fmt.Sprintf("  ── scrolled · %d%% · ↓ more below · end / pgdn for live ──", pct)
-		b.WriteString(truncVisible(stDim.Render(marker), w) + "\n")
+	if seam {
+		// The seam doubles as the FOCUS cue: lit + labeled while the transcript owns
+		// the keyboard, dim wayfinding while merely scrolled up.
+		switch {
+		case m.agentPaneFocus && scrolledUp:
+			pct := int(m.agentVP.ScrollPercent() * 100)
+			b.WriteString(truncVisible(stKey.Render(fmt.Sprintf("  ── ● transcript · %d%% · ↑↓ scroll · end live · tab/esc back ──", pct)), w) + "\n")
+		case m.agentPaneFocus:
+			b.WriteString(truncVisible(stKey.Render("  ── ● transcript · ↑↓ scroll · tab/esc back to ask ──"), w) + "\n")
+		default:
+			pct := int(m.agentVP.ScrollPercent() * 100)
+			marker := fmt.Sprintf("  ── scrolled · %d%% · ↓ more below · end / pgdn for live · tab focuses ──", pct)
+			b.WriteString(truncVisible(stDim.Render(marker), w) + "\n")
+		}
 	}
 	// The pre-launch plate (Phase 3): the ONE confirm between picking a guest and
 	// PATCHING YOU THROUGH - modal, so it renders instead of everything below.
@@ -1550,7 +1631,7 @@ func (m model) agentView(w int) string {
 	if !m.compact {
 		// Busy-aware help: while a turn streams, the one thing the user needs is how to
 		// STOP it (esc), so lead with that instead of the idle command list.
-		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  ⌃p history  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  read/list auto · write/run confirm"
+		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  tab focuses the transcript  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  read/list auto · write/run confirm"
 		switch {
 		case m.agentBusy && m.narrow():
 			help = "type queues · esc cancels (2× force)"

--- a/internal/tui/agent_pane_focus_test.go
+++ b/internal/tui/agent_pane_focus_test.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestAgentPaneFocus locks the two-pane focus model: tab hands the keyboard to the
+// transcript (highlighted seam, arrows scroll), esc/tab/typing hand it back, and the
+// slash-completion + input-history behaviors survive on the input side.
+func TestAgentPaneFocus(t *testing.T) {
+	base := browseSeed(120)
+	base.connected = &offer{NodeID: "n", Model: "gpt-oss-20b", Online: true}
+	nm, _ := base.enterAgent()
+	am := asModel(nm)
+	for i := 0; i < 80; i++ {
+		am.agentLines = append(am.agentLines, "LINE")
+	}
+	am.agentIn.Focus()
+
+	// Tab from a non-slash input focuses the transcript.
+	var m tea.Model = am
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if !asModel(m).agentPaneFocus {
+		t.Fatal("tab should focus the transcript pane")
+	}
+	// The seam lights up as the focus cue.
+	if !strings.Contains(stripANSI(m.View()), "● transcript") {
+		t.Error("focused pane should render the lit seam cue")
+	}
+	// Arrows scroll, not recall, while the pane is focused.
+	mm := asModel(m)
+	mm.agentHist.add("older")
+	m = mm
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if got := asModel(m).agentIn.Value(); got != "" {
+		t.Errorf("up with the pane focused must scroll, not recall; input became %q", got)
+	}
+	// Esc returns the keyboard to the input (and does NOT leave AGENT).
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	got := asModel(m)
+	if got.agentPaneFocus || got.mode != modeAgent {
+		t.Fatalf("esc should refocus the input and stay in AGENT (paneFocus=%v mode=%v)", got.agentPaneFocus, got.mode)
+	}
+
+	// Type-through: focusing the pane then typing a rune snaps back and types it.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	got = asModel(m)
+	if got.agentPaneFocus || got.agentIn.Value() != "h" {
+		t.Fatalf("typing should snap focus back to the input and type (paneFocus=%v input=%q)", got.agentPaneFocus, got.agentIn.Value())
+	}
+
+	// A slash word keeps tab as completion, never a pane toggle.
+	mm = asModel(m)
+	mm.agentIn.SetValue("/he")
+	m = mm
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	got = asModel(m)
+	if got.agentPaneFocus {
+		t.Error("tab on a slash word must slash-complete, not switch panes")
+	}
+	if !strings.HasPrefix(got.agentIn.Value(), "/help") {
+		t.Errorf("tab should complete /he -> /help, got %q", got.agentIn.Value())
+	}
+}

--- a/internal/tui/breadth2_cov_test.go
+++ b/internal/tui/breadth2_cov_test.go
@@ -159,9 +159,9 @@ func TestAgentModelPickerKeys(t *testing.T) {
 }
 
 // TestAgentKeyScrollAndRecall covers the non-text AGENT keys: pgup/pgdown/ctrl+u/ctrl+d
-// scroll the transcript, ctrl+p/ctrl+n recall sent prompts (arrows scroll instead - the
-// wheel arrives as arrows), esc (idle) leaves to BROWSE, and esc (busy) cancels the
-// in-flight turn instead of leaving.
+// scroll the transcript, up/down recall sent prompts while the input owns focus (the
+// wheel scrolls as real mouse events), esc (idle) leaves to BROWSE, and esc (busy)
+// cancels the in-flight turn instead of leaving.
 func TestAgentKeyScrollAndRecall(t *testing.T) {
 	base := browseSeed(120)
 	base.connected = &offer{NodeID: "n", Model: "gpt-oss-20b", Online: true}
@@ -178,18 +178,13 @@ func TestAgentKeyScrollAndRecall(t *testing.T) {
 		}
 	}
 
-	// Arrows scroll, never recall (the wheel arrives as arrows).
+	// Up (input focused) recalls the most recent sent prompt onto the input.
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
-	if v := asModel(m).agentIn.Value(); v != "" {
-		t.Errorf("up must scroll, not recall; input became %q", v)
-	}
-	// ctrl+p recalls the most recent sent prompt onto the input.
-	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
 	if v := asModel(m).agentIn.Value(); v != "second prompt" {
-		t.Errorf("ctrl+p should recall the latest sent prompt, got %q", v)
+		t.Errorf("up should recall the latest sent prompt, got %q", v)
 	}
-	// ctrl+n walks newer / restores the draft.
-	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	// Down walks newer / restores the draft.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
 
 	// esc while idle leaves AGENT for BROWSE.
 	im, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})

--- a/internal/tui/breadth_cov_test.go
+++ b/internal/tui/breadth_cov_test.go
@@ -107,13 +107,14 @@ func TestRunSeamEntryPoints(t *testing.T) {
 		if got.updateLine != "note" {
 			t.Errorf("RunWithController should set the notice, got %q", got.updateLine)
 		}
-		// Only AltScreen is passed: mouse capture is OFF by default so native drag-select +
-		// copy works on any text (opencode-style); the user opts into wheel-scroll via ctrl+o.
-		if len(opts) != 1 {
-			t.Errorf("RunWithController should pass alt-screen ONLY (1 opt; mouse capture off), got %d", len(opts))
+		// AltScreen + MouseCellMotion are passed: mouse capture is ON by default so the
+		// wheel scrolls the transcripts as real mouse events (arrows mean history);
+		// ctrl+o / /mouse toggles back to native drag-select.
+		if len(opts) != 2 {
+			t.Errorf("RunWithController should pass alt-screen + mouse capture (2 opts), got %d", len(opts))
 		}
-		if !got.mouseOff {
-			t.Errorf("RunWithController model should start mouseOff=true (native copy default)")
+		if got.mouseOff {
+			t.Errorf("RunWithController model should start mouseOff=false (wheel-scroll default)")
 		}
 	})
 }

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -9,8 +9,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// keyUp / keyDown are the arrow keys: they SCROLL the transcripts (the mouse wheel
-// arrives as these under alternate scroll). Recall lives on ctrl+p / ctrl+n.
+// keyUp / keyDown are the arrow keys: while the INPUT owns focus they recall history
+// (the wheel scrolls as real mouse events - capture is on by default). ctrl+p / ctrl+n
+// remain shell-style recall aliases.
 func keyUp() tea.KeyMsg         { return tea.KeyMsg{Type: tea.KeyUp} }
 func keyDown() tea.KeyMsg       { return tea.KeyMsg{Type: tea.KeyDown} }
 func keyRecallPrev() tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyCtrlP} }
@@ -219,20 +220,24 @@ func TestChatInputUpDownRecall(t *testing.T) {
 		t.Fatalf("send not recorded in chatHist: %v", ents)
 	}
 
-	// Arrows must NOT recall (they scroll the transcript; the wheel arrives as arrows).
+	// Up (input focused) stashes the draft and recalls the sent line.
 	mm3 := asModel(m)
 	mm3.chatIn.SetValue("a draft")
 	m = mm3
 	m, _ = m.Update(keyUp())
-	if got := asModel(m).chatIn.Value(); got != "a draft" {
-		t.Fatalf("Up must scroll, not recall; input became %q", got)
+	if got := asModel(m).chatIn.Value(); got != "hello there" {
+		t.Fatalf("Up should recall the sent line, got %q", got)
 	}
-	// ctrl+p stashes the draft and recalls the sent line.
+	// Down past the newest restores the stashed draft.
+	m, _ = m.Update(keyDown())
+	if got := asModel(m).chatIn.Value(); got != "a draft" {
+		t.Fatalf("Down should restore the draft, got %q", got)
+	}
+	// ctrl+p / ctrl+n remain recall aliases.
 	m, _ = m.Update(keyRecallPrev())
 	if got := asModel(m).chatIn.Value(); got != "hello there" {
 		t.Fatalf("ctrl+p should recall the sent line, got %q", got)
 	}
-	// ctrl+n past the newest restores the stashed draft.
 	m, _ = m.Update(keyRecallNext())
 	if got := asModel(m).chatIn.Value(); got != "a draft" {
 		t.Fatalf("ctrl+n should restore the draft, got %q", got)
@@ -262,15 +267,20 @@ func TestAgentPromptUpDownRecall(t *testing.T) {
 	if len(asModel(m).chatHist.entries) != 0 {
 		t.Fatalf("chat history bled from the agent: %v", asModel(m).chatHist.entries)
 	}
-	// Arrows must NOT recall in AGENT either (they scroll the transcript).
+	// Up (input focused) recalls the agent's sent prompt.
+	m, _ = m.Update(keyUp())
+	if got := asModel(m).agentIn.Value(); got != "/help" {
+		t.Fatalf("Up in AGENT should recall /help, got %q", got)
+	}
+	// With the TRANSCRIPT focused, Up scrolls instead of recalling.
+	am2 := asModel(m)
+	am2.agentIn.SetValue("")
+	am2.agentHist.cursor = len(am2.agentHist.entries)
+	am2.agentPaneFocus = true
+	m = am2
 	m, _ = m.Update(keyUp())
 	if got := asModel(m).agentIn.Value(); got != "" {
-		t.Fatalf("Up in AGENT must scroll, not recall; input became %q", got)
-	}
-	// ctrl+p recalls the agent's sent prompt.
-	m, _ = m.Update(keyRecallPrev())
-	if got := asModel(m).agentIn.Value(); got != "/help" {
-		t.Fatalf("ctrl+p in AGENT should recall /help, got %q", got)
+		t.Fatalf("Up with the transcript focused must scroll, not recall; input became %q", got)
 	}
 }
 

--- a/internal/tui/phase1_copy_cov_test.go
+++ b/internal/tui/phase1_copy_cov_test.go
@@ -81,19 +81,20 @@ func TestSlashCopyLastReplyAndAll(t *testing.T) {
 }
 
 func TestSlashMouseToggle(t *testing.T) {
-	// Default is native-select (mouseOff=true, copy works). /mouse toggles INTO wheel-scroll
-	// (mouseOff=false), and again back to native-select.
+	// Default is wheel-scroll (mouseOff=false: the wheel scrolls transcripts as real
+	// mouse events, arrows mean history). /mouse toggles OUT to native-select (copy
+	// without shift-drag), and again back to wheel-scroll.
 	m := chatModelForCopy()
-	if !m.mouseOff {
-		t.Fatal("default should be native-select (mouseOff=true) so copy works out of the box")
+	if m.mouseOff {
+		t.Fatal("default should be wheel-scroll (mouseOff=false) so the wheel scrolls the transcripts")
 	}
 	out, cmd := m.runSession("/mouse")
-	if asModel(out).mouseOff || cmd == nil {
-		t.Error("/mouse from the default should enable wheel-scroll (mouseOff=false) + a cmd")
+	if !asModel(out).mouseOff || cmd == nil {
+		t.Error("/mouse from the default should switch to native-select (mouseOff=true) + DisableMouse")
 	}
 	out2, cmd2 := asModel(out).runSession("/mouse")
-	if !asModel(out2).mouseOff || cmd2 == nil {
-		t.Error("/mouse again should restore native-select (mouseOff=true) + DisableMouse")
+	if asModel(out2).mouseOff || cmd2 == nil {
+		t.Error("/mouse again should restore wheel-scroll (mouseOff=false) + a cmd")
 	}
 }
 
@@ -170,13 +171,14 @@ func TestChannelFooterDedupAndHints(t *testing.T) {
 }
 
 func TestCtrlOTogglesNativeSelect(t *testing.T) {
-	// Default native-select; ctrl+o toggles to wheel-scroll, then back to native-select.
+	// Default wheel-scroll; ctrl+o toggles to native-select (copy without shift-drag),
+	// then back to wheel-scroll.
 	out, cmd := chatModelForCopy().Update(tea.KeyMsg{Type: tea.KeyCtrlO})
-	if asModel(out).mouseOff || cmd == nil {
-		t.Error("ctrl+o from the default should enable wheel-scroll (mouseOff=false) + a cmd")
+	if !asModel(out).mouseOff || cmd == nil {
+		t.Error("ctrl+o from the default should switch to native-select (mouseOff=true) + DisableMouse")
 	}
 	out2, cmd2 := asModel(out).Update(tea.KeyMsg{Type: tea.KeyCtrlO})
-	if !asModel(out2).mouseOff || cmd2 == nil {
-		t.Error("ctrl+o again should restore native-select (mouseOff=true) + a cmd")
+	if asModel(out2).mouseOff || cmd2 == nil {
+		t.Error("ctrl+o again should restore wheel-scroll (mouseOff=false) + a cmd")
 	}
 }

--- a/internal/tui/scroll_test.go
+++ b/internal/tui/scroll_test.go
@@ -172,18 +172,21 @@ func TestChatArrowScrollsWhenNoHistory(t *testing.T) {
 	}
 }
 
-// TestChatHistoryRecallStillWorks: command-history recall is preserved on ctrl+p with
-// the scrollable transcript in place, and Up scrolls instead of recalling (the wheel
-// arrives as arrow keys, so arrows must never type old messages).
+// TestChatHistoryRecallStillWorks: Up recalls command history while the input owns
+// focus (the wheel scrolls as real mouse events), and ctrl+p stays an alias.
 func TestChatHistoryRecallStillWorks(t *testing.T) {
 	m := tallChat(t, 60)
 	mm := asModel(m)
 	mm.chatHist.add("recall me")
 	m = mm
 	m, _ = m.Update(keyUp())
-	if got := asModel(m).chatIn.Value(); got != "" {
-		t.Fatalf("Up must scroll, not recall; input became %q", got)
+	if got := asModel(m).chatIn.Value(); got != "recall me" {
+		t.Fatalf("Up should recall command history, got %q", got)
 	}
+	mm = asModel(m)
+	mm.chatIn.SetValue("")
+	mm.chatHist.cursor = len(mm.chatHist.entries)
+	m = mm
 	m, _ = m.Update(keyRecallPrev())
 	if got := asModel(m).chatIn.Value(); got != "recall me" {
 		t.Fatalf("ctrl+p should recall command history, got %q", got)
@@ -274,8 +277,8 @@ func TestAgentTypingAndHistoryStillWork(t *testing.T) {
 	mm.agentIn.SetValue("")
 	mm.agentHist.add("earlier prompt")
 	m = mm
-	m, _ = m.Update(keyRecallPrev())
+	m, _ = m.Update(keyUp())
 	if got := asModel(m).agentIn.Value(); got != "earlier prompt" {
-		t.Fatalf("ctrl+p should recall the agent history, got %q", got)
+		t.Fatalf("Up should recall the agent history, got %q", got)
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -677,8 +677,10 @@ type model struct {
 	// lastReply is the RAW (unstyled) text of the most recent station reply, kept so
 	// ctrl+y / `/copy` yank clean text to the clipboard (the transcript holds styled lines).
 	lastReply string
-	// mouseOff: mouse reporting is off (the DEFAULT, keyboard-first like opencode) so the user
-	// can click-drag select+copy ANY text natively; ctrl+o / `/mouse` toggles wheel-scroll on.
+	// mouseOff: mouse reporting state. The DEFAULT is ON (wheel scrolls the transcripts
+	// as real mouse events, so arrow keys are free to mean history in the inputs - the
+	// founder's "up should show history, the wheel should scroll"). ctrl+o / /mouse
+	// toggles OFF for native drag-select + copy (shift+drag also selects while on).
 	mouseOff bool
 	// chatVP is the INDEPENDENT scroll region for the CHANNEL transcript: the
 	// response area scrolls (PgUp/PgDn, Ctrl+U/D, mouse wheel, and the arrow keys
@@ -881,6 +883,13 @@ type model struct {
 	// in agentSlashCandidates(agentTabPrefix) - the carated strip entry.
 	agentTabPrefix string
 	agentTabIdx    int
+	// agentPaneFocus: which AGENT pane owns the keyboard. false = the ask input (the
+	// default: arrows recall history, typing types). true = the TRANSCRIPT (tab from
+	// an empty/non-slash input): arrows + pgup/pgdn/home/end scroll, the seam row
+	// lights up as the focus cue, and esc / enter / any typed rune hand the keyboard
+	// back to the input. The mouse wheel scrolls the transcript in EITHER state
+	// (real wheel events; mouse capture is on by default).
+	agentPaneFocus bool
 	// async, cached update check (non-blocking)
 	updateLine string // "update available v<cur> -> v<new>" or "" (set by updateMsg)
 	// in-TUI provider/account/money flows (TUI-V2-CRITIQUE D / audit C5)
@@ -1222,7 +1231,7 @@ func newBase(broker, user string, limits *LimitStore) model {
 		// mouse capture OFF by default (keyboard-first, like opencode): the terminal owns the
 		// mouse so native drag-select + copy works on ANY text out of the box. ctrl+o / /mouse
 		// opts INTO wheel-scroll. Scrollback is always available via PgUp/PgDn + arrows.
-		mouseOff: true}
+		mouseOff: false}
 }
 
 func (m model) Init() tea.Cmd {
@@ -1808,13 +1817,22 @@ func (m model) onKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.chatVP.HalfPageDown()
 			return m, nil
 		case "up":
-			// Up/Down ALWAYS scroll the transcript (the wheel arrives as arrow keys
-			// while mouse capture is off, and it must never "type" old messages).
-			// Recall lives on ctrl+p / ctrl+n, shell-style - same split as AGENT.
-			m.chatVP.ScrollUp(1)
+			// Shell-style recall first (the wheel scrolls as REAL mouse events now, so
+			// arrows are free to mean history); with nothing to recall, scroll.
+			if v, ok := m.chatHist.prev(m.chatIn.Value()); ok {
+				m.chatIn.SetValue(v)
+				m.chatIn.CursorEnd()
+			} else {
+				m.chatVP.ScrollUp(1)
+			}
 			return m, nil
 		case "down":
-			m.chatVP.ScrollDown(1)
+			if v, ok := m.chatHist.next(); ok {
+				m.chatIn.SetValue(v)
+				m.chatIn.CursorEnd()
+			} else {
+				m.chatVP.ScrollDown(1)
+			}
 			return m, nil
 		case "end":
 			m.chatVP.GotoBottom()
@@ -8968,11 +8986,12 @@ func sendChat(broker, user, mdl, prompt string, confidential bool, maxOut float6
 func RunWithController(broker, user string, limits *LimitStore, notice string, hooks Hooks, ctrl *node.Controller) error {
 	m := NewWithHooksController(broker, user, limits, hooks, ctrl)
 	m.updateLine = notice
-	// Mouse capture is OFF at startup (keyboard-first, like opencode) so the terminal owns the
-	// mouse and native drag-select + copy works on ANY text immediately. The user opts INTO
-	// wheel-scroll with ctrl+o / /mouse (EnableMouseCellMotion); scrollback also works via
-	// PgUp/PgDn + arrows regardless. (m.mouseOff defaults true to match this start state.)
-	return launchTUI(m, tea.WithAltScreen())
+	// Mouse capture is ON at startup: the wheel scrolls the transcripts as REAL mouse
+	// events, which frees the arrow keys to mean history in the inputs (with capture
+	// off, terminals deliver the wheel AS arrow keys and the two are indistinguishable).
+	// Native drag-select still works via shift+drag, and ctrl+o / /mouse toggles capture
+	// off entirely. (m.mouseOff defaults false to match this start state.)
+	return launchTUI(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 }
 
 // runProgram launches a Bubble Tea program and returns its exit error. It is a


### PR DESCRIPTION
Restores arrow-key history in the inputs while keeping wheel scrolling everywhere, by capturing the mouse by default (real wheel events) and adding a tab-toggled transcript focus with a lit seam cue, scroll keys, and type-through back to the ask input. ctrl+o and /mouse still switch to native drag-select. Full suite + vet green; new pane-focus test; mouse-default tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)