### PR TITLE
agent: /perms permission modes (confirm | edits | all)

### DIFF
--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -73,6 +73,69 @@ type agentRuntime struct {
 	callStart  time.Time // zero between model calls
 	callSoft   time.Time // when the past-cap prompt appears; +PerCallCap per tab
 	callExtend func(time.Duration)
+	// perms is the tool-approval mode (agentPermMode) - written on the UI goroutine
+	// (/perms), read on the loop goroutine (the confirmer), hence atomic.
+	perms atomic.Int32
+}
+
+// agentPermMode is the AGENT's tool-approval level - the Claude-Code-style permission
+// modes (the founder's "setting to bypass permissions"). Session-only: it always
+// resets to permConfirm on a fresh TUI (or via ROGERAI_AGENT_PERMS), and anything
+// permissive is named in the masthead so a bypass is never invisible.
+type agentPermMode int32
+
+const (
+	permConfirm agentPermMode = iota // every mutating tool asks y/N (the default)
+	permEdits                        // write_file auto-approves; run_shell still asks
+	permAll                          // every mutating tool auto-approves (the bypass)
+)
+
+func (p agentPermMode) String() string {
+	switch p {
+	case permEdits:
+		return "auto-edits"
+	case permAll:
+		return "auto-all"
+	}
+	return "confirm"
+}
+
+// permAllows reports whether mode p auto-approves the named mutating tool (read-only
+// tools never reach the confirmer at all).
+func permAllows(p agentPermMode, tool string) bool {
+	switch p {
+	case permAll:
+		return true
+	case permEdits:
+		return tool == "write_file"
+	}
+	return false
+}
+
+// parsePermMode accepts the /perms spellings (and the env default): confirm/ask,
+// edits/auto-edits, all/auto-all/yolo/bypass.
+func parsePermMode(s string) (agentPermMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "confirm", "ask", "default":
+		return permConfirm, true
+	case "edits", "auto-edits", "edit":
+		return permEdits, true
+	case "all", "auto-all", "yolo", "bypass":
+		return permAll, true
+	}
+	return permConfirm, false
+}
+
+// permsHelp is the one-line "what runs without asking" summary for the mode - shared
+// by /perms notes and the idle help tail so the two never drift.
+func permsHelp(p agentPermMode) string {
+	switch p {
+	case permEdits:
+		return "read/list + write auto · run_shell confirms"
+	case permAll:
+		return "ALL tools auto-run - nothing asks (/perms confirm restores the gate)"
+	}
+	return "read/list auto · write/run confirm"
 }
 
 // agentCapGrace is how long past the soft cap a model call keeps running while the
@@ -401,12 +464,23 @@ func (m model) newAgentRuntime() *agentRuntime {
 		return harness.BrokerCompleter(m.broker, m.user, rt.model, m.confidentialOnly, maxOut, costFn)(cctx, messages, tools)
 	}
 	confirmer := func(tool string, args map[string]any) bool {
+		// Permission modes: a permissive session auto-approves here (the masthead
+		// names the mode, so this is never silent). The operator money plate is a
+		// DIFFERENT flow and never passes through this gate.
+		if permAllows(agentPermMode(rt.perms.Load()), tool) {
+			return true
+		}
 		c := agentConfirm{tool: tool, args: args, resp: make(chan bool, 1)}
 		rt.confirmReq <- c // surfaced to the UI as agentConfirmMsg
 		return <-c.resp    // blocks until the user answers y/N
 	}
 	persona := harness.LoadPersona(harness.PersonaPath())
 	rt.loop = harness.NewLoop(agentRoot(), persona, completer, confirmer)
+	// Startup default for the approval mode: ROGERAI_AGENT_PERMS=confirm|edits|all
+	// (unset/invalid = confirm). Session-only from there; /perms toggles live.
+	if mode, ok := parsePermMode(os.Getenv("ROGERAI_AGENT_PERMS")); ok {
+		rt.perms.Store(int32(mode))
+	}
 	return rt
 }
 
