### PR TITLE
web(easter-egg): Ping's bubble points at the live App Store listing

### DIFF
--- a/web/src/js/easter-egg.js
+++ b/web/src/js/easter-egg.js
@@ -31,10 +31,9 @@
   function clamp(v, a, b) { return v < a ? a : v > b ? b : v; }
   function easeInOutCubic(t) { return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2; }
 
-  // The iOS app isn't live yet (bundle fyi.rogerai.app; Sign-in-with-Apple still a submission
-  // blocker), so there is no real numeric App Store id. PLACEHOLDER - swap in the real id at launch;
-  // the bubble says "coming soon" so this is never presented as a live listing.
-  var APP_STORE_URL = "https://apps.apple.com/app/rogerai/id000000000"; // TODO: real App Store ID once the app is live
+  // The live App Store listing (RogerAI.fyi, shipped 2026-07-09) - canonical form, kept in
+  // lockstep with the /app.html links.
+  var APP_STORE_URL = "https://apps.apple.com/us/app/rogerai-fyi/id6785743752";
   // pure: the argument tuple for a safe new-tab open - opener severed so the store tab can't touch us.
   function openArgs(url) { return [url, "_blank", "noopener,noreferrer"]; }
 
@@ -72,8 +71,8 @@
     arrow.textContent = "→";
     arrow.style.cssText = "color:#e0231c;font-weight:700;";
     line.appendChild(arrow);
-    var soon = document.createElement("div"); // honest: the listing isn't live yet (placeholder id)
-    soon.textContent = "coming soon";
+    var soon = document.createElement("div");
+    soon.textContent = "free on iPhone, iPad & Mac";
     soon.style.cssText = "margin-top:2px;font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-400,#9a968b);";
     var tail = document.createElement("div"); // little downward beak toward Ping
     tail.style.cssText = "position:absolute;left:50%;bottom:-5px;width:10px;height:10px;" +

--- a/web/test/easter-egg.test.mjs
+++ b/web/test/easter-egg.test.mjs
@@ -43,7 +43,7 @@ test("openArgs: new tab with the opener severed (no window.opener leak to the st
   assert.ok(R.openArgs("u")[2].includes("noopener")); // security: store tab can't reach back via opener
 });
 
-test("APP_STORE_URL: a well-formed apps.apple.com deep link (id format locked for the real swap)", () => {
-  // Placeholder today; this lock still passes once a real numeric id replaces id000000000.
-  assert.match(R.APP_STORE_URL, /^https:\/\/apps\.apple\.com\/.+\/id\d+$/);
+test("APP_STORE_URL: the live RogerAI.fyi listing, canonical form (matches app.html)", () => {
+  assert.equal(R.APP_STORE_URL, "https://apps.apple.com/us/app/rogerai-fyi/id6785743752");
+  assert.match(R.APP_STORE_URL, /^https:\/\/apps\.apple\.com\/.+\/id\d+$/); // well-formed deep link, no trailing slash
 });


### PR DESCRIPTION
The app shipped on the App Store 2026-07-09, but the Ping easter-egg still opened the placeholder `id000000000` deep link and labelled it "coming soon".

- Swap in the canonical listing URL (`https://apps.apple.com/us/app/rogerai-fyi/id6785743752`), the same form /app.html links to (#83).
- Replace the stale placeholder comment and change the bubble sub-line to "free on iPhone, iPad & Mac".
- Test now locks the exact live URL (red first, then green); 79/79 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)