### PR TITLE
cli: --yolo / --perms launch flags + persisted roger perms default

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -94,6 +94,11 @@ type config struct {
 	// (loadOrCreateStation); the owner can rename it (`share --node`, or the TUI [2]
 	// SHARE `n` rename). The broker node id is derived as `<station>-<model-slug>`.
 	Station string `json:"station,omitempty"`
+	// AgentPerms is the PERSISTED default for the AGENT's tool-approval mode
+	// (confirm | edits | all) - `roger perms <mode>` writes it, the launch seeds
+	// ROGERAI_AGENT_PERMS from it (flag/env win per run), and the TUI masthead
+	// names any permissive mode so a saved bypass is never invisible.
+	AgentPerms string `json:"agent_perms,omitempty"`
 }
 
 // SharePrice is a per-model price + time-of-use schedule the in-TUI pricing editor
@@ -679,6 +684,13 @@ func run(argv []string, cfg config) error {
 	// subcommands; strip them here so the dispatcher reads the real command, and resolve
 	// whether the console comes up (ON by default; saved config or --no-webui opts out).
 	rest, webuiOn, webuiPort := stripWebuiFlags(argv, cfg.webuiEnabled(), defaultWebuiPort)
+	// Global approval-mode flags (--yolo / --perms <mode>) apply to this run only;
+	// with no flag, a persisted `roger perms` default seeds the env the TUI reads.
+	rest, permsFlag, err := stripPermsFlags(rest)
+	if err != nil {
+		return err
+	}
+	applyPermsDefault(permsFlag, cfg.AgentPerms)
 	if len(rest) == 0 {
 		// First run: a tiny guided wizard (consume vs share, free vs earn) before the
 		// app. Non-interactive / already-onboarded runs skip it and launch straight in.
@@ -753,6 +765,8 @@ func dispatch(cfg config, args []string) error {
 		return cmdVoices(cfg, args[1:])
 	case "share":
 		return cmdShare(cfg, args[1:])
+	case "perms", "permissions":
+		return cmdPerms(cfg, args[1:])
 	case "limits":
 		return cmdConfig(append([]string{"limits"}, args[1:]...))
 	case "limit":
@@ -2088,6 +2102,8 @@ func usage() {
   roger balance               your wallet balance
   roger topup <amt>           add funds to your wallet
   roger limit --monthly $X    cap your spend per calendar month  (0/off = no cap)
+  roger perms <mode>          agent tool approvals default: confirm | edits | all
+  roger --perms <m> / --yolo  same, for THIS run only (yolo = all)
   roger remote                your private remote sessions: list · attach <code> · off · link
 
 providers (share your GPU):

--- a/cmd/rogerai/perms.go
+++ b/cmd/rogerai/perms.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Agent tool-approval mode on the CLI (the founder's "roger --yolo"):
+//
+//   - `roger --yolo` / `roger --perms <mode>` set the mode FOR THIS RUN (they win
+//     over the env and the saved config; nothing is persisted).
+//   - `roger perms <mode>` PERSISTS the default to config.json; `roger perms` shows
+//     the effective default and where it comes from.
+//
+// Precedence at launch: flag > ROGERAI_AGENT_PERMS env > config.json > confirm.
+// The TUI reads the resolved value from the env (internal/tui reads
+// ROGERAI_AGENT_PERMS at runtime build) and always shows a permissive mode in the
+// AGENT masthead, so a persisted bypass is loud in every session.
+
+// normalizePerms maps the accepted spellings onto the canonical mode names the TUI
+// parses: confirm | edits | all. ok=false for anything else.
+func normalizePerms(s string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "confirm", "ask", "default":
+		return "confirm", true
+	case "edits", "auto-edits", "edit":
+		return "edits", true
+	case "all", "auto-all", "yolo", "bypass":
+		return "all", true
+	}
+	return "", false
+}
+
+// stripPermsFlags pulls the global approval-mode flags out of argv (mirrors
+// stripWebuiFlags): --yolo, --perms=<mode>, --perms <mode>. The LAST flag wins.
+// mode is "" when no flag was given; an invalid --perms value returns err so the
+// user gets a clear message instead of a silently-ignored flag.
+func stripPermsFlags(args []string) (rest []string, mode string, err error) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--yolo":
+			mode = "all"
+		case a == "--perms" && i+1 < len(args):
+			m, ok := normalizePerms(args[i+1])
+			if !ok {
+				return nil, "", fmt.Errorf("--perms %q: want confirm, edits, or all", args[i+1])
+			}
+			mode = m
+			i++
+		case strings.HasPrefix(a, "--perms="):
+			m, ok := normalizePerms(strings.TrimPrefix(a, "--perms="))
+			if !ok {
+				return nil, "", fmt.Errorf("%s: want confirm, edits, or all", a)
+			}
+			mode = m
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return rest, mode, nil
+}
+
+// applyPermsDefault resolves the launch-time approval mode into the env the TUI
+// reads: the flag wins for this run; otherwise an already-set env stands; otherwise
+// the persisted config default seeds it.
+func applyPermsDefault(flagMode, cfgMode string) {
+	switch {
+	case flagMode != "":
+		os.Setenv("ROGERAI_AGENT_PERMS", flagMode)
+	case os.Getenv("ROGERAI_AGENT_PERMS") == "" && cfgMode != "":
+		os.Setenv("ROGERAI_AGENT_PERMS", cfgMode)
+	}
+}
+
+// permsBlurb is the one-line meaning of each mode (kept in plain CLI voice; the
+// TUI's own /perms notes carry the in-app copy).
+func permsBlurb(mode string) string {
+	switch mode {
+	case "edits":
+		return "write_file auto-approves; run_shell still asks"
+	case "all":
+		return "EVERY mutating tool auto-approves - nothing asks"
+	}
+	return "write_file and run_shell ask y/N (the default)"
+}
+
+// cmdPerms is `roger perms [mode]`: bare shows the effective default and its source;
+// with a mode it persists the default to config.json.
+func cmdPerms(cfg config, args []string) error {
+	if len(args) == 0 {
+		mode, src := "confirm", "built-in default"
+		if cfg.AgentPerms != "" {
+			mode, src = cfg.AgentPerms, "config.json"
+		}
+		if env := os.Getenv("ROGERAI_AGENT_PERMS"); env != "" {
+			if m, ok := normalizePerms(env); ok {
+				mode, src = m, "ROGERAI_AGENT_PERMS env"
+			}
+		}
+		fmt.Printf("agent tool approvals: %s (%s) - %s\n", mode, src, permsBlurb(mode))
+		fmt.Println("set: roger perms confirm|edits|all   this run only: roger --perms <mode> / --yolo")
+		return nil
+	}
+	m, ok := normalizePerms(args[0])
+	if !ok {
+		return fmt.Errorf("perms %q: want confirm, edits, or all", args[0])
+	}
+	cfg.AgentPerms = m
+	if m == "confirm" {
+		cfg.AgentPerms = "" // the default needs no config entry
+	}
+	if err := saveConfig(cfg); err != nil {
+		return err
+	}
+	fmt.Printf("saved: agent tool approvals default to %s - %s\n", m, permsBlurb(m))
+	if m == "all" {
+		fmt.Println("! every new session starts with the bypass ON (the AGENT masthead shows AUTO-ALL); roger perms confirm restores the gate")
+	}
+	return nil
+}

--- a/cmd/rogerai/perms_test.go
+++ b/cmd/rogerai/perms_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNormalizePerms locks the accepted spellings onto the canonical trio.
+func TestNormalizePerms(t *testing.T) {
+	for in, want := range map[string]string{
+		"confirm": "confirm", "ask": "confirm", "default": "confirm",
+		"edits": "edits", "auto-edits": "edits", "EDIT": "edits",
+		"all": "all", "YOLO": "all", "bypass": "all",
+	} {
+		if got, ok := normalizePerms(in); !ok || got != want {
+			t.Errorf("normalizePerms(%q) = %q,%v want %q,true", in, got, ok, want)
+		}
+	}
+	if _, ok := normalizePerms("junk"); ok {
+		t.Error("junk should not normalize")
+	}
+}
+
+// TestStripPermsFlags covers the three flag shapes, last-wins, pass-through of other
+// args, and the clear error on a bad value.
+func TestStripPermsFlags(t *testing.T) {
+	rest, mode, err := stripPermsFlags([]string{"--yolo"})
+	if err != nil || mode != "all" || len(rest) != 0 {
+		t.Fatalf("--yolo = %v/%q/%v", rest, mode, err)
+	}
+	rest, mode, err = stripPermsFlags([]string{"--perms", "edits", "search"})
+	if err != nil || mode != "edits" || len(rest) != 1 || rest[0] != "search" {
+		t.Fatalf("--perms edits search = %v/%q/%v", rest, mode, err)
+	}
+	rest, mode, err = stripPermsFlags([]string{"--perms=confirm", "--yolo"})
+	if err != nil || mode != "all" || len(rest) != 0 {
+		t.Fatalf("last flag should win, got %v/%q/%v", rest, mode, err)
+	}
+	if _, _, err = stripPermsFlags([]string{"--perms", "junk"}); err == nil {
+		t.Error("bad --perms value should error")
+	}
+	rest, mode, err = stripPermsFlags([]string{"share", "gpt"})
+	if err != nil || mode != "" || len(rest) != 2 {
+		t.Fatalf("non-flag args must pass through, got %v/%q/%v", rest, mode, err)
+	}
+}
+
+// TestApplyPermsDefault locks the precedence: flag > existing env > config.
+func TestApplyPermsDefault(t *testing.T) {
+	t.Setenv("ROGERAI_AGENT_PERMS", "")
+	os.Unsetenv("ROGERAI_AGENT_PERMS")
+	applyPermsDefault("", "edits") // config seeds an empty env
+	if got := os.Getenv("ROGERAI_AGENT_PERMS"); got != "edits" {
+		t.Fatalf("config seed = %q want edits", got)
+	}
+	applyPermsDefault("", "all") // an already-set env stands
+	if got := os.Getenv("ROGERAI_AGENT_PERMS"); got != "edits" {
+		t.Fatalf("existing env must stand, got %q", got)
+	}
+	applyPermsDefault("all", "confirm") // the flag wins over everything
+	if got := os.Getenv("ROGERAI_AGENT_PERMS"); got != "all" {
+		t.Fatalf("flag must win, got %q", got)
+	}
+}
+
+// TestCmdPermsPersists: `roger perms edits` writes config.json; `confirm` clears the
+// entry (the default needs no config); a bad mode errors.
+func TestCmdPermsPersists(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	os.Unsetenv("ROGERAI_AGENT_PERMS")
+	if err := cmdPerms(loadConfig(), []string{"edits"}); err != nil {
+		t.Fatalf("perms edits: %v", err)
+	}
+	if got := loadConfig().AgentPerms; got != "edits" {
+		t.Fatalf("persisted = %q want edits", got)
+	}
+	if _, err := os.Stat(filepath.Dir(configPath())); err != nil {
+		t.Fatalf("config dir missing: %v", err)
+	}
+	if err := cmdPerms(loadConfig(), []string{"confirm"}); err != nil {
+		t.Fatalf("perms confirm: %v", err)
+	}
+	if got := loadConfig().AgentPerms; got != "" {
+		t.Fatalf("confirm should clear the entry, got %q", got)
+	}
+	if err := cmdPerms(loadConfig(), []string{"junk"}); err == nil {
+		t.Error("bad mode should error")
+	}
+}

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -2012,6 +2012,11 @@ func shortFailure(raw, model string) string {
 		return noStationServing(model) + statusSuffix(s)
 	case strings.Contains(low, "timeout") || strings.Contains(low, "deadline exceeded") || strings.Contains(low, "timed out"):
 		return "the station timed out" + statusSuffix(s)
+	case strings.Contains(low, "decode() failed") || strings.Contains(low, "failed to process"):
+		// A station-side inference crash (e.g. llama.cpp 'failed to process
+		// speculative batch'): the band exists and usually recovers - say so instead
+		// of implying nobody is on air.
+		return "the station hit an internal error - try again, it usually recovers" + statusSuffix(s)
 	case strings.Contains(low, "could not reach the broker") || strings.Contains(low, "broker unreachable") || strings.Contains(low, "connection refused") || strings.Contains(low, "connection reset"):
 		return "could not reach the broker"
 	}

--- a/internal/tui/breadth3_cov_test.go
+++ b/internal/tui/breadth3_cov_test.go
@@ -114,6 +114,7 @@ func TestShortFailureShapes(t *testing.T) {
 		{"the station returned status 504 with no reply", "m", "no station is serving m right now (504)"},
 		{"the station sent an empty response (status 502)", "m", "no station is serving m right now (502)"},
 		{"context deadline exceeded", "m", "the station timed out"},
+		{"decode() failed: failed to process speculative batch", "m", "the station hit an internal error - try again, it usually recovers"},
 		{"could not reach the broker: dial tcp", "", "could not reach the broker"},
 		{"connection refused", "", "could not reach the broker"},
 		{"some other weird error", "", "some other weird error"},


### PR DESCRIPTION
Launch flags (this run only) and a config.json-persisted default for the agent tool-approval mode, flag > env > config precedence, TUI masthead still naming permissive modes. Plus honest copy for station-side inference crashes (seen live today). Unit tests for normalization, stripping, precedence, persistence, and the new error shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)