@@ -967,7 +1041,7 @@ func (m model) dequeueAgentPrompts() (model, tea.Cmd) {
 // TestAgentCommandRegistrySeam: every entry must dispatch, never "unknown:").
 // Sorted; slash-prefixed canonical names only - short aliases (/dj /y /rc /h) stay
 // typable but are not suggested.
-var agentCommands = []string{"/clear", "/commands", "/copy", "/help", "/model", "/operator", "/persona", "/remote-control"}
+var agentCommands = []string{"/clear", "/commands", "/copy", "/help", "/model", "/operator", "/perms", "/persona", "/remote-control"}
 
 // agentSlashCandidates returns the agentCommands entries the input's command word
 // prefix-matches (case-insensitive, PREFIX-only), in registry (sorted) order - the
@@ -1047,6 +1121,33 @@ func (m model) runAgentCommand(line string) (tea.Model, tea.Cmd) {
 		// A cleared session IS the landing again: its one note is the new entry chrome,
 		// so THE DESK roster returns (desk_view: "/clear returns the landing").
 		m.agentLandingLines = len(m.agentLines)
+		return m, nil
+	case "perms", "permissions", "yolo":
+		if m.agent == nil {
+			return m, nil
+		}
+		cur := agentPermMode(m.agent.perms.Load())
+		next := cur
+		switch {
+		case cmd == "yolo":
+			next = permAll
+		case len(fields) >= 2:
+			mode, ok := parsePermMode(fields[1])
+			if !ok {
+				note("usage: /perms confirm | edits | all   (bare /perms cycles)")
+				return m, nil
+			}
+			next = mode
+		default:
+			next = (cur + 1) % 3 // bare /perms cycles confirm -> edits -> all -> confirm
+		}
+		m.agent.perms.Store(int32(next))
+		if next == permAll {
+			// The bypass is loud on purpose: an ember line, not a dim note.
+			m.agentLines = append(m.agentLines, stEmber.Render("! tools "+next.String()+" - "+permsHelp(next)))
+		} else {
+			note("tools " + next.String() + " - " + permsHelp(next))
+		}
 		return m, nil
 	case "persona", "dj":
 		note("persona: " + harness.PersonaPath() + " (editable - keeps getting updated)")
@@ -1473,14 +1574,14 @@ func (m model) agentView(w int) string {
 	if m.compact {
 		// The windowshade folds the desk strip to a bare count (§3f) - "" with zero
 		// guests, so the zero-guest compact heading stays byte-identical.
-		head := "  " + stSelBar.Render("▌") + " " + stBrand.Render("AGENT") + stDim.Render(" · tools") +
+		head := "  " + stSelBar.Render("▌") + " " + stBrand.Render("AGENT") + stDim.Render(" · tools") + m.agentPermTag() +
 			stDim.Render(" ") + mdlCell + stDim.Render(" · ") + stEmber.Render(dollars(m.agentCost)) + m.deskCompactCount()
 		b.WriteString(truncVisible(head, w) + "\n")
 	} else {
 		if mdl != "" && !m.narrow() {
 			mdlCell += stDim.Render(" · ") + stKey.Render("/model") + stDim.Render(" to switch")
 		}
-		head := "  " + stSelBar.Render("▌") + " " + stBrand.Render("AGENT") + stDim.Render(" · tools") +
+		head := "  " + stSelBar.Render("▌") + " " + stBrand.Render("AGENT") + stDim.Render(" · tools") + m.agentPermTag() +
 			stDim.Render("  ") + mdlCell + stDim.Render(" · files ") + stKey.Render(shortPath(root)) +
 			stDim.Render("   cost ") + stEmber.Render(dollars(m.agentCost))
 		b.WriteString(truncVisible(head, w) + "\n")
@@ -1631,7 +1732,11 @@ func (m model) agentView(w int) string {
 	if !m.compact {
 		// Busy-aware help: while a turn streams, the one thing the user needs is how to
 		// STOP it (esc), so lead with that instead of the idle command list.
-		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  tab focuses the transcript  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  read/list auto · write/run confirm"
+		permTail := permsHelp(permConfirm)
+		if m.agent != nil {
+			permTail = permsHelp(agentPermMode(m.agent.perms.Load()))
+		}
+		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  tab focuses the transcript  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  " + permTail
 		switch {
 		case m.agentBusy && m.narrow():
 			help = "type queues · esc cancels (2× force)"
@@ -1643,6 +1748,22 @@ func (m model) agentView(w int) string {
 		b.WriteString(truncVisible("  "+stDim.Render(help), w) + "\n")
 	}
 	return b.String()
+}
+
+// agentPermTag is the masthead's approval-mode chip: empty at the confirm default
+// (the masthead stays byte-identical), a quiet key chip for auto-edits, an EMBER one
+// for the full bypass - a permissive session must be visible at a glance.
+func (m model) agentPermTag() string {
+	if m.agent == nil {
+		return ""
+	}
+	switch agentPermMode(m.agent.perms.Load()) {
+	case permEdits:
+		return stDim.Render(" · ") + stKey.Render("auto-edits")
+	case permAll:
+		return stDim.Render(" · ") + stEmber.Render("AUTO-ALL")
+	}
+	return ""
 }
 
 // agentAskLines echoes one sent ask. From the second ask on, a dim time-stamped rule

--- a/internal/tui/agent_perms_test.go
+++ b/internal/tui/agent_perms_test.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPermModeMachinery locks the approval-mode table: what each mode auto-approves,
+// the accepted /perms spellings, and the shared help copy.
+func TestPermModeMachinery(t *testing.T) {
+	if permAllows(permConfirm, "write_file") || permAllows(permConfirm, "run_shell") {
+		t.Error("confirm must auto-approve nothing")
+	}
+	if !permAllows(permEdits, "write_file") || permAllows(permEdits, "run_shell") {
+		t.Error("edits must auto-approve write_file only")
+	}
+	if !permAllows(permAll, "write_file") || !permAllows(permAll, "run_shell") {
+		t.Error("all must auto-approve everything")
+	}
+	for in, want := range map[string]agentPermMode{
+		"confirm": permConfirm, "ask": permConfirm,
+		"edits": permEdits, "auto-edits": permEdits,
+		"all": permAll, "yolo": permAll, "bypass": permAll,
+	} {
+		if got, ok := parsePermMode(in); !ok || got != want {
+			t.Errorf("parsePermMode(%q) = %v,%v want %v,true", in, got, ok, want)
+		}
+	}
+	if _, ok := parsePermMode("nope"); ok {
+		t.Error("parsePermMode should reject junk")
+	}
+}
+
+// TestPermsCommandCycles: bare /perms cycles confirm -> edits -> all -> confirm, the
+// explicit form sets, /yolo jumps to all, and the masthead chip appears only when
+// permissive (ember at the full bypass).
+func TestPermsCommandCycles(t *testing.T) {
+	base := browseSeed(120)
+	base.connected = &offer{NodeID: "n", Model: "gpt-oss-20b", Online: true}
+	nm, _ := base.enterAgent()
+	m := asModel(nm)
+	if got := agentPermMode(m.agent.perms.Load()); got != permConfirm {
+		t.Fatalf("default mode = %v want confirm", got)
+	}
+	if m.agentPermTag() != "" {
+		t.Error("confirm default must add NO masthead chip")
+	}
+
+	step := func(cmdline string, want agentPermMode) {
+		t.Helper()
+		out, _ := m.runAgentCommand(cmdline)
+		m = asModel(out)
+		if got := agentPermMode(m.agent.perms.Load()); got != want {
+			t.Fatalf("%s -> %v want %v", cmdline, got, want)
+		}
+	}
+	step("/perms", permEdits)
+	if !strings.Contains(stripANSI(m.agentPermTag()), "auto-edits") {
+		t.Error("edits mode should chip the masthead")
+	}
+	step("/perms", permAll)
+	if !strings.Contains(stripANSI(m.agentPermTag()), "AUTO-ALL") {
+		t.Error("all mode should chip the masthead loudly")
+	}
+	step("/perms", permConfirm)
+	step("/perms all", permAll)
+	step("/perms confirm", permConfirm)
+	step("/yolo", permAll)
+	// The bypass line is loud (ember, bang) in the transcript.
+	joined := stripANSI(strings.Join(m.agentLines, "\n"))
+	if !strings.Contains(joined, "! tools auto-all") {
+		t.Errorf("bypass should print the loud line, got:\n%s", joined)
+	}
+	// The idle help tail follows the mode.
+	m.agentBusy = false
+	if v := stripANSI(m.agentView(120)); !strings.Contains(v, "ALL tools auto-run") {
+		t.Error("idle help should carry the auto-all warning tail")
+	}
+}

--- a/internal/tui/agent_slash_complete_test.go
+++ b/internal/tui/agent_slash_complete_test.go
@@ -66,7 +66,7 @@ func lineAbovePrompt(t *testing.T, tm tea.Model) string {
 }
 
 // allCommandsStrip is the full sorted registry as the strip renders it on a bare "/".
-const allCommandsStrip = "/clear · /commands · /copy · /help · /model · /operator · /persona · /remote-control"
+const allCommandsStrip = "/clear · /commands · /copy · /help · /model · /operator · /perms · /persona · /remote-control"
 
 // TestAgentSlashStripMatrix drives the strip with real typed keys: which commands it
 // suggests for what input, and when it hides. Matching is case-insensitive and
@@ -78,9 +78,9 @@ func TestAgentSlashStripMatrix(t *testing.T) {
 		want  string // "" = NO strip (the blank separator above the prompt)
 	}{
 		{"bare slash lists ALL commands sorted", "/", allCommandsStrip},
-		{"slash-p narrows to persona", "/p", "/persona"},
+		{"slash-p lists both p-commands", "/p", "/perms · /persona"},
 		{"slash-c narrows to clear commands copy", "/c", "/clear · /commands · /copy"},
-		{"case-insensitive capital P", "/P", "/persona"},
+		{"case-insensitive capital P", "/P", "/perms · /persona"},
 		{"case-insensitive capital CL", "/CL", "/clear"},
 		{"no matches hides the strip", "/zz", ""},
 		{"leading text is not a slash command", "hello /p", ""},
@@ -88,7 +88,7 @@ func TestAgentSlashStripMatrix(t *testing.T) {
 		{"args after the word stay strip-free", "/model up", ""},
 		{"empty input has no strip", "", ""},
 		{"complete word without a space still shows", "/remote-control", "/remote-control"},
-		{"leading spaces match enter's trim", " /p", "/persona"},
+		{"leading spaces match enter's trim", " /p", "/perms · /persona"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -104,10 +104,10 @@ func TestAgentSlashStripMatrix(t *testing.T) {
 // a trailing space (ready for args / enter) and the strip hides; a second Tab is a
 // no-op (the word is complete and spaced - nothing to complete, nothing inserted).
 func TestAgentSlashTabUnique(t *testing.T) {
-	tm := typeRunes(agentReady(t), "/p")
+	tm := typeRunes(agentReady(t), "/pers")
 	tm = pressTab(tm)
 	if got := asModel(tm).agentIn.Value(); got != "/persona " {
-		t.Fatalf("Tab on the unique match /p should fill %q, got %q", "/persona ", got)
+		t.Fatalf("Tab on the unique match /pers should fill %q, got %q", "/persona ", got)
 	}
 	if got := lineAbovePrompt(t, tm); got != "" {
 		t.Fatalf("strip should hide after a completed word + space, still shows %q", got)


### PR DESCRIPTION
Claude-Code-style approval levels for the AGENT's mutating tools, session-only, with a loud masthead chip + help tail when permissive, /yolo shortcut, and ROGERAI_AGENT_PERMS startup default. Money-plate flow untouched. Full suite + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)