### PR TITLE
agent: /model pick survives turns on the already-open channel

### DIFF
--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -366,10 +366,18 @@ func (m *model) refreshAgentModel() {
 	if m.agent == nil {
 		return
 	}
-	// A model chosen explicitly in this session (via /model) stays put unless a fresh
-	// channel is opened on top of it - the user's pick wins over auto-resolution.
-	if m.agentPicked && m.connected == nil {
-		return
+	// A model chosen explicitly via /model stays put: over turns, over re-entries, and
+	// over the channel that was ALREADY open at pick time (the old guard only held with
+	// no channel open, so picking deepseek while tuned to Qwen snapped back on the very
+	// next ask). Only tuning a DIFFERENT channel afterwards re-points the agent - that
+	// is a deliberate act (and the auto-tune path clears the pick itself).
+	if m.agentPicked {
+		cur := m.agentChannelIdent()
+		if cur == "" || cur == m.agentPickedOver {
+			return // no channel, or the same one as at pick time: the pick wins
+		}
+		m.agentPicked = false // a fresh channel was opened on top: follow it below
+		m.agentPickedOver = ""
 	}
 	want := m.resolveAgentModel()
 	if want == m.agent.model {
@@ -385,6 +393,16 @@ func (m *model) refreshAgentModel() {
 		// if the user sends a turn anyway, still surfaces once via the deduped failureHint.
 		m.status = agentNoModelStatus()
 	}
+}
+
+// agentChannelIdent is the open channel's identity for the /model pin: node + model,
+// "" when nothing is tuned in. Two different stations serving the same model count as
+// different channels (a re-tune is a deliberate act either way).
+func (m model) agentChannelIdent() string {
+	if m.connected == nil {
+		return ""
+	}
+	return m.connected.NodeID + "·" + m.connected.Model
 }
 
 // agentNoModelStatus is the status line shown when the AGENT has no model tuned in - the
@@ -410,6 +428,7 @@ func (m *model) pickAgentModel(mdl string) {
 		return
 	}
 	m.agentPicked = true
+	m.agentPickedOver = m.agentChannelIdent() // the pick survives turns on THIS channel
 	if mdl == m.agent.model {
 		m.agentLines = append(m.agentLines, stDim.Render("· ")+stDim.Render("already running on ")+stKey.Render(mdl))
 		return

--- a/internal/tui/agent_model_pin_test.go
+++ b/internal/tui/agent_model_pin_test.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestModelPickSurvivesTurnsOnOpenChannel is the founder's exact bug: tuned to one
+// band, /model picks another, and the NEXT ask must run on the pick - not snap back
+// to the open channel. Only tuning a DIFFERENT channel re-points the agent.
+func TestModelPickSurvivesTurnsOnOpenChannel(t *testing.T) {
+	base := browseSeed(120)
+	base.connected = &offer{NodeID: "qwen-node", Model: "Qwen3.6-27B", Online: true}
+	nm, _ := base.enterAgent()
+	m := asModel(nm)
+	if m.agent.model != "Qwen3.6-27B" {
+		t.Fatalf("agent should start on the open channel, got %q", m.agent.model)
+	}
+
+	// Pick deepseek while the Qwen channel is still open.
+	m.pickAgentModel("deepseek-v4-flash")
+	if m.agent.model != "deepseek-v4-flash" || !m.agentPicked {
+		t.Fatalf("pick did not take: model=%q picked=%v", m.agent.model, m.agentPicked)
+	}
+
+	// The next turn re-resolves (refreshAgentModel) - the pick must hold.
+	m.refreshAgentModel()
+	if m.agent.model != "deepseek-v4-flash" {
+		t.Fatalf("refresh snapped the pick back to %q (the founder's bug)", m.agent.model)
+	}
+	joined := stripANSI(strings.Join(m.agentLines, "\n"))
+	if strings.Contains(joined, "now runs on Qwen3.6-27B") {
+		t.Errorf("no snap-back note should print:\n%s", joined)
+	}
+
+	// Disconnecting does not lose the pick either.
+	m.connected = nil
+	m.refreshAgentModel()
+	if m.agent.model != "deepseek-v4-flash" {
+		t.Fatalf("pick lost on disconnect, model=%q", m.agent.model)
+	}
+
+	// Tuning a DIFFERENT channel afterwards IS a deliberate re-point.
+	m.connected = &offer{NodeID: "grok-node", Model: "grok-4.5", Online: true}
+	m.refreshAgentModel()
+	if m.agent.model != "grok-4.5" || m.agentPicked {
+		t.Fatalf("a fresh channel should re-point and clear the pin: model=%q picked=%v", m.agent.model, m.agentPicked)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -849,7 +849,12 @@ type model struct {
 	// list (open with 2+ candidates); agentPickerRows is the candidate models and
 	// agentPickerCursor the selected row. See agent.go (openAgentModelPicker / the
 	// picker key + view).
-	agentPicked       bool     // the model was chosen via /model (sticky over auto-resolve)
+	agentPicked bool // the model was chosen via /model (sticky over auto-resolve)
+	// agentPickedOver is the channel identity (node+model) that was OPEN when the user
+	// picked via /model - the pick must survive turns on that same channel (the founder's
+	// "I switched to deepseek and the next ask snapped back to Qwen"). Only tuning a
+	// DIFFERENT channel afterwards re-points the agent. "" = nothing was open at pick time.
+	agentPickedOver   string
 	agentPicker       bool     // the /model picker modal is open
 	agentPickerRows   []string // candidate models in the open picker
 	agentPickerCursor int      // selected row in the picker
@@ -6559,6 +6564,7 @@ func (m *model) runAutoTune() tea.Cmd {
 		}
 		m.agent.model = o.Model
 		m.agentPicked = false
+		m.agentPickedOver = ""
 		// Keep focus where it is: if the user is on the FOCUSED desk (a guest scan landed
 		// first), a silent auto-tune must not yank them to the ask box mid-pick. Otherwise
 		// the ask box takes focus so a turn can be typed straight away.


### PR DESCRIPTION
Fixes the reported snap-back: /model deepseek while tuned to Qwen ran the next ask on Qwen. The pick now pins across turns and disconnects; only a fresh tune-in re-points. Regression test included; full tui suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)