### PR TITLE
tui/cli: countable staircase signal meter

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -153,45 +153,45 @@ func signalTower(signal int, tps float64, online bool) string {
 	if !online {
 		return glyphs.Current().SigOff
 	}
-	base := signalLevel(signal)
-	if base == 0 {
-		// No broker signal (legacy offer) - fall back to the tps-derived level so a
+	count := signalLevel(signal)
+	if count == 0 {
+		// No broker signal (legacy offer) - fall back to the tps-derived count so a
 		// node that DOES report throughput still meters.
-		base = tpsLevel(tps)
+		count = tpsLevel(tps)
 	}
-	if base == 0 {
+	if count == 0 {
 		// Online with neither a broker signal nor measured tps: show one bar, never a
-		// fully blank tower (online always reads as at least faint carrier).
-		base = 1
+		// fully blank meter (online always reads as at least faint carrier).
+		count = 1
 	}
+	// The staircase meter, lock-step with the TUI's stairHeights: lit bars ascend
+	// ▃▄▅▇█, unlit cells show the ▁ rail, and the COUNT of lit bars is the signal.
+	stairs := [5]int{2, 3, 4, 6, 7}
 	ramp := glyphs.Current().Signal
 	var b strings.Builder
 	for i := 0; i < 5; i++ {
-		lvl := base - (i % 2)
-		if lvl < 0 {
-			lvl = 0
+		if i >= count {
+			b.WriteRune(ramp[0])
+			continue
 		}
-		if lvl >= len(ramp) {
-			lvl = len(ramp) - 1
-		}
-		b.WriteRune(ramp[lvl])
+		b.WriteRune(ramp[stairs[i]])
 	}
 	return b.String()
 }
 
-// signalLevel maps the broker's 0..100 signal onto the 0..7 glyph ramp (▁..█). An
-// online node's baseline signal (~43 with no traffic) lands mid-tower; 100 pins
-// the top. 0 means "no broker signal" (the caller then falls back to tps).
+// signalLevel maps the broker's 0..100 signal onto the staircase's LIT-BAR COUNT
+// (0..5): ceil(signal/20). An online node's baseline (~43) lands mid-meter at 3
+// bars; 100 pins the full 5. 0 means "no broker signal" (the caller then falls
+// back to tps). Lock-step with the TUI's signalLevel.
 func signalLevel(signal int) int {
 	if signal <= 0 {
 		return 0
 	}
-	// 1..100 -> 1..7 (never 0 for a positive signal, so an online node always meters).
-	lvl := 1 + (signal*6+99)/100 // ceil((signal/100)*6), then +1 base; ~43 -> 4
-	if lvl > 7 {
-		lvl = 7
+	n := (signal*5 + 99) / 100 // ceil(signal/20)
+	if n > 5 {
+		n = 5
 	}
-	return lvl
+	return n
 }
 
 // tpsLevel is the legacy tok/s -> level mapping, kept as the fallback meter when an
@@ -199,14 +199,12 @@ func signalLevel(signal int) int {
 func tpsLevel(tps float64) int {
 	switch {
 	case tps >= 600:
-		return 6
-	case tps >= 300:
 		return 5
-	case tps >= 150:
+	case tps >= 300:
 		return 4
-	case tps >= 60:
+	case tps >= 150:
 		return 3
-	case tps >= 20:
+	case tps >= 60:
 		return 2
 	case tps > 0:
 		return 1

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -249,22 +249,22 @@ func TestSignalTowerUsesBrokerSignal(t *testing.T) {
 	}
 }
 
-// TestSignalLevelMapping checks the 0..100 -> 0..7 ramp: 0 yields the "no signal"
-// sentinel (0), any positive signal is >= 1 (online never fully blank), ~43 lands
-// mid-tower, and 100 pins the top of the 8-glyph ramp.
+// TestSignalLevelMapping checks the 0..100 -> lit-bar COUNT (0..5): 0 yields the "no
+// signal" sentinel (0), any positive signal is >= 1 bar (online never fully blank),
+// ~43 lands mid-meter at 3 bars, and 100 lights the full staircase. Lock-step with
+// the TUI's mapping.
 func TestSignalLevelMapping(t *testing.T) {
 	if signalLevel(0) != 0 {
 		t.Errorf("signalLevel(0) = %d want 0 (no signal sentinel)", signalLevel(0))
 	}
-	if l := signalLevel(1); l < 1 {
-		t.Errorf("signalLevel(1) = %d want >= 1 (online never blank)", l)
+	if l := signalLevel(1); l != 1 {
+		t.Errorf("signalLevel(1) = %d want 1 (online never blank)", l)
 	}
-	if l := signalLevel(43); l < 3 || l > 5 {
-		t.Errorf("signalLevel(43) = %d want mid-tower (~4)", l)
+	if l := signalLevel(43); l != 3 {
+		t.Errorf("signalLevel(43) = %d want 3 (mid-meter)", l)
 	}
-	top := len(glyphs.Current().Signal) - 1 // 7 for the ▁..█ ramp
-	if l := signalLevel(100); l != top {
-		t.Errorf("signalLevel(100) = %d want %d (top of ramp)", l, top)
+	if l := signalLevel(100); l != 5 {
+		t.Errorf("signalLevel(100) = %d want 5 (full staircase)", l)
 	}
 	// Monotonic: stronger signal never reads shorter.
 	if signalLevel(20) > signalLevel(80) {

--- a/internal/client/helpers_cov_test.go
+++ b/internal/client/helpers_cov_test.go
@@ -126,9 +126,10 @@ func TestBrokerErrorBranches(t *testing.T) {
 	}
 }
 
-// TestTpsLevel covers the throughput->signal-bar mapping across every band boundary.
+// TestTpsLevel covers the throughput -> lit-bar-count mapping across every band
+// boundary of the 5-bar staircase meter.
 func TestTpsLevel(t *testing.T) {
-	cases := map[float64]int{0: 0, 10: 1, 30: 2, 100: 3, 200: 4, 400: 5, 700: 6}
+	cases := map[float64]int{0: 0, 10: 1, 30: 1, 100: 2, 200: 3, 400: 4, 700: 5}
 	for tps, want := range cases {
 		if got := tpsLevel(tps); got != want {
 			t.Errorf("tpsLevel(%v) = %d, want %d", tps, got, want)

--- a/internal/tui/signal_band_test.go
+++ b/internal/tui/signal_band_test.go
@@ -32,22 +32,28 @@ func TestBandSignalMeterUsesBrokerSignal(t *testing.T) {
 	}
 }
 
-// TestBandSignalLevelMapping checks the TUI's 0..100 -> 0..7 ramp matches the CLI's:
-// 0 is the no-signal sentinel, positive is always >= 1, ~43 lands mid-tower, 100 pins
-// the top of the 8-glyph ramp.
+// TestBandSignalLevelMapping checks the TUI's 0..100 -> lit-bar COUNT (0..5) matches
+// the CLI's: 0 is the no-signal sentinel, positive is always >= 1 bar, ~43 lands
+// mid-meter at 3 bars, 100 lights the full staircase.
 func TestBandSignalLevelMapping(t *testing.T) {
 	if signalLevel(0) != 0 {
 		t.Errorf("signalLevel(0) = %d want 0", signalLevel(0))
 	}
-	if signalLevel(1) < 1 {
-		t.Errorf("signalLevel(1) = %d want >= 1 (online never blank)", signalLevel(1))
+	if signalLevel(1) != 1 {
+		t.Errorf("signalLevel(1) = %d want 1 (online never blank)", signalLevel(1))
 	}
-	if l := signalLevel(43); l < 3 || l > 5 {
-		t.Errorf("signalLevel(43) = %d want mid-tower (~4)", l)
+	if l := signalLevel(43); l != 3 {
+		t.Errorf("signalLevel(43) = %d want 3 (mid-meter)", l)
 	}
-	top := len(signalRamp()) - 1
-	if l := signalLevel(100); l != top {
-		t.Errorf("signalLevel(100) = %d want %d (top of ramp)", l, top)
+	if l := signalLevel(100); l != 5 {
+		t.Errorf("signalLevel(100) = %d want 5 (full staircase)", l)
+	}
+	// The 20-point steps: each threshold adds exactly one bar.
+	for i, sig := range []int{20, 21, 40, 41, 60, 61, 80, 81} {
+		want := []int{1, 2, 2, 3, 3, 4, 4, 5}[i]
+		if l := signalLevel(sig); l != want {
+			t.Errorf("signalLevel(%d) = %d want %d", sig, l, want)
+		}
 	}
 }
 

--- a/internal/tui/signal_staircase_test.go
+++ b/internal/tui/signal_staircase_test.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"testing"
+)
+
+// TestSignalStaircaseShapes locks the beauty-director spec: the meter is a cellphone
+// staircase (lit ascending bars over a visible rail), the count of lit bars IS the
+// signal, and the reduced-motion frozen frame (anim pins frame=1, where scanOffset
+// is 0) renders the pure staircase at any activity level.
+func TestSignalStaircaseShapes(t *testing.T) {
+	cases := map[int]string{ // broker signal -> frozen render
+		0:   "▃▁▁▁▁", // online floor: never blank
+		20:  "▃▁▁▁▁",
+		40:  "▃▄▁▁▁",
+		60:  "▃▄▅▁▁",
+		80:  "▃▄▅▇▁",
+		100: "▃▄▅▇█",
+	}
+	for sig, want := range cases {
+		for _, amp := range []int{0, 1, 2} { // frozen frame is identical at every amp
+			got := signalTowerAt(1, maxInt(signalLevel(sig), 1), amp)
+			if got != want {
+				t.Errorf("signal %d amp %d frozen = %q, want %q", sig, amp, got, want)
+			}
+		}
+	}
+	// Offline stays the flat rail.
+	if got := signalBarsRaw(1, 50, 100, false, 1, 1); got != signalFlat() {
+		t.Errorf("offline = %q, want %q", got, signalFlat())
+	}
+	// Stations boost adds bars on the count, capped at the full meter.
+	if got := signalBarsRaw(1, 50, 0, true, 0, 3); got != "▃▄▅▇█" {
+		t.Errorf("signal 50 + 3 stations = %q, want the full staircase", got)
+	}
+	// Motion moves ONLY the top of the staircase: at any frame/amp, all bars below
+	// the top (and the rail) match the frozen render, so the count never wavers.
+	for frame := 0; frame < 8; frame++ {
+		for _, amp := range []int{1, 2} {
+			got := []rune(signalTowerAt(frame, 3, amp))
+			if got[0] != '▃' || got[3] != '▁' || got[4] != '▁' {
+				t.Errorf("frame %d amp %d: base/rail moved: %q", frame, amp, string(got))
+			}
+			if got[2] == '▁' {
+				t.Errorf("frame %d amp %d: the top bar collapsed into the rail: %q", frame, amp, string(got))
+			}
+		}
+	}
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -293,7 +293,7 @@ var (
 //	glyphLineage ✓ signed-lineage / GitHub-verified-operator glint - the IDENTITY mark
 //	               on every co-signed channel + on login. Distinct from ◆: lineage
 //	               receipts are on ALL channels; ◆ is only the confidential tier.
-//	signalGlyphs ▁▂▃▄▅▆▇█  the signal-strength tower
+//	signalGlyphs ▃▄▅▇█ over a ▁ rail  the signal staircase (lit bars = strength)
 //
 // These degrade to plain runes under NO_COLOR (lipgloss strips the color, the
 // glyph itself is still a recognizable Unicode mark) and stay fixed-width. They are
@@ -5781,7 +5781,7 @@ func (m model) browseView(w int) string {
 		case loading:
 			return "\n  " + m.transmitLineFor(0) + "\n  " + stDim.Render("scanning the band…") + "\n"
 		default:
-			shimmer := tintSignal(signalBarsRaw(m.frame, 0, 0, true, 0, 0), 0, 0, true)
+			shimmer := tintSignal(signalBarsRaw(m.frame, 55, 0, true, 0, 0), 55, 0, true)
 			if m.narrow() {
 				// Slim: stack the shimmer above the trimmed CTA so neither overflows the
 				// real width (the empty-band line is not width-clamped).
@@ -8624,20 +8624,21 @@ func indentBlock(s, pad string) string {
 // legacy Windows console. signalPeak indexes into either ramp identically.
 func signalRamp() []rune { return glyphs.Current().Signal }
 
-// signalLevel maps the broker's 0..100 signal onto the 0..7 glyph-ramp level (▁..█).
-// A positive signal always returns >= 1, so an online node never reads fully blank;
-// ~43 (an on-air node with no traffic) lands mid-tower; 100 pins the top. 0 means
-// "no broker signal carried" so the caller can fall back to the tps-derived level.
-// Kept in lock-step with client.signalLevel (the plain-CLI tower) so both agree.
+// signalLevel maps the broker's 0..100 signal onto the LIT-BAR COUNT (0..5) of the
+// staircase meter: ceil(signal/20), so 1-20 -> 1 bar, 41-60 -> 3 bars (the ~43
+// baseline lands mid-meter), 81-100 -> the full 5. A positive signal always returns
+// >= 1 so an online node never reads blank. 0 means "no broker signal carried" so
+// the caller can fall back to the tps-derived count. Kept in lock-step with
+// client.signalLevel (the plain-CLI meter) so both agree.
 func signalLevel(signal int) int {
 	if signal <= 0 {
 		return 0
 	}
-	lvl := 1 + (signal*6+99)/100 // ceil((signal/100)*6) + 1 base; ~43 -> 4
-	if lvl > 7 {
-		lvl = 7
+	n := (signal*5 + 99) / 100 // ceil(signal/20)
+	if n > 5 {
+		n = 5
 	}
-	return lvl
+	return n
 }
 
 // signalFlat is the 5-cell "no signal" tower (offline / unmeasured) for the resolved
@@ -8655,14 +8656,12 @@ func signalBarsRaw(frame, signal int, tps float64, online bool, inFlight, statio
 	if base == 0 {
 		switch {
 		case tps >= 600:
-			base = 6
-		case tps >= 300:
 			base = 5
-		case tps >= 150:
+		case tps >= 300:
 			base = 4
-		case tps >= 60:
+		case tps >= 150:
 			base = 3
-		case tps >= 20:
+		case tps >= 60:
 			base = 2
 		case tps > 0:
 			base = 1
@@ -8670,18 +8669,21 @@ func signalBarsRaw(frame, signal int, tps float64, online bool, inFlight, statio
 	}
 	if base == 0 {
 		// Online with neither a broker signal nor measured tps: one faint bar, never
-		// a fully blank tower (online always reads as at least a carrier).
+		// a fully blank meter (online always reads as at least a carrier).
 		base = 1
 	}
-	// More stations on the band -> a stronger carrier: +1 notch per extra station
-	// beyond the first, capped at +2 so a single fast node and a crowded band stay
-	// distinguishable without pinning everything to the top.
+	// More stations on the band -> a stronger carrier: +1 bar per extra station
+	// beyond the first, capped at +2 (and at the meter's 5), so a single fast node
+	// and a crowded band stay distinguishable without pinning everything full.
 	if stations > 1 {
 		boost := stations - 1
 		if boost > 2 {
 			boost = 2
 		}
 		base += boost
+	}
+	if base > 5 {
+		base = 5
 	}
 	// ACTIVITY -> animation amplitude. amp is how far the scanning wave swings around the
 	// measured level: 0 = idle (a STEADY tower, no shimmer), 1..2 = actively serving
@@ -8693,22 +8695,41 @@ func signalBarsRaw(frame, signal int, tps float64, online bool, inFlight, statio
 	return signalTowerAt(anim(frame), base, amp)
 }
 
-// signalTowerAt renders the 5-cell tower at an ALREADY-RESOLVED frame (the caller has
-// applied any reduced-motion freeze via anim()/sigFrame). It is the pure render: level
-// = base, motion = a scanning wave of amplitude amp (amp==0 -> a dead-steady tower).
-// Split out so the animation is testable independent of the process-wide quiet freeze.
-func signalTowerAt(frame, base, amp int) string {
+// stairHeights are the glyph-ramp indices of the staircase meter's lit bars, low to
+// high: ▃▄▅▇█ on the Unicode ramp. The count of LIT bars is the signal (cellphone
+// style - instantly countable); an unlit cell renders the index-0 rail (▁) so every
+// slot stays visible. The top two stairs sit at/above signalPeak, so the existing red
+// glint lands only on a strong 4-5 bar carrier.
+var stairHeights = [5]int{2, 3, 4, 6, 7}
+
+// signalTowerAt renders the 5-cell staircase at an ALREADY-RESOLVED frame (the caller
+// has applied any reduced-motion freeze via anim()/sigFrame). count (0..5) is how many
+// bars are lit; motion = real activity, and it moves ONLY the top of the staircase so
+// the lit-bar COUNT never wavers: at amp 1 the top bar breathes one ramp step, at amp
+// 2 it swings both ways and the bar below ripples with it. The frozen frame (anim()
+// pins frame=1, where scanOffset returns 0) is exactly the pure staircase.
+func signalTowerAt(frame, count, amp int) string {
 	set := signalRamp()
+	if count > 5 {
+		count = 5
+	}
 	var sb strings.Builder
 	for i := 0; i < 5; i++ {
-		// A wave travels across the 5 cells (phase = frame+i); its swing is scaled by amp
-		// = real activity. Idle (amp==0) -> offset is always 0 -> every cell sits at the
-		// flat measured level (a STEADY tower). The wave only adds motion AROUND base
-		// within [-amp,+amp]; it never lifts the resting height, so the bar still reads
-		// the true signal even at peak swing.
-		lvl := base + scanOffset(frame+i, amp)
-		if lvl < 0 {
-			lvl = 0
+		if i >= count {
+			sb.WriteRune(set[0]) // the unlit rail: visible, clearly empty
+			continue
+		}
+		lvl := stairHeights[i]
+		switch {
+		case i == count-1:
+			lvl += scanOffset(frame, amp)
+		case amp >= 2 && i == count-2:
+			lvl += scanOffset(frame, 1)
+		}
+		// Clamp the swing: never down to the rail (the count stays honest) and never
+		// past the ramp top.
+		if lvl < 1 {
+			lvl = 1
 		}
 		if lvl >= len(set) {
 			lvl = len(set) - 1
@@ -8786,9 +8807,11 @@ func tintSignal(raw string, signal int, tps float64, online bool) string {
 		switch {
 		case lvl < 0: // a space / non-bar rune (alignment padding) - leave bare
 			b.WriteRune(r)
-		case lvl >= signalPeak: // peaking - the one red glint
+		case lvl == 0: // the unlit rail - visibly empty, never inked
+			b.WriteString(stDim.Render(string(r)))
+		case lvl >= signalPeak: // peaking - the one red glint (the 4th/5th stair)
 			b.WriteString(stRed.Render(string(r)))
-		default: // body of the tower - mono ink
+		default: // lit bars - mono ink
 			b.WriteString(stLive.Render(string(r)))
 		}
 	}


### PR DESCRIPTION
Replaces the flat same-height signal stripe with a cellphone-style staircase (lit ascending bars over a rail; count = strength), per the beauty-director spec: ceil(signal/20) mapping, honest top-only animation, red glint only at 4-5 bars, ASCII + NO_COLOR safe, TUI + plain CLI lock-step. Verified live in tmux against the real band browser. Full suite + vet green; spec test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)