### PR TITLE
release: v5.3.9 prep (web console on demand + ctrl+p perms)

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -41,7 +41,7 @@ import (
 //
 // The default below is the fallback for a plain `go build`. Keep it in sync with
 // releases. Use semver, optionally with a prerelease suffix (e.g. 4.8.0-beta.1).
-var Version = "5.3.8"
+var Version = "5.3.9"
 
 // The production broker is the default - `rogerai` works out of the box, no config.
 // Override per-session with ROGER_BROKER=... or persist with `roger config set broker`.

--- a/web/src/manual.html
+++ b/web/src/manual.html
@@ -35,7 +35,7 @@
         </p>
         <div class="man-cover__meta">
           <span>Set: <b>rogerai</b></span>
-          <span>Version: <b data-cli-version>v5.3.8</b></span>
+          <span>Version: <b data-cli-version>v5.3.9</b></span>
           <span>Broker: <b>broker.rogerai.fyi</b></span>
           <span>Protocol: <b>OpenAI-compatible</b></span>
         </div>
@@ -921,7 +921,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
           <section class="man-sec" id="s9">
             <span class="man-sec__no">§9 · Command reference</span>
             <h2>Every command, every key</h2>
-            <p>The full surface as of <b data-cli-version>v5.3.8</b>: the top-level CLI
+            <p>The full surface as of <b data-cli-version>v5.3.9</b>: the top-level CLI
               commands with their key flags, then the in-app keys and slash commands grouped
               by context. Run any command with <code>--help</code> for its flags; advanced
               flags hide behind <code>--advanced</code>. Run <code>rogerai</code> with no
@@ -1201,6 +1201,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
               Newest first. The set self-updates - <code>roger upgrade</code> pulls the
               latest, <code>roger upgrade --check</code> just reports.</p>
             <div class="man-plate">
+              <div class="man-plate__row"><span class="man-plate__k">v5.3.9</span><span class="man-plate__v">The browser console opens on demand (<code>w</code> in the band view, <code>/webui</code> in the agent) instead of auto-opening at launch; <code>ctrl+p</code> cycles agent tool-approval mode (<code>/perms</code>) instantly, even mid-turn.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.3.8</span><span class="man-plate__v">Updates upgrade themselves: the notice is a banner in the band view, <code>u</code> installs right there (checksum-verified) and offers a one-key restart into the new version.</span></div>
             <div class="man-plate__row"><span class="man-plate__k">v5.3.7</span><span class="man-plate__v"><code>--yolo</code> / <code>--perms</code> launch flags and a persisted <code>roger perms</code> default for agent tool approvals, plus honest copy when a station hits an internal inference error.</span></div>
             <div class="man-plate__row"><span class="man-plate__k">v5.3.6</span><span class="man-plate__v"><code>/perms</code> permission modes (confirm / edits / all, plus <code>/yolo</code>), a <code>/model</code> pick that sticks, a scrollable HELP that opens at the top, a masked API key, single-ask tool confirms, and honest section badges.</span></div>


### PR DESCRIPTION
Bump the rogerai set to **v5.3.9** for the one CLI commit since v5.3.8 (#95): the browser console opens on demand (`w` / `/webui`) instead of auto-opening at launch, and `ctrl+p` cycles the agent tool-approval mode instantly, even mid-turn.

- `cmd/rogerai/main.go`: Version 5.3.8 → 5.3.9
- `web/src/manual.html`: both `data-cli-version` badges → v5.3.9, plus a new v5.3.9 row atop Appendix C

Tagging `v5.3.9` happens after this merges (triggers release.yml → gate → GoReleaser → package managers).