### PR TITLE
tui: web console on demand (w · /webui) + ctrl+p cycles /perms

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -1929,6 +1929,8 @@ func cmdConfig(args []string) error {
 				fmt.Println(c.Broker)
 			case "user":
 				fmt.Println(c.User)
+			case "webui-open":
+				fmt.Println(c.webuiOpenEnabled())
 			}
 			return nil
 		}

--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -89,6 +89,7 @@ type config struct {
 	Voices    map[string]ShareVoice `json:"share_voices,omitempty"` // per-model voice identity (dj name / voice / speed / language / sample_url)
 	Compact   bool                  `json:"compact,omitempty"`      // windowshade compact-mode toggle (the in-TUI [m] choice, persisted)
 	Webui     *bool                 `json:"webui,omitempty"`        // browser node console: nil/true = on (default), false = off; --no-webui overrides off for a run
+	WebuiOpen *bool                 `json:"webui_open,omitempty"`   // auto-open the console in a browser at launch: nil/false = no (default; founder respec 2026-07-14 - it hijacked terminal-embedded browsers), true = yes
 	// Station is this install's friendly, NON-SENSITIVE broadcast callsign (e.g.
 	// `brave-otter-37`). It is the public-facing identity in /discover - NOT the
 	// hostname - so it never leaks the machine name. Auto-generated once and persisted
@@ -712,7 +713,9 @@ func run(argv []string, cfg config) error {
 		hooks := tuiHooks(cfg)
 		ctrl := tui.NewController(cfg.Broker, hooks)
 		if webuiOn {
-			startWebConsoleFn(cfg, ctrl, webuiPort)
+			// The console URL rides into the TUI so `w` / /webui open it on demand
+			// (the console itself no longer auto-opens a browser by default).
+			hooks.ConsoleURL = startWebConsoleFn(cfg, ctrl, webuiPort)
 		}
 		return runTUI(cfg.Broker, cfg.User, tuiLimits(cfg), notice, hooks, ctrl)
 	}
@@ -1894,7 +1897,7 @@ func cmdAccount(cfg config, args []string) error {
 func cmdConfig(args []string) error {
 	if len(args) == 0 {
 		c := loadConfig()
-		fmt.Printf("broker = %s\nuser   = %s\n", c.Broker, c.User)
+		fmt.Printf("broker = %s\nuser   = %s\nwebui-open = %v\n", c.Broker, c.User, c.webuiOpenEnabled())
 		printLimits(c)
 		fmt.Printf("(%s)\n", configPath())
 		return nil
@@ -1932,7 +1935,7 @@ func cmdConfig(args []string) error {
 		fmt.Printf("broker = %s\nuser   = %s\n", c.Broker, c.User)
 	case "set":
 		if len(args) < 3 {
-			return fmt.Errorf("usage: roger config set <broker|user> <value>")
+			return fmt.Errorf("usage: roger config set <broker|user|webui-open> <value>")
 		}
 		c := loadConfig()
 		switch args[1] {
@@ -1940,6 +1943,14 @@ func cmdConfig(args []string) error {
 			c.Broker = strings.TrimRight(args[2], "/")
 		case "user":
 			c.User = args[2]
+		case "webui-open":
+			// Auto-open the browser console at launch (OFF by default; `w` in the app
+			// opens it on demand either way).
+			on, err := strconv.ParseBool(args[2])
+			if err != nil {
+				return fmt.Errorf("usage: roger config set webui-open true|false")
+			}
+			c.WebuiOpen = &on
 		default:
 			return fmt.Errorf("unknown key %q", args[1])
 		}
@@ -2104,6 +2115,8 @@ func usage() {
 	fmt.Printf(`rogerai - a two-way radio for GPUs. run with no args for the interactive app.
 
   roger                       open the app (browse, tune in, chat) + browser console
+                              (press w in the app to open the console in your browser;
+                               auto-open at launch: roger config set webui-open true)
   roger --no-webui            open the app WITHOUT the browser console
   roger --ping                full-screen "Ping World" screensaver (or press z in the app)
   roger search                list models, cheapest first

--- a/cmd/rogerai/seams_cov_test.go
+++ b/cmd/rogerai/seams_cov_test.go
@@ -257,13 +257,18 @@ func TestRunNoArgsLaunch(t *testing.T) {
 		if broker != "https://b" {
 			t.Errorf("runTUI got broker %q, want https://b", broker)
 		}
+		// The console URL must reach the TUI so `w` / /webui can open it on demand.
+		if hooks.ConsoleURL != "http://127.0.0.1:4180/?t=test" {
+			t.Errorf("runTUI got hooks.ConsoleURL %q, want the console URL", hooks.ConsoleURL)
+		}
 		return nil
 	}
-	startWebConsoleFn = func(cfg config, ctrl *node.Controller, port string) {
+	startWebConsoleFn = func(cfg config, ctrl *node.Controller, port string) string {
 		webCalled = true
 		if port != defaultWebuiPort {
 			t.Errorf("startWebConsoleFn got port %q, want %q", port, defaultWebuiPort)
 		}
+		return "http://127.0.0.1:4180/?t=test"
 	}
 	t.Cleanup(func() { runTUI, startWebConsoleFn = origTUI, origWeb })
 
@@ -285,7 +290,7 @@ func TestRunNoWebui(t *testing.T) {
 		tuiCalled = true
 		return nil
 	}
-	startWebConsoleFn = func(cfg config, ctrl *node.Controller, port string) { webCalled = true }
+	startWebConsoleFn = func(cfg config, ctrl *node.Controller, port string) string { webCalled = true; return "" }
 	t.Cleanup(func() { runTUI, startWebConsoleFn = origTUI, origWeb })
 
 	if err := run([]string{"--no-webui"}, config{Broker: "https://b", User: "u", Onboarded: true}); err != nil {
@@ -351,15 +356,27 @@ func TestStartWebConsole(t *testing.T) {
 	}
 }
 
-// TestStartWebConsoleBindFailure covers the non-fatal bind-failure branch: a bogus port
-// string fails to bind and startWebConsole returns without panicking (the terminal
-// front-end carries on).
-func TestStartWebConsoleBindFailure(t *testing.T) {
+// TestStartWebConsoleBogusPortRescued: webui.Listen never dead-ends on a sane host - a
+// port string outside the TCP range falls through the upward scan to the OS-picked
+// last resort, so the console still serves, returns a real URL, and (with webui_open
+// on) auto-opens exactly that URL. The true bind-failure branch (no loopback at all)
+// is not reachable in a test environment.
+func TestStartWebConsoleBogusPortRescued(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	cfg := config{Broker: "https://b", User: "u"}
+	origOpen := openBrowser
+	var opened []string
+	openBrowser = func(url string) { opened = append(opened, url) }
+	t.Cleanup(func() { openBrowser = origOpen })
+	on := true
+	cfg := config{Broker: "https://b", User: "u", WebuiOpen: &on}
 	ctrl := tui.NewController(cfg.Broker, tuiHooks(cfg))
-	// "99999999" is out of the valid TCP port range -> Listen fails -> early return.
-	startWebConsole(cfg, ctrl, "99999999")
+	url := startWebConsole(cfg, ctrl, "99999999")
+	if url == "" || !strings.Contains(url, "127.0.0.1") {
+		t.Fatalf("a bogus port should be rescued by the OS-picked fallback, got %q", url)
+	}
+	if len(opened) != 1 || opened[0] != url {
+		t.Fatalf("webui_open=true should open the rescued URL once, got %v", opened)
+	}
 }
 
 // TestPayoutRequestAmountBranches drives payoutRequest's optional-[amount] validation

--- a/cmd/rogerai/seams_cov_test.go
+++ b/cmd/rogerai/seams_cov_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +15,7 @@ import (
 	"github.com/rogerai-fyi/roger/internal/detect"
 	"github.com/rogerai-fyi/roger/internal/node"
 	"github.com/rogerai-fyi/roger/internal/tui"
+	"github.com/rogerai-fyi/roger/internal/webui"
 )
 
 // stubDetectFull points the detectFull seam at a fake local-LLM detector so the
@@ -353,6 +356,30 @@ func TestStartWebConsole(t *testing.T) {
 	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("console GET status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestStartWebConsoleListenFailure covers the true bind-failure branch (return "", no
+// browser open) by forcing the listen seam to error - the OS-fallback in webui.Listen
+// makes this branch otherwise unreachable in a test, so a seam is the only honest way
+// to exercise it.
+func TestStartWebConsoleListenFailure(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	origListen, origOpen := webConsoleListen, openBrowser
+	var opened []string
+	webConsoleListen = func(s *webui.Server, addr string) (net.Listener, string, error) {
+		return nil, "", errors.New("forced bind failure")
+	}
+	openBrowser = func(url string) { opened = append(opened, url) }
+	t.Cleanup(func() { webConsoleListen, openBrowser = origListen, origOpen })
+	on := true
+	cfg := config{Broker: "https://b", User: "u", WebuiOpen: &on}
+	ctrl := tui.NewController(cfg.Broker, tuiHooks(cfg))
+	if url := startWebConsole(cfg, ctrl, "0"); url != "" {
+		t.Fatalf("a bind failure should return no URL, got %q", url)
+	}
+	if len(opened) != 0 {
+		t.Fatalf("a bind failure must not open a browser, got %v", opened)
 	}
 }
 

--- a/cmd/rogerai/webconsole.go
+++ b/cmd/rogerai/webconsole.go
@@ -19,6 +19,16 @@ const defaultWebuiPort = "4180"
 // off for a single run (--webui forces it on). The flags are consumed by stripWebuiFlags.
 func (c config) webuiEnabled() bool { return c.Webui == nil || *c.Webui }
 
+// webuiOpenEnabled reports whether the console also auto-opens in a browser at launch.
+// OFF by default (founder respec 2026-07-14: on terminal-embedded browsers the auto-open
+// trapped the TUI); `roger config set webui-open true` opts back in. Either way the URL
+// is printed and `w` (BROWSE) / /webui (AGENT) open it on demand.
+func (c config) webuiOpenEnabled() bool { return c.WebuiOpen != nil && *c.WebuiOpen }
+
+// openBrowser is a seam over the guarded default-browser launcher, so a test can
+// observe the auto-open decision without spawning a process.
+var openBrowser = tui.OpenURL
+
 // stripWebuiFlags removes the global --no-webui / --webui / --webui-port=N flags from a
 // raw argv tail and reports the resulting enabled state + port. They are global (not tied
 // to a subcommand), so the dispatcher filters them before reading os.Args[1]; a real
@@ -43,15 +53,16 @@ func stripWebuiFlags(args []string, enabled bool, port string) (rest []string, o
 }
 
 // startWebConsole stands up the localhost browser console over ctrl (the SAME controller
-// the TUI/daemon drives), printing the tokenized URL and opening the browser. It returns
-// immediately; the server runs in a background goroutine for the life of the process. A
-// bind failure is non-fatal — the terminal front-end carries on.
-func startWebConsole(cfg config, ctrl *node.Controller, port string) {
+// the TUI/daemon drives), printing the tokenized URL, and returns that URL ("" on a bind
+// failure) so the TUI can open it on demand (`w` / /webui). It returns immediately; the
+// server runs in a background goroutine for the life of the process. A bind failure is
+// non-fatal — the terminal front-end carries on.
+func startWebConsole(cfg config, ctrl *node.Controller, port string) string {
 	s := webui.New(ctrl, webui.Options{Broker: cfg.Broker, User: cfg.User, ClientID: gitHubClientID()})
 	ln, url, err := s.Listen("127.0.0.1:" + port)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "web console: could not bind a localhost port:", err)
-		return
+		return ""
 	}
 	fmt.Printf("web console → %s\n", url)
 	go func() { _ = s.Serve(ln) }()
@@ -65,7 +76,12 @@ func startWebConsole(cfg config, ctrl *node.Controller, port string) {
 		// rewrite saved share config — that's reserved for an explicit re-detect.
 		ctrl.LoadRowsNoPersist(found)
 	}()
-	// Open the browser only on a real interactive terminal (the helper self-gates), so a
-	// headless `roger share` daemon prints the URL but never hijacks a browser.
-	tui.OpenURL(url)
+	// Auto-open ONLY when the saved config opts in (webui_open: true) - the default is
+	// to just print the URL (founder respec 2026-07-14: the auto-open trapped the TUI
+	// under terminal-embedded browsers). The launcher still self-gates on a real
+	// interactive terminal, so a headless `roger share` daemon never hijacks a browser.
+	if cfg.webuiOpenEnabled() {
+		openBrowser(url)
+	}
+	return url
 }

--- a/cmd/rogerai/webconsole.go
+++ b/cmd/rogerai/webconsole.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
@@ -28,6 +29,13 @@ func (c config) webuiOpenEnabled() bool { return c.WebuiOpen != nil && *c.WebuiO
 // openBrowser is a seam over the guarded default-browser launcher, so a test can
 // observe the auto-open decision without spawning a process.
 var openBrowser = tui.OpenURL
+
+// webConsoleListen is a seam over webui.Server.Listen so a test can force the bind to
+// fail and cover startWebConsole's non-fatal return-"" branch (webui.Listen's OS-picked
+// fallback makes a real bind failure otherwise unreachable in a test).
+var webConsoleListen = func(s *webui.Server, addr string) (net.Listener, string, error) {
+	return s.Listen(addr)
+}
 
 // stripWebuiFlags removes the global --no-webui / --webui / --webui-port=N flags from a
 // raw argv tail and reports the resulting enabled state + port. They are global (not tied
@@ -59,7 +67,7 @@ func stripWebuiFlags(args []string, enabled bool, port string) (rest []string, o
 // non-fatal — the terminal front-end carries on.
 func startWebConsole(cfg config, ctrl *node.Controller, port string) string {
 	s := webui.New(ctrl, webui.Options{Broker: cfg.Broker, User: cfg.User, ClientID: gitHubClientID()})
-	ln, url, err := s.Listen("127.0.0.1:" + port)
+	ln, url, err := webConsoleListen(s, "127.0.0.1:"+port)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "web console: could not bind a localhost port:", err)
 		return ""

--- a/cmd/rogerai/webconsole_test.go
+++ b/cmd/rogerai/webconsole_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/rogerai-fyi/roger/internal/tui"
 )
 
 func TestStripWebuiFlags(t *testing.T) {
@@ -34,6 +37,76 @@ func TestStripWebuiFlags(t *testing.T) {
 				t.Errorf("port = %q, want %q", port, tc.wantPort)
 			}
 		})
+	}
+}
+
+// Founder spec (2026-07-14): launching roger must NOT auto-open the web console in a
+// browser anymore (on some setups it opened inside the terminal and trapped the TUI).
+// The console server still comes up (URL printed; `w` / /webui open it on demand); a
+// saved `webui_open: true` opts back into the old auto-open.
+func TestWebuiOpenDefaultOff(t *testing.T) {
+	if (config{}).webuiOpenEnabled() {
+		t.Error("browser auto-open must be OFF by default (WebuiOpen nil)")
+	}
+	on, off := true, false
+	if !(config{WebuiOpen: &on}).webuiOpenEnabled() {
+		t.Error("webui_open=true should auto-open")
+	}
+	if (config{WebuiOpen: &off}).webuiOpenEnabled() {
+		t.Error("webui_open=false should not auto-open")
+	}
+}
+
+// TestStartWebConsoleOpenGating: the console server binds and returns its tokenized URL
+// either way; the browser open fires ONLY when the config opts in.
+func TestStartWebConsoleOpenGating(t *testing.T) {
+	origOpen := openBrowser
+	var opened []string
+	openBrowser = func(url string) { opened = append(opened, url) }
+	t.Cleanup(func() { openBrowser = origOpen })
+
+	ctrl := tui.NewController("http://broker.invalid", tui.Hooks{})
+	url := startWebConsole(config{}, ctrl, "0")
+	if url == "" || !strings.Contains(url, "127.0.0.1") {
+		t.Fatalf("default run should still serve the console, url = %q", url)
+	}
+	if len(opened) != 0 {
+		t.Fatalf("default run must NOT open a browser, opened %v", opened)
+	}
+
+	on := true
+	url2 := startWebConsole(config{WebuiOpen: &on}, ctrl, "0")
+	if len(opened) != 1 || opened[0] != url2 {
+		t.Fatalf("webui_open=true should open the console URL once, opened %v url %q", opened, url2)
+	}
+}
+
+// TestConfigWebuiOpenSetGet: the settings surface - `roger config set webui-open
+// true|false` persists, junk errors, and the bare listing shows the state.
+func TestConfigWebuiOpenSetGet(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := cmdConfig([]string{"set", "webui-open", "true"}); err != nil {
+		t.Fatalf("set webui-open true: %v", err)
+	}
+	if !loadConfig().webuiOpenEnabled() {
+		t.Fatal("set webui-open true did not persist")
+	}
+	if err := cmdConfig([]string{"set", "webui-open", "false"}); err != nil {
+		t.Fatalf("set webui-open false: %v", err)
+	}
+	if loadConfig().webuiOpenEnabled() {
+		t.Fatal("set webui-open false did not persist")
+	}
+	if err := cmdConfig([]string{"set", "webui-open", "sideways"}); err == nil {
+		t.Fatal("junk value should error")
+	}
+	out := captureStdout(t, func() {
+		if err := cmdConfig(nil); err != nil {
+			t.Errorf("bare config: %v", err)
+		}
+	})
+	if !strings.Contains(out, "webui-open") {
+		t.Errorf("bare `roger config` should list webui-open, got:\n%s", out)
 	}
 }
 

--- a/cmd/rogerai/webconsole_test.go
+++ b/cmd/rogerai/webconsole_test.go
@@ -108,6 +108,15 @@ func TestConfigWebuiOpenSetGet(t *testing.T) {
 	if !strings.Contains(out, "webui-open") {
 		t.Errorf("bare `roger config` should list webui-open, got:\n%s", out)
 	}
+	// `config get webui-open` answers too (audit finding: it was a silent no-output).
+	out = captureStdout(t, func() {
+		if err := cmdConfig([]string{"get", "webui-open"}); err != nil {
+			t.Errorf("get webui-open: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "false" {
+		t.Errorf("config get webui-open = %q, want false", strings.TrimSpace(out))
+	}
 }
 
 func TestWebuiEnabledDefault(t *testing.T) {

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -819,16 +819,10 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.agentVP.GotoBottom()
 		return m, nil
 	case "ctrl+p":
-		// Shell-style recall: an OLDER sent prompt (stashing the live draft on the
-		// first press). Distinct from the chat's history. Ignored mid-turn, when
-		// edits to the in-flight prompt would be lost anyway.
-		if !m.agentBusy {
-			if v, ok := m.agentHist.prev(m.agentIn.Value()); ok {
-				m.agentIn.SetValue(v)
-				m.agentIn.CursorEnd()
-			}
-		}
-		return m, nil
+		// The PERMS key (founder respec 2026-07-14): cycle the tool-approval mode
+		// exactly like bare /perms - INSTANTLY, even mid-turn (the mode is an atomic
+		// the confirmer reads live). History recall stays on Up/Down (+ ctrl+n).
+		return m.runAgentCommand("/perms")
 	case "ctrl+n":
 		// Recall a NEWER sent prompt; past the newest it restores the stashed draft.
 		if !m.agentBusy {
@@ -904,7 +898,7 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if !strings.HasPrefix(p, "/") {
 			m.rcEmitLocalTurn(p)
 		}
-		if m.agentBusy {
+		if m.agentBusy && !instantAgentCommand(p) {
 			m.agentQueued = append(m.agentQueued, queuedPrompt{text: p})
 			m.agentLines = append(m.agentLines, stDim.Render("⏳ queued · ")+stDim.Render(clipLine(p)))
 			m.status = stDim.Render(plural(len(m.agentQueued), "queued msg") + " · sends when the turn finishes · esc cancels")
@@ -1060,7 +1054,7 @@ func (m model) dequeueAgentPrompts() (model, tea.Cmd) {
 // TestAgentCommandRegistrySeam: every entry must dispatch, never "unknown:").
 // Sorted; slash-prefixed canonical names only - short aliases (/dj /y /rc /h) stay
 // typable but are not suggested.
-var agentCommands = []string{"/clear", "/commands", "/copy", "/help", "/model", "/operator", "/perms", "/persona", "/remote-control"}
+var agentCommands = []string{"/clear", "/commands", "/copy", "/help", "/model", "/operator", "/perms", "/persona", "/remote-control", "/webui"}
 
 // agentSlashCandidates returns the agentCommands entries the input's command word
 // prefix-matches (case-insensitive, PREFIX-only), in registry (sorted) order - the
@@ -1112,6 +1106,24 @@ func (m model) agentSlashStrip() string {
 // runAgentCommand handles the small set of in-AGENT slash commands (no chat turn):
 // /clear resets the session, /persona shows where dj.md lives + its first lines,
 // /help lists them. Anything else is a hint (never sent as a turn).
+// instantAgentCommand reports whether a slash line runs IMMEDIATELY even while a turn
+// is busy, instead of parking in the prompt queue. Only commands that touch local UI
+// state qualify (the perms atomic, a browser open) - queueing those is pure damage:
+// the founder's screenshot showed two "queued · /perms" firing after the turn and
+// double-cycling the mode through auto-all. Session-mutating commands (/clear, /model,
+// ...) still queue, as does every chat prompt.
+func instantAgentCommand(line string) bool {
+	f := strings.Fields(line)
+	if len(f) == 0 {
+		return false
+	}
+	switch f[0] {
+	case "/perms", "/permissions", "/yolo", "/webui", "/console", "/web":
+		return true
+	}
+	return false
+}
+
 func (m model) runAgentCommand(line string) (tea.Model, tea.Cmd) {
 	fields := strings.Fields(line)
 	cmd := strings.TrimPrefix(fields[0], "/")
@@ -1153,7 +1165,7 @@ func (m model) runAgentCommand(line string) (tea.Model, tea.Cmd) {
 		case len(fields) >= 2:
 			mode, ok := parsePermMode(fields[1])
 			if !ok {
-				note("usage: /perms confirm | edits | all   (bare /perms cycles)")
+				note("usage: /perms confirm | edits | all   (bare /perms or ctrl+p cycles)")
 				return m, nil
 			}
 			next = mode
@@ -1167,6 +1179,16 @@ func (m model) runAgentCommand(line string) (tea.Model, tea.Cmd) {
 		} else {
 			note("tools " + next.String() + " - " + permsHelp(next))
 		}
+		return m, nil
+	case "webui", "console", "web":
+		// Open the browser node console on demand - it no longer auto-opens at launch
+		// (founder respec 2026-07-14). Instant even mid-turn (instantAgentCommand).
+		if m.hooks.ConsoleURL == "" {
+			note("no web console this run - relaunch without --no-webui to serve it")
+			return m, nil
+		}
+		openURL(m.hooks.ConsoleURL)
+		note("web console → " + m.hooks.ConsoleURL)
 		return m, nil
 	case "persona", "dj":
 		note("persona: " + harness.PersonaPath() + " (editable - keeps getting updated)")

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -615,6 +615,23 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.rcEmitConfirmDone(true, "local")
 			c.resp <- true
 			return m, m.waitAgentEvent()
+		case "ctrl+p":
+			// ctrl+p is the perms key even at the gate (founder: instant perms toggle
+			// even mid-turn) - NEVER the surprise DENY the default branch would give.
+			// Cycle the mode; if the escalated mode now auto-approves THIS tool, resolve
+			// the gate as approved (the intuitive "stop asking me, allow this"); else
+			// leave the gate pending so no accidental run happens.
+			next := (agentPermMode(m.agent.perms.Load()) + 1) % 3
+			m = m.applyPermMode(next)
+			if permAllows(next, c.tool) {
+				m.agentLines = append(m.agentLines, "  "+stLive.Render("✓ ")+stDim.Render("approved · running "+c.tool))
+				m.agentPendingConfirm = nil
+				m.rcConfirmID = ""
+				m.rcEmitConfirmDone(true, "local")
+				c.resp <- true
+				return m, m.waitAgentEvent()
+			}
+			return m, nil
 		default: // n / N / esc / anything else - default DENY
 			m.agentLines = append(m.agentLines, "  "+stRed.Render("✕ ")+stEmber.Render("denied · "+c.tool+" was not run"))
 			m.agentPendingConfirm = nil
@@ -822,7 +839,11 @@ func (m model) onAgentKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// The PERMS key (founder respec 2026-07-14): cycle the tool-approval mode
 		// exactly like bare /perms - INSTANTLY, even mid-turn (the mode is an atomic
 		// the confirmer reads live). History recall stays on Up/Down (+ ctrl+n).
-		return m.runAgentCommand("/perms")
+		if m.agent == nil {
+			return m, nil
+		}
+		m = m.applyPermMode((agentPermMode(m.agent.perms.Load()) + 1) % 3)
+		return m, nil
 	case "ctrl+n":
 		// Recall a NEWER sent prompt; past the newest it restores the stashed draft.
 		if !m.agentBusy {
@@ -1124,6 +1145,35 @@ func instantAgentCommand(line string) bool {
 	return false
 }
 
+// applyPermMode stores the new tool-approval mode and echoes ONE feedback line - loud
+// (ember, bang) at the full bypass, a quiet dim note otherwise - so the /perms command,
+// the ctrl+p key, and the confirm-gate escalation all report a mode change identically.
+// Every caller guards m.agent != nil (ctrl+p and /perms early-return, a pending confirm
+// implies a live agent), so this dereferences it directly - a nil here is a real bug.
+func (m model) applyPermMode(next agentPermMode) model {
+	m.agent.perms.Store(int32(next))
+	if next == permAll {
+		m.agentLines = append(m.agentLines, stEmber.Render("! tools "+next.String()+" - "+permsHelp(next)))
+	} else {
+		m.agentLines = append(m.agentLines, stDim.Render("· ")+stDim.Render("tools "+next.String()+" - "+permsHelp(next)))
+	}
+	return m
+}
+
+// openConsole opens this run's browser node console if one is serving and returns the
+// status line to show. The single source for the guard + wording, shared by the BROWSE
+// `w` key, /webui in the AGENT, and both channel command runners (review: 4-site dup).
+// The console no longer auto-opens at launch (founder respec 2026-07-14).
+func (m model) openConsole() string {
+	if m.hooks.ConsoleURL == "" {
+		// Honest about BOTH reasons the URL can be empty (review: the old message
+		// asserted --no-webui even when the console simply failed to bind).
+		return "no web console this run - it's off (--no-webui) or the port didn't bind"
+	}
+	openURL(m.hooks.ConsoleURL)
+	return "web console → " + m.hooks.ConsoleURL
+}
+
 func (m model) runAgentCommand(line string) (tea.Model, tea.Cmd) {
 	fields := strings.Fields(line)
 	cmd := strings.TrimPrefix(fields[0], "/")
@@ -1172,23 +1222,12 @@ func (m model) runAgentCommand(line string) (tea.Model, tea.Cmd) {
 		default:
 			next = (cur + 1) % 3 // bare /perms cycles confirm -> edits -> all -> confirm
 		}
-		m.agent.perms.Store(int32(next))
-		if next == permAll {
-			// The bypass is loud on purpose: an ember line, not a dim note.
-			m.agentLines = append(m.agentLines, stEmber.Render("! tools "+next.String()+" - "+permsHelp(next)))
-		} else {
-			note("tools " + next.String() + " - " + permsHelp(next))
-		}
+		m = m.applyPermMode(next)
 		return m, nil
 	case "webui", "console", "web":
 		// Open the browser node console on demand - it no longer auto-opens at launch
 		// (founder respec 2026-07-14). Instant even mid-turn (instantAgentCommand).
-		if m.hooks.ConsoleURL == "" {
-			note("no web console this run - relaunch without --no-webui to serve it")
-			return m, nil
-		}
-		openURL(m.hooks.ConsoleURL)
-		note("web console → " + m.hooks.ConsoleURL)
+		note(m.openConsole())
 		return m, nil
 	case "persona", "dj":
 		note("persona: " + harness.PersonaPath() + " (editable - keeps getting updated)")
@@ -1777,7 +1816,7 @@ func (m model) agentView(w int) string {
 		if m.agent != nil {
 			permTail = permsHelp(agentPermMode(m.agent.perms.Load()))
 		}
-		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  tab focuses the transcript  ·  ⌃y copy  ·  esc exits AGENT  ·  /clear  ·  " + permTail
+		help := "enter asks  ·  /model switches  ·  /operator hands the mic  ·  tab focuses the transcript  ·  ⌃y copy  ·  ⌃p perms  ·  esc exits AGENT  ·  /clear  ·  " + permTail
 		switch {
 		case m.agentBusy && m.narrow():
 			help = "type queues · esc cancels (2× force)"

--- a/internal/tui/agent_slash_complete_test.go
+++ b/internal/tui/agent_slash_complete_test.go
@@ -66,7 +66,7 @@ func lineAbovePrompt(t *testing.T, tm tea.Model) string {
 }
 
 // allCommandsStrip is the full sorted registry as the strip renders it on a bare "/".
-const allCommandsStrip = "/clear · /commands · /copy · /help · /model · /operator · /perms · /persona · /remote-control"
+const allCommandsStrip = "/clear · /commands · /copy · /help · /model · /operator · /perms · /persona · /remote-control · /webui"
 
 // TestAgentSlashStripMatrix drives the strip with real typed keys: which commands it
 // suggests for what input, and when it hides. Matching is case-insensitive and

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -233,10 +233,12 @@ func TestChatInputUpDownRecall(t *testing.T) {
 	if got := asModel(m).chatIn.Value(); got != "a draft" {
 		t.Fatalf("Down should restore the draft, got %q", got)
 	}
-	// ctrl+p / ctrl+n remain recall aliases.
+	// ctrl+p is the PERMS key now (founder respec 2026-07-14) - it must NOT recall.
+	// ctrl+n keeps its newer-recall alias.
+	m, _ = m.Update(keyUp())
 	m, _ = m.Update(keyRecallPrev())
 	if got := asModel(m).chatIn.Value(); got != "hello there" {
-		t.Fatalf("ctrl+p should recall the sent line, got %q", got)
+		t.Fatalf("ctrl+p must leave the recalled line untouched, got %q", got)
 	}
 	m, _ = m.Update(keyRecallNext())
 	if got := asModel(m).chatIn.Value(); got != "a draft" {

--- a/internal/tui/scroll_test.go
+++ b/internal/tui/scroll_test.go
@@ -173,7 +173,8 @@ func TestChatArrowScrollsWhenNoHistory(t *testing.T) {
 }
 
 // TestChatHistoryRecallStillWorks: Up recalls command history while the input owns
-// focus (the wheel scrolls as real mouse events), and ctrl+p stays an alias.
+// focus (the wheel scrolls as real mouse events). ctrl+p is the PERMS key now
+// (founder respec 2026-07-14) and must NOT recall.
 func TestChatHistoryRecallStillWorks(t *testing.T) {
 	m := tallChat(t, 60)
 	mm := asModel(m)
@@ -188,8 +189,8 @@ func TestChatHistoryRecallStillWorks(t *testing.T) {
 	mm.chatHist.cursor = len(mm.chatHist.entries)
 	m = mm
 	m, _ = m.Update(keyRecallPrev())
-	if got := asModel(m).chatIn.Value(); got != "recall me" {
-		t.Fatalf("ctrl+p should recall command history, got %q", got)
+	if got := asModel(m).chatIn.Value(); got != "" {
+		t.Fatalf("ctrl+p must not recall anymore, got %q", got)
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1865,7 +1865,7 @@ func (m model) onKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "ctrl+p":
 			// The PERMS key (founder respec 2026-07-14) - but tool approvals live in
 			// the AGENT, not the channel. Point there; Up/Down still recall history.
-			m.status = stDim.Render("tool approvals live in the AGENT - shift+tab (or 0) opens it, ctrl+p cycles /perms there")
+			m.status = stDim.Render("tool approvals live in the AGENT - shift+tab opens it, then ctrl+p cycles /perms")
 			return m, nil
 		case "ctrl+n":
 			// Recall a NEWER sent message; past the newest it restores the draft.
@@ -2114,12 +2114,7 @@ func (m model) onKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "w":
 			// w = web console: open this run's browser node console on demand - it no
 			// longer auto-opens at launch (founder respec 2026-07-14).
-			if m.hooks.ConsoleURL == "" {
-				m.status = stDim.Render("no web console this run - relaunch without --no-webui to serve it")
-				return m, nil
-			}
-			openURL(m.hooks.ConsoleURL)
-			m.status = stDim.Render("web console → ") + stKey.Render(m.hooks.ConsoleURL)
+			m.status = stDim.Render(m.openConsole())
 			return m, nil
 		case "/", ":":
 			m.mode = modeCommand
@@ -2395,12 +2390,7 @@ func (m model) runSession(line string) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "webui", "console":
 		// /webui: open this run's browser node console on demand (same as `w` in BROWSE).
-		if m.hooks.ConsoleURL == "" {
-			sysLine("no web console this run - relaunch without --no-webui to serve it")
-			return m, nil
-		}
-		openURL(m.hooks.ConsoleURL)
-		sysLine("web console → " + m.hooks.ConsoleURL)
+		sysLine(m.openConsole())
 		return m, nil
 	case "help", "h", "?", "commands":
 		// Keep this listing in lock-step with what runSession actually accepts (incl. the
@@ -2500,12 +2490,7 @@ func (m model) run(cmd string) (tea.Model, tea.Cmd) {
 		m.status = stDim.Render("support: ") + stKey.Render(supportURL) + stDim.Render(" - community + Discord on the site")
 	case "webui", "console":
 		// /webui: open this run's browser node console on demand (same as the `w` key).
-		if m.hooks.ConsoleURL == "" {
-			m.status = stDim.Render("no web console this run - relaunch without --no-webui to serve it")
-			return m, nil
-		}
-		openURL(m.hooks.ConsoleURL)
-		m.status = stDim.Render("web console → ") + stKey.Render(m.hooks.ConsoleURL)
+		m.status = stDim.Render(m.openConsole())
 	case "ping", "zen":
 		// fullscreen Ping World screensaver from the command palette (any key wakes).
 		return m.enterPingWorld()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -54,6 +54,10 @@ type Hooks struct {
 	// rename updates it live + persists via SaveStation.
 	Station     string
 	SaveStation func(station string) // persist a station rename (nil = in-session only; the TUI does no disk I/O)
+	// ConsoleURL is the tokenized URL of this run's browser node console ("" = no
+	// console this run, e.g. --no-webui). The console no longer auto-opens at launch
+	// (founder respec 2026-07-14); `w` in BROWSE and /webui in AGENT open it on demand.
+	ConsoleURL string
 	HW          string               // hardware label for the offer
 	GitHubID    string               // public GitHub OAuth client id (device flow)
 	LinkedLogin string               // the locally-linked GitHub login at startup ("" = anonymous)
@@ -1859,12 +1863,9 @@ func (m model) onKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.chatVP.GotoBottom()
 			return m, nil
 		case "ctrl+p":
-			// Shell-style recall: an OLDER sent message (stashing the live draft on
-			// the first press). Guarded to modeChat (the input is focused here).
-			if v, ok := m.chatHist.prev(m.chatIn.Value()); ok {
-				m.chatIn.SetValue(v)
-				m.chatIn.CursorEnd()
-			}
+			// The PERMS key (founder respec 2026-07-14) - but tool approvals live in
+			// the AGENT, not the channel. Point there; Up/Down still recall history.
+			m.status = stDim.Render("tool approvals live in the AGENT - shift+tab (or 0) opens it, ctrl+p cycles /perms there")
 			return m, nil
 		case "ctrl+n":
 			// Recall a NEWER sent message; past the newest it restores the draft.
@@ -2110,6 +2111,16 @@ func (m model) onKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "z":
 			// z = zone out: drop into the fullscreen Ping World screensaver (any key wakes).
 			return m.enterPingWorld()
+		case "w":
+			// w = web console: open this run's browser node console on demand - it no
+			// longer auto-opens at launch (founder respec 2026-07-14).
+			if m.hooks.ConsoleURL == "" {
+				m.status = stDim.Render("no web console this run - relaunch without --no-webui to serve it")
+				return m, nil
+			}
+			openURL(m.hooks.ConsoleURL)
+			m.status = stDim.Render("web console → ") + stKey.Render(m.hooks.ConsoleURL)
+			return m, nil
 		case "/", ":":
 			m.mode = modeCommand
 			m.cmd.Focus()
@@ -2382,6 +2393,15 @@ func (m model) runSession(line string) (tea.Model, tea.Cmd) {
 		openURL(supportURL)
 		sysLine("support: " + supportURL + " · community + Discord on the site")
 		return m, nil
+	case "webui", "console":
+		// /webui: open this run's browser node console on demand (same as `w` in BROWSE).
+		if m.hooks.ConsoleURL == "" {
+			sysLine("no web console this run - relaunch without --no-webui to serve it")
+			return m, nil
+		}
+		openURL(m.hooks.ConsoleURL)
+		sysLine("web console → " + m.hooks.ConsoleURL)
+		return m, nil
 	case "help", "h", "?", "commands":
 		// Keep this listing in lock-step with what runSession actually accepts (incl. the
 		// aliases), so no real command is hidden from /? (the short help; /help + /commands alias it).
@@ -2478,6 +2498,14 @@ func (m model) run(cmd string) (tea.Model, tea.Cmd) {
 		// either way as the fallback.
 		openURL(supportURL)
 		m.status = stDim.Render("support: ") + stKey.Render(supportURL) + stDim.Render(" - community + Discord on the site")
+	case "webui", "console":
+		// /webui: open this run's browser node console on demand (same as the `w` key).
+		if m.hooks.ConsoleURL == "" {
+			m.status = stDim.Render("no web console this run - relaunch without --no-webui to serve it")
+			return m, nil
+		}
+		openURL(m.hooks.ConsoleURL)
+		m.status = stDim.Render("web console → ") + stKey.Render(m.hooks.ConsoleURL)
 	case "ping", "zen":
 		// fullscreen Ping World screensaver from the command palette (any key wakes).
 		return m.enterPingWorld()
@@ -4552,6 +4580,7 @@ var paletteCmds = []paletteCmd{
 	{"/config", "broker + identity", ""},
 	{"/compact", "minimize to the dense windowshade", "m · alt+m"},
 	{"/ping", "the Ping World screensaver", "z"},
+	{"/webui", "open the browser node console", "w"},
 	{"/support", "rogerai.fyi - community + Discord", ""},
 	{"/help", "the full operating manual", "?"},
 	{"/log", "node + broker messages", ""},
@@ -8567,6 +8596,7 @@ func (m model) helpView() string {
 		{"F/C/O", "filters: free-now / confidential / on-air"},
 		{"m  ·  alt+m", "MINIMIZE to the dense compact windowshade · alt+m (or /compact) works from anywhere, even mid-chat"},
 		{"z", "SCREENSAVER: zone out to Ping's world (fullscreen, any key wakes) · also /ping"},
+		{"w", "WEB CONSOLE: open this station's browser console (it no longer auto-opens at launch)"},
 		{"esc (in a channel)", "disconnect - leave the channel, back to the band"},
 		{"q (browsing)", "quit RogerAI"},
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2406,7 +2406,7 @@ func (m model) runSession(line string) (tea.Model, tea.Cmd) {
 		// Keep this listing in lock-step with what runSession actually accepts (incl. the
 		// aliases), so no real command is hidden from /? (the short help; /help + /commands alias it).
 		sysLine("/agent (run the agent on this model) · /model (/tune /retune) · /clear · /save · /system <p> · /cost · /stats (/detail) · /confidential (/conf)")
-		sysLine("/connect (/conn) · /endpoint (/ep) · /copy (/y) [all] · /mouse · /compact (/min · alt+m) · /ping (/zen) · /support · /disconnect (/leave /dc) · /quit (/q) · /? (/help /h /commands)")
+		sysLine("/connect (/conn) · /endpoint (/ep) · /copy (/y) [all] · /mouse · /compact (/min · alt+m) · /ping (/zen) · /webui (/console) · /support · /disconnect (/leave /dc) · /quit (/q) · /? (/help /h /commands)")
 		sysLine("copy: DRAG to select any text (native) · ctrl+y last reply · /copy all  ·  scroll: PgUp/PgDn · arrows · ctrl+o for wheel")
 		sysLine("esc or /disconnect leaves this channel · /quit exits RogerAI · tab peeks at the band")
 		return m, nil

--- a/internal/tui/webui_perms_shortcut_test.go
+++ b/internal/tui/webui_perms_shortcut_test.go
@@ -56,6 +56,18 @@ func TestAgentCtrlPCyclesPerms(t *testing.T) {
 	press(permConfirm)
 }
 
+// TestAgentIdleHelpAdvertisesPermsKey: the founder's root complaint was that toggling
+// perms felt invisible. The idle help tail must name the ⌃p key next to the mode, so
+// the shortcut is discoverable without reading docs.
+func TestAgentIdleHelpAdvertisesPermsKey(t *testing.T) {
+	m := agentSeed(t, "http://broker.local")
+	m.agentBusy = false
+	v := stripANSI(m.agentView(120))
+	if !strings.Contains(v, "⌃p") {
+		t.Errorf("idle help should advertise the ⌃p perms key, got:\n%s", v)
+	}
+}
+
 // TestAgentCtrlPWorksMidTurn: the founder pain - toggling approvals while a turn runs
 // must apply NOW (the mode is an atomic the confirmer reads live), never queue.
 func TestAgentCtrlPWorksMidTurn(t *testing.T) {
@@ -68,6 +80,66 @@ func TestAgentCtrlPWorksMidTurn(t *testing.T) {
 	}
 	if len(m.agentQueued) != 0 {
 		t.Fatalf("ctrl+p must never queue, got %d queued", len(m.agentQueued))
+	}
+}
+
+// TestAgentCtrlPAtConfirmGate: ctrl+p at a pending tool-approval confirm cycles perms
+// (never the surprise DENY the confirm modal's default branch used to give). When the
+// escalated mode now auto-approves the pending tool, the gate resolves as approved -
+// the intuitive "stop asking me, allow this"; otherwise it cycles and stays pending.
+func TestAgentCtrlPAtConfirmGate(t *testing.T) {
+	// run_shell: confirm -> edits (still gated) -> all (auto-approved).
+	m := agentSeed(t, "http://broker.local")
+	resp := make(chan bool, 1)
+	m.agentPendingConfirm = &agentConfirm{tool: "run_shell", resp: resp}
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	m = asModel(out)
+	if got := agentPermMode(m.agent.perms.Load()); got != permEdits {
+		t.Fatalf("first ctrl+p at gate -> %v want edits", got)
+	}
+	if m.agentPendingConfirm == nil {
+		t.Fatal("edits does not cover run_shell - the gate must stay pending, not resolve")
+	}
+	if len(resp) != 0 {
+		t.Fatal("the pending tool must NOT be answered while still gated")
+	}
+	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	m = asModel(out)
+	if got := agentPermMode(m.agent.perms.Load()); got != permAll {
+		t.Fatalf("second ctrl+p -> %v want all", got)
+	}
+	if m.agentPendingConfirm != nil {
+		t.Fatal("auto-all covers run_shell - the gate should resolve, not linger")
+	}
+	if got := <-resp; !got {
+		t.Fatal("escalating past the tool's bar should APPROVE it, not deny")
+	}
+
+	// write_file is covered the moment we reach edits - one press approves.
+	m2 := agentSeed(t, "http://broker.local")
+	resp2 := make(chan bool, 1)
+	m2.agentPendingConfirm = &agentConfirm{tool: "write_file", resp: resp2}
+	out, _ = m2.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	m2 = asModel(out)
+	if m2.agentPendingConfirm != nil || len(resp2) != 1 || !<-resp2 {
+		t.Fatal("edits covers write_file - one ctrl+p should approve the gate")
+	}
+}
+
+// TestInstantCommandsAreRealCommands: every instantAgentCommand token must be a command
+// runAgentCommand actually dispatches - otherwise an instant token would fall through to
+// the model picker (the unknown-command default) instead of running now. Guards the two
+// parallel lists against drift (review finding).
+func TestInstantCommandsAreRealCommands(t *testing.T) {
+	for _, tok := range []string{"/perms", "/permissions", "/yolo", "/webui", "/console", "/web"} {
+		if !instantAgentCommand(tok) {
+			t.Fatalf("%s should classify as instant", tok)
+		}
+		m := agentSeed(t, "http://broker.local")
+		out, _ := m.runAgentCommand(tok)
+		if asModel(out).agentPicker {
+			t.Errorf("%s is instant but runAgentCommand did not handle it (fell to the model picker)", tok)
+		}
 	}
 }
 
@@ -128,8 +200,12 @@ func TestChatCtrlPNoLongerRecalls(t *testing.T) {
 	if got := asModel(m).chatIn.Value(); got != "a draft" {
 		t.Fatalf("ctrl+p must not touch the draft, got %q", got)
 	}
-	if s := stripANSI(asModel(m).status); !strings.Contains(s, "AGENT") {
-		t.Errorf("ctrl+p in chat should point at the AGENT, status = %q", s)
+	s := stripANSI(asModel(m).status)
+	if !strings.Contains(s, "AGENT") || !strings.Contains(s, "shift+tab") {
+		t.Errorf("ctrl+p in chat should point at the AGENT via shift+tab, status = %q", s)
+	}
+	if strings.Contains(s, "0 opens") || strings.Contains(s, "(or 0)") {
+		t.Errorf("chat has no 0-opens-agent binding - the hint must not claim it, status = %q", s)
 	}
 }
 

--- a/internal/tui/webui_perms_shortcut_test.go
+++ b/internal/tui/webui_perms_shortcut_test.go
@@ -1,0 +1,242 @@
+package tui
+
+// Founder spec (2026-07-14, session note):
+//   - ctrl+p is the PERMS key, not a history alias: in AGENT it cycles the tool-approval
+//     mode exactly like bare /perms (history recall stays on Up/Down; ctrl+n keeps its
+//     newer-recall alias). It works MID-TURN - the whole point is instant toggling.
+//   - /perms and /yolo typed mid-turn execute IMMEDIATELY instead of being parked in the
+//     prompt queue (the queued form fired late and cycled the mode unpredictably).
+//   - In the channel (chat) ctrl+p no longer recalls; it points at the AGENT instead.
+//   - The browser node console no longer auto-opens by default; `w` in BROWSE and /webui
+//     in AGENT open it on demand at Hooks.ConsoleURL.
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// fakeTTY makes openURL's interactive() gate pass and records every attempted browser
+// open, so a test can assert an open without spawning a process.
+func fakeTTY(t *testing.T) *[]string {
+	t.Helper()
+	origIn, origOut, origExec := stdinIsTTY, stdoutIsTTY, openURLExec
+	var opened []string
+	stdinIsTTY = func() bool { return true }
+	stdoutIsTTY = func() bool { return true }
+	openURLExec = func(url string) { opened = append(opened, url) }
+	t.Cleanup(func() { stdinIsTTY, stdoutIsTTY, openURLExec = origIn, origOut, origExec })
+	return &opened
+}
+
+// TestAgentCtrlPCyclesPerms: ctrl+p cycles confirm -> edits -> all -> confirm, with the
+// same visible feedback as /perms (masthead chip, loud ember on the full bypass).
+func TestAgentCtrlPCyclesPerms(t *testing.T) {
+	m := agentSeed(t, "http://broker.local")
+	if got := agentPermMode(m.agent.perms.Load()); got != permConfirm {
+		t.Fatalf("default mode = %v want confirm", got)
+	}
+	press := func(want agentPermMode) {
+		t.Helper()
+		out, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+		m = asModel(out)
+		if got := agentPermMode(m.agent.perms.Load()); got != want {
+			t.Fatalf("ctrl+p -> %v want %v", got, want)
+		}
+	}
+	press(permEdits)
+	if !strings.Contains(stripANSI(m.agentPermTag()), "auto-edits") {
+		t.Error("edits mode should chip the masthead")
+	}
+	press(permAll)
+	if !strings.Contains(stripANSI(strings.Join(m.agentLines, "\n")), "! tools auto-all") {
+		t.Error("the full bypass should print the loud ember line")
+	}
+	press(permConfirm)
+}
+
+// TestAgentCtrlPWorksMidTurn: the founder pain - toggling approvals while a turn runs
+// must apply NOW (the mode is an atomic the confirmer reads live), never queue.
+func TestAgentCtrlPWorksMidTurn(t *testing.T) {
+	m := agentSeed(t, "http://broker.local")
+	m.agentBusy = true
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	m = asModel(out)
+	if got := agentPermMode(m.agent.perms.Load()); got != permEdits {
+		t.Fatalf("mid-turn ctrl+p -> %v want edits", got)
+	}
+	if len(m.agentQueued) != 0 {
+		t.Fatalf("ctrl+p must never queue, got %d queued", len(m.agentQueued))
+	}
+}
+
+// TestPermsCommandBypassesQueue: typing /perms (or /yolo) mid-turn executes immediately
+// instead of parking in the prompt queue - the queued form fired after the turn and
+// cycled the mode unpredictably (screenshot: two "queued · /perms" then a late double
+// cycle through auto-all).
+func TestPermsCommandBypassesQueue(t *testing.T) {
+	m := agentSeed(t, "http://broker.local")
+	m.agentBusy = true
+	send := func(line string) {
+		t.Helper()
+		m.agentIn.SetValue(line)
+		out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m = asModel(out)
+	}
+	send("/perms")
+	if got := agentPermMode(m.agent.perms.Load()); got != permEdits {
+		t.Fatalf("mid-turn /perms -> %v want edits (must run now, not queue)", got)
+	}
+	if len(m.agentQueued) != 0 {
+		t.Fatalf("/perms must not be queued, got %d queued", len(m.agentQueued))
+	}
+	send("/yolo")
+	if got := agentPermMode(m.agent.perms.Load()); got != permAll {
+		t.Fatalf("mid-turn /yolo -> %v want all", got)
+	}
+	// A REAL prompt still queues while busy - the bypass is only for instant commands.
+	send("do the thing")
+	if len(m.agentQueued) != 1 {
+		t.Fatalf("a chat prompt should still queue mid-turn, got %d queued", len(m.agentQueued))
+	}
+}
+
+// TestInstantAgentCommandTable: the instant-command classifier, including the
+// defensive empty line (unreachable from the enter handler, which trims first).
+func TestInstantAgentCommandTable(t *testing.T) {
+	for line, want := range map[string]bool{
+		"/perms": true, "/permissions": true, "/yolo": true, "/perms all": true,
+		"/webui": true, "/console": true, "/web": true,
+		"/clear": false, "/model x": false, "do the thing": false, "": false, "   ": false,
+	} {
+		if got := instantAgentCommand(line); got != want {
+			t.Errorf("instantAgentCommand(%q) = %v want %v", line, got, want)
+		}
+	}
+}
+
+// TestChatCtrlPNoLongerRecalls: in the channel ctrl+p is not a recall alias anymore -
+// the draft stays put and the status points at the AGENT (Up/Down still recall).
+func TestChatCtrlPNoLongerRecalls(t *testing.T) {
+	m := tallChat(t, 5)
+	mm := asModel(m)
+	mm.chatHist.add("recall me")
+	mm.chatIn.SetValue("a draft")
+	m = mm
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if got := asModel(m).chatIn.Value(); got != "a draft" {
+		t.Fatalf("ctrl+p must not touch the draft, got %q", got)
+	}
+	if s := stripANSI(asModel(m).status); !strings.Contains(s, "AGENT") {
+		t.Errorf("ctrl+p in chat should point at the AGENT, status = %q", s)
+	}
+}
+
+// TestBrowseWOpensConsole: `w` in BROWSE opens the browser node console at the URL the
+// host wired into Hooks.ConsoleURL, and says so in the status line.
+func TestBrowseWOpensConsole(t *testing.T) {
+	opened := fakeTTY(t)
+	m := browseSeed(100)
+	m.hooks.ConsoleURL = "http://127.0.0.1:4180/?t=abc"
+	var tm tea.Model = m
+	tm, _ = tm.Update(keyMsg("w"))
+	if len(*opened) != 1 || (*opened)[0] != "http://127.0.0.1:4180/?t=abc" {
+		t.Fatalf("w should open the console URL once, got %v", *opened)
+	}
+	if s := stripANSI(asModel(tm).status); !strings.Contains(s, "4180") {
+		t.Errorf("status should show the console URL, got %q", s)
+	}
+}
+
+// TestBrowseWWithoutConsole: with no console this run (--no-webui), `w` explains
+// instead of silently doing nothing.
+func TestBrowseWWithoutConsole(t *testing.T) {
+	opened := fakeTTY(t)
+	m := browseSeed(100)
+	var tm tea.Model = m
+	tm, _ = tm.Update(keyMsg("w"))
+	if len(*opened) != 0 {
+		t.Fatalf("no console URL - nothing should open, got %v", *opened)
+	}
+	if s := stripANSI(asModel(tm).status); !strings.Contains(s, "no-webui") {
+		t.Errorf("status should explain how to get the console, got %q", s)
+	}
+}
+
+// TestBrowseWebuiCommand: the `/`-palette spelling works from BROWSE and the channel
+// runner too (with and without a console this run).
+func TestBrowseWebuiCommand(t *testing.T) {
+	opened := fakeTTY(t)
+	m := browseSeed(100)
+	m.hooks.ConsoleURL = "http://127.0.0.1:4180/?t=abc"
+	out, _ := m.run("webui")
+	if len(*opened) != 1 || (*opened)[0] != "http://127.0.0.1:4180/?t=abc" {
+		t.Fatalf("run(webui) should open the console URL, got %v", *opened)
+	}
+	if s := stripANSI(asModel(out).status); !strings.Contains(s, "4180") {
+		t.Errorf("status should show the console URL, got %q", s)
+	}
+	m2 := browseSeed(100)
+	out, _ = m2.run("console")
+	if len(*opened) != 1 {
+		t.Fatalf("no console URL - run(console) must not open, got %v", *opened)
+	}
+	if s := stripANSI(asModel(out).status); !strings.Contains(s, "no-webui") {
+		t.Errorf("status should explain how to get the console, got %q", s)
+	}
+	// The channel-session runner spelling too, both with and without a console.
+	mc := asModel(tallChat(t, 5))
+	mc.hooks.ConsoleURL = "http://127.0.0.1:4180/?t=abc"
+	mc.runSession("webui")
+	if len(*opened) != 2 {
+		t.Fatalf("runSession(webui) should open the console URL, got %v", *opened)
+	}
+	mc2 := asModel(tallChat(t, 5))
+	out, _ = mc2.runSession("console")
+	if len(*opened) != 2 {
+		t.Fatalf("no console URL - runSession(console) must not open, got %v", *opened)
+	}
+}
+
+// TestAgentWebuiCommand: /webui in AGENT opens the console (an instant command - it
+// also bypasses the mid-turn queue), /console is an alias, and the no-console run
+// explains itself.
+func TestAgentWebuiCommand(t *testing.T) {
+	opened := fakeTTY(t)
+	m := agentSeed(t, "http://broker.local")
+	m.hooks.ConsoleURL = "http://127.0.0.1:4180/?t=abc"
+	out, _ := m.runAgentCommand("/webui")
+	m = asModel(out)
+	if len(*opened) != 1 || (*opened)[0] != "http://127.0.0.1:4180/?t=abc" {
+		t.Fatalf("/webui should open the console URL, got %v", *opened)
+	}
+	out, _ = m.runAgentCommand("/console")
+	m = asModel(out)
+	if len(*opened) != 2 {
+		t.Fatalf("/console should alias /webui, got %v", *opened)
+	}
+
+	m2 := agentSeed(t, "http://broker.local")
+	out, _ = m2.runAgentCommand("/webui")
+	m2 = asModel(out)
+	if len(*opened) != 2 {
+		t.Fatalf("no console URL - /webui must not open, got %v", *opened)
+	}
+	joined := stripANSI(strings.Join(m2.agentLines, "\n"))
+	if !strings.Contains(joined, "no-webui") {
+		t.Errorf("/webui without a console should explain, lines:\n%s", joined)
+	}
+
+	// Mid-turn: /webui is instant, never queued.
+	m.agentBusy = true
+	m.agentIn.SetValue("/webui")
+	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = asModel(out)
+	if len(m.agentQueued) != 0 {
+		t.Fatalf("/webui must not queue mid-turn, got %d queued", len(m.agentQueued))
+	}
+	if len(*opened) != 3 {
+		t.Fatalf("mid-turn /webui should open now, got %v", *opened)
+	}
+}

--- a/internal/tui/webui_perms_shortcut_test.go
+++ b/internal/tui/webui_perms_shortcut_test.go
@@ -197,6 +197,12 @@ func TestBrowseWebuiCommand(t *testing.T) {
 	if len(*opened) != 2 {
 		t.Fatalf("no console URL - runSession(console) must not open, got %v", *opened)
 	}
+	// The /? short help stays in lock-step with what runSession accepts.
+	mh := asModel(tallChat(t, 5))
+	out, _ = mh.runSession("?")
+	if joined := stripANSI(strings.Join(asModel(out).transcript, "\n")); !strings.Contains(joined, "/webui") {
+		t.Errorf("/? should list /webui, got:\n%s", joined)
+	}
 }
 
 // TestAgentWebuiCommand: /webui in AGENT opens the console (an instant command - it


### PR DESCRIPTION
## What

- The browser node console **no longer auto-opens at launch** (under a terminal-embedded browser the auto-open trapped the TUI). The console still serves and prints its URL; `roger config set webui-open true` restores the launch auto-open, and `roger config get webui-open` / the bare listing report it.
- **Open it on demand instead**: `w` in BROWSE, `/webui` (alias `/console`) in the AGENT, channel, and command palette.
- **ctrl+p is the perms key**: it cycles the tool-approval mode (confirm → edits → all) with the masthead chip feedback - instantly, even mid-turn. In the channel it points at the AGENT instead of recalling.
- **Instant commands bypass the busy-turn queue**: `/perms`, `/yolo`, `/webui` execute immediately while a turn runs (queued `/perms` used to fire late and double-cycle the mode). Chat prompts still queue.
- History recall stays on Up/Down (ctrl+n keeps its newer-recall alias).

## Tests

Spec-first: 10 new specs (agent ctrl+p cycle + mid-turn, queue bypass matrix, chat ctrl+p, `w`/`/webui`/`/console` across all three runners with and without a console, config set/get/junk, console open-gating + bogus-port rescue, ConsoleURL threading through run()). Coverage: internal/tui 91.9%, cmd/rogerai 90.6%; `make cover-gate` PASS (total 92.0%). Live E2E: TUI boots with the console serving and zero browser opens by default; opt-in config path verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)