### PR TITLE
tui: in-app upgrade banner with one-key restart

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -14,6 +14,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -661,7 +662,17 @@ var (
 )
 
 func main() {
-	if err := run(os.Args[1:], loadConfig()); err != nil {
+	err := run(os.Args[1:], loadConfig())
+	if errors.Is(err, tui.ErrRestart) {
+		// The in-TUI upgrade finished and the user chose "restart now": re-exec the
+		// freshly installed binary in place (same argv/env).
+		if err := execRestart(); err != nil {
+			fmt.Fprintln(os.Stderr, "restart failed:", err, "- start roger again manually")
+			os.Exit(1)
+		}
+		return
+	}
+	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
 	}

--- a/cmd/rogerai/restart_unix.go
+++ b/cmd/rogerai/restart_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// execRestart replaces this process with the freshly upgraded binary, preserving
+// argv + env - the "restart now" half of the in-TUI upgrade. Unix exec is atomic:
+// on success it never returns.
+func execRestart() error {
+	self, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	return syscall.Exec(self, os.Args, os.Environ())
+}

--- a/cmd/rogerai/restart_windows.go
+++ b/cmd/rogerai/restart_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package main
+
+import "fmt"
+
+// execRestart: Windows has no exec(2); the freshly installed binary runs on the
+// next launch, so just say that.
+func execRestart() error {
+	fmt.Println("upgraded - start roger again to run the new version")
+	return nil
+}

--- a/internal/tui/operator_steps_desk_entry_test.go
+++ b/internal/tui/operator_steps_desk_entry_test.go
@@ -285,6 +285,7 @@ func (s *opBDD) noCostConfirmShown() error {
 	}
 	return nil
 }
+
 // onlyFreeBandSmallBesidePaidLarge seeds the model's market with a SINGLE band whose free
 // station has an 8k window and whose paid sibling has a 32k window - the mixed band the
 // handoff auto-tune must NOT bind the 8k free station onto (finding 2026-07-08). The band

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -898,8 +898,9 @@ type model struct {
 	// back to the input. The mouse wheel scrolls the transcript in EITHER state
 	// (real wheel events; mouse capture is on by default).
 	agentPaneFocus bool
-	// async, cached update check (non-blocking)
+	// async, cached update check (non-blocking) + the in-TUI upgrade banner state
 	updateLine string // "update available v<cur> -> v<new>" or "" (set by updateMsg)
+	upg        upgState
 	// in-TUI provider/account/money flows (TUI-V2-CRITIQUE D / audit C5)
 	hooks     Hooks          // host-supplied platform/auth bits (nil-safe)
 	share     *agent.Session // most-recently-shared in-process session (the panel's headline; nil = none)
@@ -1663,6 +1664,14 @@ func (m model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.rcConfirmID = protocol.NewRequestID()
 		m.rcEmitConfirmReq(&c, m.rcConfirmID)
 		return m, nil
+	case upgradeDoneMsg:
+		if msg.err != nil {
+			m.upg = upgFailed
+			tuiLog.Write([]byte("upgrade failed: " + msg.err.Error() + "\n"))
+		} else {
+			m.upg = upgDone
+		}
+		return m, nil
 	case agentCostMsg:
 		m.agentCost += msg.cost
 		m.agentTokensIn += msg.tokensIn // running ↑ billed tokens (broker re-count)
@@ -2238,6 +2247,12 @@ func (m model) onKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.status = "re-scanning the band…"
 			m.scanErr, m.scanned = false, false // back to the loading pose while we retune
 			return m, fetchOffers(m.broker)
+		case "u", "x":
+			// The update banner's keys (upgrade now / restart / hide) - only when a
+			// notice is showing; otherwise the keys stay free for future browse use.
+			if nm, cmd, handled := m.onUpgradeKey(k.String()); handled {
+				return nm, cmd
+			}
 		}
 	}
 	return m, nil
