### PR TITLE
release: v5.3.6 prep (permission modes + model pin + audit round 1)

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -40,7 +40,7 @@ import (
 //
 // The default below is the fallback for a plain `go build`. Keep it in sync with
 // releases. Use semver, optionally with a prerelease suffix (e.g. 4.8.0-beta.1).
-var Version = "5.3.5"
+var Version = "5.3.6"
 
 // The production broker is the default - `rogerai` works out of the box, no config.
 // Override per-session with ROGER_BROKER=... or persist with `roger config set broker`.

--- a/web/src/manual.html
+++ b/web/src/manual.html
@@ -35,7 +35,7 @@
         </p>
         <div class="man-cover__meta">
           <span>Set: <b>rogerai</b></span>
-          <span>Version: <b data-cli-version>v5.3.5</b></span>
+          <span>Version: <b data-cli-version>v5.3.6</b></span>
           <span>Broker: <b>broker.rogerai.fyi</b></span>
           <span>Protocol: <b>OpenAI-compatible</b></span>
         </div>
@@ -921,7 +921,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
           <section class="man-sec" id="s9">
             <span class="man-sec__no">§9 · Command reference</span>
             <h2>Every command, every key</h2>
-            <p>The full surface as of <b data-cli-version>v5.3.5</b>: the top-level CLI
+            <p>The full surface as of <b data-cli-version>v5.3.6</b>: the top-level CLI
               commands with their key flags, then the in-app keys and slash commands grouped
               by context. Run any command with <code>--help</code> for its flags; advanced
               flags hide behind <code>--advanced</code>. Run <code>rogerai</code> with no
@@ -1201,7 +1201,8 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
               Newest first. The set self-updates - <code>roger upgrade</code> pulls the
               latest, <code>roger upgrade --check</code> just reports.</p>
             <div class="man-plate">
-              <div class="man-plate__row"><span class="man-plate__k">v5.3.5</span><span class="man-plate__v">The signal meter is a countable staircase (lit bars = strength). The wheel scrolls transcripts as real mouse events by default, arrows recall history again, and <code>tab</code> focuses the AGENT transcript for keyboard scrolling with a lit seam.</span></div>
+              <div class="man-plate__row"><span class="man-plate__k">v5.3.6</span><span class="man-plate__v"><code>/perms</code> permission modes (confirm / edits / all, plus <code>/yolo</code>), a <code>/model</code> pick that sticks, a scrollable HELP that opens at the top, a masked API key, single-ask tool confirms, and honest section badges.</span></div>
+            <div class="man-plate__row"><span class="man-plate__k">v5.3.5</span><span class="man-plate__v">The signal meter is a countable staircase (lit bars = strength). The wheel scrolls transcripts as real mouse events by default, arrows recall history again, and <code>tab</code> focuses the AGENT transcript for keyboard scrolling with a lit seam.</span></div>
             <div class="man-plate__row"><span class="man-plate__k">v5.3.4</span><span class="man-plate__v">Thinking models that answer inside their reasoning no longer read as &quot;finished with no text&quot;: the AGENT surfaces the thought (labeled and dimmed) and names a run-out answer budget. Answers render as gutter blocks and each ask starts a time-stamped turn.</span></div>
             <div class="man-plate__row"><span class="man-plate__k">v5.3.3</span><span class="man-plate__v">Arrows and the mouse wheel now always scroll the AGENT and chat transcripts; prompt recall moves to <code>ctrl+p</code>/<code>ctrl+n</code>, <code>end</code> jumps to live, and a scrolled-position seam marks the scrollable area.</span></div>
             <div class="man-plate__row"><span class="man-plate__k">v5.3.2</span><span class="man-plate__v">The AGENT's 300s call cap is now extendable: past the cap, <code>tab</code> grants more time and <code>esc</code> stops (auto-stop after a grace window). The relay recognizes thinking-model output, ending false empty-output voids and strikes.</span></div>


### PR DESCRIPTION
Version bump + manual badges + Appendix C row for v5.3.6, covering #84, #85, #86. Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)