@@ -8520,9 +8535,10 @@ func (m model) footer(w int) string {
 	if m.status != "" {
 		st = "\n" + stDim.Render("  ") + m.status
 	}
-	// A subtle non-blocking update notice rides in the status area when available.
-	if m.updateLine != "" {
-		st += "\n" + stDim.Render("  ") + stEmber.Render(m.updateLine)
+	// The update banner rides in the status area when available - actionable in
+	// BROWSE (u upgrades right here, x hides), passive prose elsewhere.
+	if b := m.upgradeBanner(); b != "" {
+		st += "\n" + stDim.Render("  ") + b
 	}
 	rule := stHeadRule.Render(strings.Repeat("─", w))
 	// Narrow: stack the keys above the bal/broker line (a two-line status bar) so
@@ -9080,7 +9096,14 @@ func RunWithController(broker, user string, limits *LimitStore, notice string, h
 	// off, terminals deliver the wheel AS arrow keys and the two are indistinguishable).
 	// Native drag-select still works via shift+drag, and ctrl+o / /mouse toggles capture
 	// off entirely. (m.mouseOff defaults false to match this start state.)
-	return launchTUI(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	wantRestart = false
+	if err := launchTUI(m, tea.WithAltScreen(), tea.WithMouseCellMotion()); err != nil {
+		return err
+	}
+	if wantRestart {
+		return ErrRestart
+	}
+	return nil
 }
 
 // runProgram launches a Bubble Tea program and returns its exit error. It is a

--- a/internal/tui/upgrade.go
+++ b/internal/tui/upgrade.go
@@ -1,0 +1,94 @@
+package tui
+
+// In-TUI upgrade (the founder's "opencode told me there was an update in a banner,
+// asked upgrade or skip, and did it right there"): the passive update notice is an
+// ACTIONABLE banner in BROWSE. `u` downloads, checksum-verifies and atomically
+// installs the new binary via the same update.Upgrade the CLI uses; `x` hides the
+// banner for this session. A finished upgrade offers `u` again as a one-key restart:
+// the TUI exits cleanly and the caller re-execs the freshly installed binary.
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rogerai-fyi/roger/internal/update"
+)
+
+// upgState is the banner's lifecycle: an offer, a running install, a restart offer,
+// or a failure (which keeps the CLI path as the fallback).
+type upgState int
+
+const (
+	upgIdle    upgState = iota // notice present: offer u upgrade / x hide
+	upgRunning                 // download + verify + install in flight
+	upgDone                    // installed: offer u restart / x later
+	upgFailed                  // install failed: name the error, point at `roger upgrade`
+)
+
+// upgradeDoneMsg is the background install's completion (err nil = installed).
+type upgradeDoneMsg struct{ err error }
+
+// runUpgrade is a seam over update.Upgrade so tests drive the whole banner flow
+// without network access or binary replacement.
+var runUpgrade = update.Upgrade
+
+// ErrRestart is returned by RunWithController when the user chose "restart now"
+// after an in-TUI upgrade: the caller (cmd/rogerai) re-execs the new binary.
+var ErrRestart = errors.New("restart into the upgraded binary")
+
+// wantRestart carries the restart choice across the Bubble Tea exit (the framework
+// returns the final model by value; a package var is the plain channel out).
+var wantRestart bool
+
+// startUpgrade launches the install in the background; the buffer swallows the CLI
+// progress prose (the banner carries the state instead).
+func startUpgrade(version string) tea.Cmd {
+	return func() tea.Msg {
+		var buf bytes.Buffer
+		return upgradeDoneMsg{err: runUpgrade(version, &buf)}
+	}
+}
+
+// upgradeBanner renders the update row for the current state ("" when there is no
+// notice at all). It rides in the status area, one row, same as the old notice.
+func (m model) upgradeBanner() string {
+	if m.updateLine == "" {
+		return ""
+	}
+	switch m.upg {
+	case upgRunning:
+		return stEmber.Render("⇪ upgrading … downloading + verifying (a few seconds)")
+	case upgDone:
+		return stLive.Render("✓ upgraded · ") + stKey.Render("u") + stLive.Render(" restarts now · ") +
+			stKey.Render("x") + stLive.Render(" later (next launch is the new version)")
+	case upgFailed:
+		return stEmber.Render("✕ upgrade failed - try `roger upgrade` in a terminal · x hides")
+	}
+	// Idle: the notice + the two keys. The keys act in BROWSE (typing views keep them).
+	return stEmber.Render("⇪ "+strings.TrimSuffix(m.updateLine, " · run 'roger upgrade'")) +
+		stDim.Render(" · ") + stKey.Render("u") + stDim.Render(" upgrade now · ") +
+		stKey.Render("x") + stDim.Render(" hide")
+}
+
+// onUpgradeKey handles the banner keys from BROWSE. handled=false when the key is
+// not the banner's to take (no notice, or a state that ignores it).
+func (m model) onUpgradeKey(key string) (model, tea.Cmd, bool) {
+	if m.updateLine == "" {
+		return m, nil, false
+	}
+	switch {
+	case key == "u" && m.upg == upgIdle:
+		m.upg = upgRunning
+		return m, startUpgrade(helpVersion), true
+	case key == "u" && m.upg == upgDone:
+		wantRestart = true
+		return m, tea.Quit, true
+	case key == "x" && m.upg != upgRunning:
+		m.updateLine = ""
+		m.upg = upgIdle
+		return m, nil, true
+	}
+	return m, nil, false
+}

--- a/internal/tui/upgrade_test.go
+++ b/internal/tui/upgrade_test.go
@@ -1,0 +1,85 @@
+package tui
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestInTUIUpgradeFlow drives the whole banner lifecycle with a stubbed installer:
+// offer -> u installs -> restart offer -> u quits with the restart flag; and the
+// failure branch keeps the CLI fallback visible. x hides the banner.
+func TestInTUIUpgradeFlow(t *testing.T) {
+	orig := runUpgrade
+	defer func() { runUpgrade = orig; wantRestart = false }()
+
+	m := browseSeed(120)
+	m.updateLine = "update available v5.3.7 -> v5.3.8 · run 'roger upgrade'"
+
+	// The idle banner offers both keys.
+	if b := stripANSI(m.upgradeBanner()); !strings.Contains(b, "u") || !strings.Contains(b, "upgrade now") || !strings.Contains(b, "hide") {
+		t.Fatalf("idle banner = %q", b)
+	}
+
+	// u starts the install (state flips to running; the returned cmd is the worker).
+	calls := 0
+	runUpgrade = func(cur string, w io.Writer) error { calls++; fmt.Fprintln(w, "ok"); return nil }
+	nm, cmd, handled := m.onUpgradeKey("u")
+	if !handled || nm.upg != upgRunning || cmd == nil {
+		t.Fatalf("u should start the upgrade (handled=%v state=%v cmd=%v)", handled, nm.upg, cmd)
+	}
+	if !strings.Contains(stripANSI(nm.upgradeBanner()), "upgrading") {
+		t.Errorf("running banner = %q", stripANSI(nm.upgradeBanner()))
+	}
+	msg := cmd()
+	if calls != 1 {
+		t.Fatalf("the worker should call the installer once, got %d", calls)
+	}
+	done, ok := msg.(upgradeDoneMsg)
+	if !ok || done.err != nil {
+		t.Fatalf("worker msg = %#v", msg)
+	}
+
+	// Success: the restart offer; u quits with the restart flag set.
+	nm.upg = upgDone
+	if b := stripANSI(nm.upgradeBanner()); !strings.Contains(b, "restarts now") {
+		t.Errorf("done banner = %q", b)
+	}
+	nm2, cmd2, handled := nm.onUpgradeKey("u")
+	if !handled || cmd2 == nil || !wantRestart {
+		t.Fatalf("u after done should quit with wantRestart (handled=%v cmd=%v want=%v)", handled, cmd2, wantRestart)
+	}
+	_ = nm2
+
+	// Failure branch names the fallback.
+	wantRestart = false
+	runUpgrade = func(cur string, w io.Writer) error { return errors.New("boom") }
+	m3 := m
+	m3.upg = upgIdle
+	m3n, cmd3, _ := m3.onUpgradeKey("u")
+	if done := cmd3().(upgradeDoneMsg); done.err == nil {
+		t.Fatal("failure should surface err")
+	}
+	m3n.upg = upgFailed
+	if b := stripANSI(m3n.upgradeBanner()); !strings.Contains(b, "roger upgrade") {
+		t.Errorf("failed banner should point at the CLI, got %q", b)
+	}
+
+	// x hides the banner entirely.
+	mx, _, handled := m3n.onUpgradeKey("x")
+	if !handled || mx.updateLine != "" || stripANSI(mx.upgradeBanner()) != "" {
+		t.Fatalf("x should hide the banner (handled=%v line=%q)", handled, mx.updateLine)
+	}
+
+	// A running install ignores x (no half-finished dismissals).
+	mr := m
+	mr.upg = upgRunning
+	if _, _, handled := mr.onUpgradeKey("x"); handled {
+		t.Error("x during a running install must be ignored")
+	}
+	_ = tea.Quit
+}


### PR DESCRIPTION
opencode-style update flow: the notice row becomes actionable in BROWSE (u = download + verify + install in place, x = hide), success offers a one-key restart that re-execs the new binary (unix; Windows advises relaunch), failure falls back to the CLI path. Stubbed-installer test covers the lifecycle; full suite + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)