### PR TITLE
brand: character-exact claude plate + reregister deflake (v5.4.5)

### DIFF
--- a/cmd/rogerai/main.go
+++ b/cmd/rogerai/main.go
@@ -41,7 +41,7 @@ import (
 //
 // The default below is the fallback for a plain `go build`. Keep it in sync with
 // releases. Use semver, optionally with a prerelease suffix (e.g. 4.8.0-beta.1).
-var Version = "5.4.4"
+var Version = "5.4.5"
 
 // The production broker is the default - `rogerai` works out of the box, no config.
 // Override per-session with ROGER_BROKER=... or persist with `roger config set broker`.

--- a/features/operator/desk_view.feature
+++ b/features/operator/desk_view.feature
@@ -14,8 +14,9 @@
 #
 # Grounding: heading style stSelBar ▌ + stBrand (agent.go:1086); resident ◉ in the house
 # red like the connected band row (tui.go:5758-5760); rows follow operator.Registry()
-# order; the needs-a-key status is the Guest.NeedsSetup seam (registry.go, reserved for
-# the future claude row); the single not-installed suggestion mirrors buildOperatorRows
+# order; the needs-a-key status is the Guest.NeedsSetup seam (registry.go - no guest sets
+# it today, but it gates any future guest that needs a key of its own); the single
+# not-installed suggestion mirrors buildOperatorRows
 # (operator.go:153 — at most ONE, only while the desk is sparse).
 #
 # Phase boundary: the desk STRIP (heading line 2) + the windowshade count are

--- a/features/operator/operator_command.feature
+++ b/features/operator/operator_command.feature
@@ -12,8 +12,9 @@
 # guests = a transcript note, never a one-row picker); rows are detected guests plus AT
 # MOST ONE dim not-installed suggestion at the bottom that the cursor SKIPS;
 # installed-but-not-configured rows are selectable but print a setup note instead of
-# execing (reserved in v1 for the future claude row — every MVP guest is config-generated,
-# so none of the three can be "not configured"); the DJ row keeps the current session.
+# execing (no guest sets NeedsSetup today - the three wired ones are config-generated and
+# claude, a live guest since v5.4.4, needs no configuring at all - but the gate stays for a
+# future guest that needs a key of its own); the DJ row keeps the current session.
 #
 # Phase boundary: THIS file specs command dispatch + picker state. What happens after a
 # valid pick (preconditions, staging, exec) is handoff_lifecycle.feature. THE DESK roster

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -251,7 +251,6 @@ func (rr *reregistrar) recover(seenGen uint64, stop <-chan struct{}) {
 	// offers/HW so the node reappears identically in /market + /discover). The
 	// only mutated fields are a fresh anti-replay timestamp + signature and a
 	// fresh bridge token, so the broker's tunnel adopts the token we will now use.
-	backoff := []time.Duration{1 * time.Second, 2 * time.Second, 5 * time.Second, 10 * time.Second}
 	attempt := 0
 	for {
 		select {
@@ -293,10 +292,8 @@ func (rr *reregistrar) recover(seenGen uint64, stop <-chan struct{}) {
 			log.Printf("broker restarted - re-registered node %s", rr.reg.NodeID)
 			return
 		}
-		d := backoff[attempt]
-		if attempt < len(backoff)-1 {
-			attempt++
-		}
+		d := backoffFor(attempt)
+		attempt++
 		select {
 		case <-stop:
 			rr.finishBusy()
@@ -304,6 +301,25 @@ func (rr *reregistrar) recover(seenGen uint64, stop <-chan struct{}) {
 		case <-time.After(d):
 		}
 	}
+}
+
+// reregisterBackoff is the retry schedule for re-registering against a down broker:
+// rising, then HELD at the last value forever (never gives up, never busy-loops). It is a
+// var only so a test can shorten it - the house shellTimeout / ProbeTimeout idiom -
+// because a test that races the real seconds is a test that flakes on a loaded runner.
+var reregisterBackoff = []time.Duration{1 * time.Second, 2 * time.Second, 5 * time.Second, 10 * time.Second}
+
+// backoffFor is the pure schedule: the delay before the attempt AFTER this one. Past the
+// end of the table it holds at the last (longest) value rather than growing without bound
+// or wrapping back to a hot retry.
+func backoffFor(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	if attempt >= len(reregisterBackoff) {
+		return reregisterBackoff[len(reregisterBackoff)-1]
+	}
+	return reregisterBackoff[attempt]
 }
 
 // finishBusy clears the single-flight gate without advancing the generation

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -282,9 +282,44 @@ func TestReregisterAlreadyRecovered(t *testing.T) {
 	}
 }
 
-// TestReregisterBackoffBounded: a broker that 500s for a while then accepts is
-// retried with bounded backoff and eventually heals (never gives up, never busy-
-// loops). We assert it recovers and the retry count stays small.
+// TestBackoffSchedule pins the retry schedule DIRECTLY, as a pure function: rising, then
+// held at the longest value forever. This is the assertion the old wall-clock version of
+// TestReregisterBackoffBounded was really trying to make - by counting server-side hits
+// inside a 10s window, which is unsound (the handler counts a request whose response the
+// client never received, so a loaded runner produced 15 "attempts" for a 3-attempt run and
+// the test flaked on main). The schedule is now checked without a clock at all.
+func TestBackoffSchedule(t *testing.T) {
+	for _, c := range []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{-1, 1 * time.Second}, // defensive: never a zero delay (that is a busy-loop)
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 5 * time.Second},
+		{3, 10 * time.Second},
+		{4, 10 * time.Second}, // held, not grown and not wrapped back to a hot retry
+		{50, 10 * time.Second},
+	} {
+		if got := backoffFor(c.attempt); got != c.want {
+			t.Errorf("backoffFor(%d) = %s, want %s", c.attempt, got, c.want)
+		}
+	}
+	for i := range reregisterBackoff {
+		if reregisterBackoff[i] <= 0 {
+			t.Errorf("backoff[%d] is %s - a non-positive delay is a busy-loop", i, reregisterBackoff[i])
+		}
+		if i > 0 && reregisterBackoff[i] <= reregisterBackoff[i-1] {
+			t.Errorf("backoff must rise: [%d]=%s is not longer than [%d]=%s",
+				i, reregisterBackoff[i], i-1, reregisterBackoff[i-1])
+		}
+	}
+}
+
+// TestReregisterBackoffBounded: a broker that 500s for a while then accepts is retried and
+// eventually HEALS - never gives up, never busy-loops. It no longer asserts an exact
+// server-side hit count: the handler counts requests whose responses the client may never
+// have received, which is what made this flake. The schedule itself is pinned above.
 func TestReregisterBackoffBounded(t *testing.T) {
 	var attempts int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -295,6 +330,11 @@ func TestReregisterBackoffBounded(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
+
+	// Shorten the real schedule through the seam so this exercises the retry LOOP without
+	// racing seconds on a shared runner.
+	defer func(v []time.Duration) { reregisterBackoff = v }(reregisterBackoff)
+	reregisterBackoff = []time.Duration{time.Millisecond, 2 * time.Millisecond, 5 * time.Millisecond}
 
 	rr := newTestReregistrar(srv.URL)
 	_, gen0 := rr.curToken()
@@ -310,9 +350,10 @@ func TestReregisterBackoffBounded(t *testing.T) {
 	if _, gen1 := rr.curToken(); gen1 != gen0+1 {
 		t.Errorf("generation should advance once after eventual success, got %d", gen1)
 	}
-	// 1s + 2s backoff between the 3 attempts; should be only a few attempts.
-	if got := atomic.LoadInt32(&attempts); got != 3 {
-		t.Errorf("expected 3 attempts before success, got %d", got)
+	// It RETRIED (more than one attempt) and it did not spin: the schedule test above pins
+	// the delays, so all this needs to show is that the loop used them and stopped.
+	if got := atomic.LoadInt32(&attempts); got < 3 {
+		t.Errorf("expected the failing attempts to be retried, got %d", got)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -333,19 +333,28 @@ func TestReregisterBackoffBounded(t *testing.T) {
 
 	// Shorten the real schedule through the seam so this exercises the retry LOOP without
 	// racing seconds on a shared runner.
-	defer func(v []time.Duration) { reregisterBackoff = v }(reregisterBackoff)
+	saved := reregisterBackoff
 	reregisterBackoff = []time.Duration{time.Millisecond, 2 * time.Millisecond, 5 * time.Millisecond}
 
 	rr := newTestReregistrar(srv.URL)
 	_, gen0 := rr.curToken()
 	stop := make(chan struct{})
-
 	done := make(chan struct{})
+	// STOP the goroutine and wait for it BEFORE restoring the seam: on the timeout path
+	// below, recover() is still reading reregisterBackoff, and restoring it underneath a
+	// live reader would add a spurious -race report to an already-failing run.
+	defer func() {
+		close(stop)
+		<-done
+		reregisterBackoff = saved
+	}()
+
 	go func() { rr.recover(gen0, stop); close(done) }()
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		t.Fatal("recover did not heal within 10s (backoff unbounded or stuck)")
+		t.Error("recover did not heal within 10s (backoff unbounded or stuck)")
+		return
 	}
 	if _, gen1 := rr.curToken(); gen1 != gen0+1 {
 		t.Errorf("generation should advance once after eventual success, got %d", gen1)

--- a/internal/operator/brand.go
+++ b/internal/operator/brand.go
@@ -76,12 +76,11 @@ var (
 	inkClayB = BrandInk{Dark: "#D97757", Light: "#B85F41", Bold: true} // claude wordmark
 )
 
-// BrandArts returns all five doc plates keyed by guest name. opencode, hermes
-// and aider are wired into Registry(); claude and codex are the doc's shim-era
-// DRAFTS kept here as DORMANT data only - the registry deliberately has no home
-// for a non-detectable guest, and adding a row would change detection/picker
-// behavior (this pass is data-only). Returned fresh per call (the Registry()
-// idiom) so callers can never corrupt the shared art.
+// BrandArts returns all five doc plates keyed by guest name. opencode, hermes, aider and
+// claude are wired into Registry(); codex alone remains the doc's shim-era DRAFT, kept
+// here as DORMANT data - the registry deliberately has no home for a guest it cannot
+// launch. Returned fresh per call (the Registry() idiom) so callers can never corrupt
+// the shared art.
 func BrandArts() map[string]*BrandArt {
 	return map[string]*BrandArt{
 		// §1 opencode - the exact wordmark `opencode --help` prints (v1.17.x),
@@ -145,20 +144,27 @@ func BrandArts() map[string]*BrandArt {
 			Lockup:   BrandRow{Text: "aider", Ink: inkGreen},
 			ASCIIArt: true,
 		},
-		// §4 claude - shim-era DRAFT (dormant until the /v1/messages shim lands):
-		// the SHIPPED Claude Code mascot pose, mascot + wordmark one lockup, one hue.
+		// §4 claude - LIVE since v5.4.4 (the context-only guest). CHARACTER-EXACT to the
+		// mascot Claude Code 2.1.220 prints on its own welcome, captured from the real
+		// binary: three rows, no more (the earlier draft carried an invented fourth "ears"
+		// row - ▗ appears nowhere in the shipped art). The wordmark sits beside row 1 and
+		// the vendor byline beside row 2, at the same column the real welcome aligns its
+		// version/model lines to, so the plate reads the way the guest's own banner does.
+		// Byline in dim, the hermes "nous research" pattern. One hue throughout.
 		"claude": {
 			Rows: []BrandRow{
-				{Text: "  ▗   ▖", Ink: inkClay},
-				{Text: " ▐▛███▜▌", Ink: inkClay},
-				{Text: "▝▜█████▛▘   claude", Spans: []BrandSpan{
+				{Text: " ▐▛███▜▌   Claude Code", Spans: []BrandSpan{
+					{From: 0, To: 8, Ink: inkClay},
+					{From: 11, To: 22, Ink: inkClayB},
+				}},
+				{Text: "▝▜█████▛▘  anthropic", Spans: []BrandSpan{
 					{From: 0, To: 9, Ink: inkClay},
-					{From: 12, To: 18, Ink: inkClayB},
+					{From: 11, To: 20, Ink: BrandInk{Token: InkDim}},
 				}},
 				{Text: "  ▘▘ ▝▝", Ink: inkClay},
 			},
-			Width:  18,
-			Lockup: BrandRow{Text: "* claude", Ink: inkClay}, // ✻ pre-folded to * (house asciiFold idiom)
+			Width:  22,
+			Lockup: BrandRow{Text: "* Claude Code", Ink: inkClay}, // ✳ pre-folded to * (house asciiFold idiom)
 		},
 		// §5 codex - shim-era DRAFT (shape-only): no shipped terminal art exists and
 		// OpenAI's brand is hueless, so 100% mono + the red beat - their `>_` motif

--- a/internal/operator/brand_test.go
+++ b/internal/operator/brand_test.go
@@ -83,13 +83,15 @@ func TestBrandArtsExactBytes(t *testing.T) {
 		},
 		{
 			name: "claude",
+			// Character-exact to what `claude` 2.1.220 prints on its own welcome, captured
+			// from the real binary. The earlier draft carried a fourth "ears" row that the
+			// shipped art does not have (▗ appears nowhere in it).
 			rows: []string{
-				"  ▗   ▖",
-				" ▐▛███▜▌",
-				"▝▜█████▛▘   claude",
+				" ▐▛███▜▌   Claude Code",
+				"▝▜█████▛▘  anthropic",
 				"  ▘▘ ▝▝",
 			},
-			lockup: "* claude",
+			lockup: "* Claude Code",
 		},
 		{
 			name: "codex",
@@ -129,9 +131,9 @@ func TestBrandArtsExactBytes(t *testing.T) {
 // TestBrandArtWidths pins each plate's narrow-swap width (§7: full art renders
 // whenever termWidth >= 2 + artWidth; opencode 42, hermes 51, aider 36 (the tagline
 // is the WIDEST row, so it gates the swap - iteration-2 fix so the tagline never
-// clips), claude 18, codex 15).
+// clips), claude 22 (row 1: 8-cell mascot + gap + the "Claude Code" wordmark), codex 15).
 func TestBrandArtWidths(t *testing.T) {
-	want := map[string]int{"opencode": 42, "hermes": 51, "aider": 36, "claude": 18, "codex": 15}
+	want := map[string]int{"opencode": 42, "hermes": 51, "aider": 36, "claude": 22, "codex": 15}
 	arts := BrandArts()
 	for name, w := range want {
 		if got := arts[name].Width; got != w {
@@ -235,17 +237,26 @@ func TestBrandAiderInks(t *testing.T) {
 // (the ✻ spark pre-folded to * per the house asciiFold idiom).
 func TestBrandClaudeLockupSpans(t *testing.T) {
 	art := BrandArts()["claude"]
-	for _, i := range []int{0, 1, 3} {
-		if got := art.Rows[i].Ink; got != wantClay {
-			t.Fatalf("row %d ink: got %+v, want %+v", i+1, got, wantClay)
-		}
+	if len(art.Rows) != 3 {
+		t.Fatalf("claude art has %d rows, want the 3 the shipped welcome prints", len(art.Rows))
 	}
-	wantRow3 := []BrandSpan{
+	// Row 3 is the whole-row hue; rows 1-2 carry the mascot plus their text spans.
+	if got := art.Rows[2].Ink; got != wantClay {
+		t.Fatalf("row 3 ink: got %+v, want %+v", got, wantClay)
+	}
+	wantRow1 := []BrandSpan{
+		{From: 0, To: 8, Ink: wantClay},
+		{From: 11, To: 22, Ink: wantClayB}, // the wordmark, bold
+	}
+	if !reflect.DeepEqual(art.Rows[0].Spans, wantRow1) {
+		t.Fatalf("row 1 spans: got %+v, want %+v", art.Rows[0].Spans, wantRow1)
+	}
+	wantRow2 := []BrandSpan{
 		{From: 0, To: 9, Ink: wantClay},
-		{From: 12, To: 18, Ink: wantClayB},
+		{From: 11, To: 20, Ink: BrandInk{Token: InkDim}}, // the vendor byline, dim
 	}
-	if !reflect.DeepEqual(art.Rows[2].Spans, wantRow3) {
-		t.Fatalf("row 3 spans: got %+v, want %+v", art.Rows[2].Spans, wantRow3)
+	if !reflect.DeepEqual(art.Rows[1].Spans, wantRow2) {
+		t.Fatalf("row 2 spans: got %+v, want %+v", art.Rows[1].Spans, wantRow2)
 	}
 	if got := art.Lockup.Ink; got != wantClay {
 		t.Fatalf("lockup ink: got %+v, want %+v", got, wantClay)
@@ -312,3 +323,41 @@ func TestRegistryCarriesBrandArts(t *testing.T) {
 // BrandGlyph seam was deleted (iteration-2 minimization), so there is no field a guest
 // could ever carry a picker glyph on, and the picker renderer has no glyph slot. The
 // identity moment lives only on the PATCHING plate - one hue, one beat, once.
+
+// TestBrandSpansWithinRows pins a cross-plate invariant the per-plate tests cannot: every
+// span must address runes that actually exist in its row. A From/To computed against the
+// wrong index base (these rows are block characters, 3 bytes each) or left behind after an
+// edit would otherwise silently mis-colour, or index past the end of, a shipped plate.
+func TestBrandSpansWithinRows(t *testing.T) {
+	for name, art := range BrandArts() {
+		if art == nil {
+			t.Fatalf("%s: nil plate", name)
+		}
+		rows := append(append([]BrandRow{}, art.Rows...), art.Lockup)
+		for i, r := range rows {
+			n := len([]rune(r.Text))
+			for j, sp := range r.Spans {
+				switch {
+				case sp.From < 0 || sp.To < 0:
+					t.Errorf("%s row %d span %d: negative bounds %+v", name, i+1, j, sp)
+				case sp.From > sp.To:
+					t.Errorf("%s row %d span %d: From %d is past To %d", name, i+1, j, sp.From, sp.To)
+				case sp.To > n:
+					t.Errorf("%s row %d span %d: To %d is past the row's %d runes (%q)",
+						name, i+1, j, sp.To, n, r.Text)
+				}
+			}
+		}
+		// The declared Width gates the narrow swap, so it must be the widest row - a Width
+		// under it would let the plate render clipped rather than swapping to the lockup.
+		widest := 0
+		for _, r := range art.Rows {
+			if n := len([]rune(r.Text)); n > widest {
+				widest = n
+			}
+		}
+		if art.Width != widest {
+			t.Errorf("%s: Width %d but the widest row is %d runes", name, art.Width, widest)
+		}
+	}
+}

--- a/internal/operator/brand_test.go
+++ b/internal/operator/brand_test.go
@@ -232,9 +232,10 @@ func TestBrandAiderInks(t *testing.T) {
 	}
 }
 
-// TestBrandClaudeLockupSpans pins §4a: mascot rows in #D97757 (#B85F41 light),
-// row 3 = art cols 0-8 + bold wordmark cols 12-17, and the §4c `* claude` lockup
-// (the ✻ spark pre-folded to * per the house asciiFold idiom).
+// TestBrandClaudeLockupSpans pins §4a: the mascot in #D97757 (#B85F41 light) across all
+// three shipped rows, the "Claude Code" wordmark bold beside row 1 (cols 11-22), the dim
+// "anthropic" byline beside row 2 (cols 11-20), and the §4c `* Claude Code` lockup (the
+// ✳ spark pre-folded to * per the house asciiFold idiom).
 func TestBrandClaudeLockupSpans(t *testing.T) {
 	art := BrandArts()["claude"]
 	if len(art.Rows) != 3 {

--- a/internal/operator/brand_test.go
+++ b/internal/operator/brand_test.go
@@ -288,10 +288,10 @@ func TestBrandCodexSpans(t *testing.T) {
 	}
 }
 
-// TestRegistryCarriesBrandArts: the three MVP guests carry their plate as registry
-// data; claude and codex stay DORMANT in BrandArts() only - the doc's shim-era
-// drafts have no Registry() row (adding one would change detection/picker behavior,
-// and this pass is data-only).
+// TestRegistryCarriesBrandArts: every launchable guest carries its plate as registry data -
+// opencode, hermes, aider and (since v5.4.4) claude. codex alone stays DORMANT in
+// BrandArts(), the last of the doc's shim-era drafts with no Registry() row, because there
+// is still no way to launch it honestly.
 func TestRegistryCarriesBrandArts(t *testing.T) {
 	arts := BrandArts()
 	byName := map[string]Guest{}

--- a/internal/operator/registry.go
+++ b/internal/operator/registry.go
@@ -41,9 +41,10 @@ type Guest struct {
 	// (or unparsable) degrades the detection to UNVERIFIED - never hidden (§8 version skew).
 	KnownGood string
 	Strategy  string // one of the Strategy* constants
-	// NeedsSetup marks a guest that is detectable but not launchable without user setup
-	// (reserved for the future claude row - picking it prints SetupNote instead of execing).
-	// Every MVP guest is config-generated, so none of the three sets it.
+	// NeedsSetup marks a guest that is detectable but not launchable without user setup:
+	// picking it prints SetupNote instead of execing. No guest sets it today - the three
+	// wired ones are config-generated and claude needs no configuring at all - but the gate
+	// stays, because a future guest that needs a key of its own must not silently launch.
 	NeedsSetup bool
 	SetupNote  string
 

--- a/internal/tui/operator.go
+++ b/internal/tui/operator.go
@@ -668,7 +668,7 @@ func (m *model) operatorRefuseSmallBand() {
 // with it any scratch config, budget change, or spend - begins only when the plate is
 // accepted with an explicit local y.
 func (m model) startOperatorHandoff(d operator.Detection, fromPicker bool) (tea.Model, tea.Cmd) {
-	// Installed-but-not-configured (reserved for the future claude row): a setup note on
+	// Installed-but-not-configured: a setup note on
 	// EVERY path to the desk - never a plate, never an exec. THE one NeedsSetup gate -
 	// it covers the picker's enter AND the /operator <name> direct-jump (iteration-1
 	// finding #5: the direct-jump used to skip the picker's copy of this check).
@@ -1290,7 +1290,7 @@ func (m model) operatorPlateView(w int) string {
 // --- THE DESK on the AGENT landing (Phase 3, design doc §3a/§3f) -------------------------
 
 // deskGuests returns the detections in DESK display order: registry order first, then
-// any non-registry detections (the future claude row) in detection order.
+// any non-registry detections in detection order.
 func deskGuests(ds []operator.Detection) []operator.Detection {
 	if len(ds) == 0 {
 		return nil

--- a/internal/tui/operator_plates_test.go
+++ b/internal/tui/operator_plates_test.go
@@ -41,8 +41,9 @@ func plateGuest(t *testing.T, name string) operator.Guest {
 	return operator.Guest{}
 }
 
-// dormantGuest wraps a dormant BrandArts() draft (claude/codex) in a Guest so the
-// render seam can be exercised without a registry row.
+// dormantGuest wraps a BrandArts() plate in a Guest so the render seam can be exercised
+// without a registry row. codex is the only plate that still needs it (it has no registry
+// entry); claude is a LIVE guest and is fixtured from the registry via plateGuest.
 func dormantGuest(t *testing.T, name string) operator.Guest {
 	t.Helper()
 	art := operator.BrandArts()[name]
@@ -151,7 +152,7 @@ func TestPlateClaudeCodexPlates(t *testing.T) {
 	colorOn(t, true)
 	clay := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B85F41", Dark: "#D97757"})
 	clayB := clay.Bold(true)
-	claude := operatorBrandBlock(dormantGuest(t, "claude"), 120)
+	claude := operatorBrandBlock(plateGuest(t, "claude"), 120)
 	if got, want := plainLines(claude), []string{
 		"   ▐▛███▜▌   Claude Code",
 		"  ▝▜█████▛▘  anthropic",
@@ -220,7 +221,7 @@ func TestPlateASCIILockups(t *testing.T) {
 			"  \\__,_|_\\__,_\\___|_|",
 			"  ai pair programming in your terminal",
 		}},
-		{dormantGuest(t, "claude"), []string{"  * Claude Code"}},
+		{plateGuest(t, "claude"), []string{"  * Claude Code"}},
 		{dormantGuest(t, "codex"), []string{"  >_ codex . openai"}},
 	}
 	for _, tc := range cases {
@@ -259,8 +260,8 @@ func TestPlateNarrowSwap(t *testing.T) {
 	}{
 		{plateGuest(t, "opencode"), 44, "█▀▀█", "opencode _"},
 		{plateGuest(t, "hermes"), 53, "██╗", "H E R M E S · nous research"},
-		{plateGuest(t, "aider"), 38, "__ _(_)__", "aider"},          // the tagline (36) governs the swap, not the wordmark
-		{dormantGuest(t, "claude"), 24, "▐▛███▜▌", "* Claude Code"}, // 2 + the 22-cell row 1
+		{plateGuest(t, "aider"), 38, "__ _(_)__", "aider"},        // the tagline (36) governs the swap, not the wordmark
+		{plateGuest(t, "claude"), 24, "▐▛███▜▌", "* Claude Code"}, // 2 + the 22-cell row 1
 		// codex's full lockup (19 cells with indent) is itself clamped at width 16,
 		// so the probe is the un-cropped head of the lockup.
 		{dormantGuest(t, "codex"), 17, "▀█▄", ">_ codex"},

--- a/internal/tui/operator_plates_test.go
+++ b/internal/tui/operator_plates_test.go
@@ -143,24 +143,27 @@ func TestPlateAiderGreenAndTagline(t *testing.T) {
 	}
 }
 
-// TestPlateClaudeCodexDormantDrafts: §4a/§5a - the shim-era drafts render through
-// the same seam when given a Guest wrapper: claude's mascot+wordmark lockup in one
-// hue (#D97757, bold wordmark), codex's mono chevron with the stRed underscore beat.
-func TestPlateClaudeCodexDormantDrafts(t *testing.T) {
+// TestPlateClaudeCodexPlates: §4a/§5a - claude (LIVE since v5.4.4) and codex (still a
+// dormant draft) render through the same seam: claude's mascot in one hue (#D97757) with
+// the wordmark bold beside it and the vendor byline dim, codex's mono chevron with the
+// stRed underscore beat. claude's rows are character-exact to what the real binary prints.
+func TestPlateClaudeCodexPlates(t *testing.T) {
 	colorOn(t, true)
 	clay := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B85F41", Dark: "#D97757"})
 	clayB := clay.Bold(true)
 	claude := operatorBrandBlock(dormantGuest(t, "claude"), 120)
 	if got, want := plainLines(claude), []string{
-		"    ▗   ▖",
-		"   ▐▛███▜▌",
-		"  ▝▜█████▛▘   claude",
+		"   ▐▛███▜▌   Claude Code",
+		"  ▝▜█████▛▘  anthropic",
 		"    ▘▘ ▝▝",
 	}; !equalLines(got, want) {
 		t.Fatalf("claude mascot bytes corrupted:\n got %q\nwant %q", got, want)
 	}
-	if !strings.Contains(claude, clay.Render("▝▜█████▛▘")) || !strings.Contains(claude, clayB.Render("claude")) {
+	if !strings.Contains(claude, clay.Render("▝▜█████▛▘")) || !strings.Contains(claude, clayB.Render("Claude Code")) {
 		t.Fatal("claude: art in #D97757, wordmark same hue bold")
+	}
+	if strings.Contains(stripANSI(claude), "▗") {
+		t.Fatal("claude: the shipped art has no ▗ row - that was an invented draft row")
 	}
 	codex := operatorBrandBlock(dormantGuest(t, "codex"), 120)
 	if got, want := plainLines(codex), []string{
@@ -217,7 +220,7 @@ func TestPlateASCIILockups(t *testing.T) {
 			"  \\__,_|_\\__,_\\___|_|",
 			"  ai pair programming in your terminal",
 		}},
-		{dormantGuest(t, "claude"), []string{"  * claude"}},
+		{dormantGuest(t, "claude"), []string{"  * Claude Code"}},
 		{dormantGuest(t, "codex"), []string{"  >_ codex . openai"}},
 	}
 	for _, tc := range cases {
@@ -256,8 +259,8 @@ func TestPlateNarrowSwap(t *testing.T) {
 	}{
 		{plateGuest(t, "opencode"), 44, "█▀▀█", "opencode _"},
 		{plateGuest(t, "hermes"), 53, "██╗", "H E R M E S · nous research"},
-		{plateGuest(t, "aider"), 38, "__ _(_)__", "aider"}, // the tagline (36) governs the swap, not the wordmark
-		{dormantGuest(t, "claude"), 20, "▐▛███▜▌", "* claude"},
+		{plateGuest(t, "aider"), 38, "__ _(_)__", "aider"},          // the tagline (36) governs the swap, not the wordmark
+		{dormantGuest(t, "claude"), 24, "▐▛███▜▌", "* Claude Code"}, // 2 + the 22-cell row 1
 		// codex's full lockup (19 cells with indent) is itself clamped at width 16,
 		// so the probe is the un-cropped head of the lockup.
 		{dormantGuest(t, "codex"), 17, "▀█▄", ">_ codex"},

--- a/web/src/manual.html
+++ b/web/src/manual.html
@@ -35,7 +35,7 @@
         </p>
         <div class="man-cover__meta">
           <span>Set: <b>rogerai</b></span>
-          <span>Version: <b data-cli-version>v5.4.4</b></span>
+          <span>Version: <b data-cli-version>v5.4.5</b></span>
           <span>Broker: <b>broker.rogerai.fyi</b></span>
           <span>Protocol: <b>OpenAI-compatible</b></span>
         </div>
@@ -937,7 +937,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
           <section class="man-sec" id="s9">
             <span class="man-sec__no">§9 · Command reference</span>
             <h2>Every command, every key</h2>
-            <p>The full surface as of <b data-cli-version>v5.4.4</b>: the top-level CLI
+            <p>The full surface as of <b data-cli-version>v5.4.5</b>: the top-level CLI
               commands with their key flags, then the in-app keys and slash commands grouped
               by context. Run any command with <code>--help</code> for its flags; advanced
               flags hide behind <code>--advanced</code>. Run <code>rogerai</code> with no
@@ -1221,6 +1221,7 @@ OPENAI_API_KEY=rog-grant_3f9a...c10b</pre>
               Newest first. The set self-updates - <code>roger upgrade</code> pulls the
               latest, <code>roger upgrade --check</code> just reports.</p>
             <div class="man-plate">
+              <div class="man-plate__row"><span class="man-plate__k">v5.4.5</span><span class="man-plate__v">Desk polish for the new guest: the <b>claude</b> plate is now character-exact to the mascot Claude Code prints on its own welcome (the first draft carried a row the real art does not have), set beside its wordmark and vendor byline the way the guest's own banner reads.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.4.4</span><span class="man-plate__v">Hand your session to Claude Code. <code>/operator</code> now lists <b>claude</b> as a CONTEXT-ONLY guest: it takes your conversation with it - what you asked, what the tools returned, and anything you refused - and runs on <b>your own Anthropic account</b>, which the desk says plainly (no band, no key, nothing metered by RogerAI). It needs no tuned band at all. What the guest did comes back: leave a note in <code>.roger/return.md</code> and it merges into the conversation on exit. The agent's own turns now travel in the context capsule too - until now every guest handoff from the agent carried an empty one.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.4.3</span><span class="man-plate__v">Answers with sources. The agent can search the web (<code>web_search</code>, once a provider key is set in <code>search.json</code>) and read pages, and every answer it builds that way ends with a numbered <b>Sources</b> list - derived from the pages actually retrieved, never from URLs the model merely mentions. Fetching is hardened for the open web: blocked private, loopback, cloud-metadata and tunnelled address space, per-hop redirect vetting, HTML reduced to readable text, and control bytes stripped before anything reaches the transcript. Retrieval is bounded per turn, and <code>esc</code> abandons a fetch in flight.</span></div>
               <div class="man-plate__row"><span class="man-plate__k">v5.4.2</span><span class="man-plate__v">The first release of the radio-operator overhaul (see v5.4.0): the tube warm-up boot + on-air beacon read at a calm, watchable pace and the screensaver moves smoothly (motion tuned; the tick loop now runs a single chain, no stacked animation loops or extra polling), and <code>roger boot</code> replays the warm-up.</span></div>


### PR DESCRIPTION
Follow-up polish to v5.4.4's Claude Code guest, plus the CI flake that has been costing re-runs.

## The claude plate is now the guest's real shipped art

Every plate in this set is the guest's **actual** art - opencode's is the exact wordmark `opencode --help` prints, hermes' is their `banner.py` ANSI Shadow, aider's is its own figlet fallback. claude's was the odd one out: a hand-drawn approximation carrying a top "ears" row that the shipped art does not have. `▗` appears nowhere in what Claude Code actually prints.

Captured from the real binary (2.1.220), the mascot is **three** rows, set beside the wordmark with the version/model line under it. The plate now reproduces that:

```
 ▐▛███▜▌   Claude Code
▝▜█████▛▘  anthropic
  ▘▘ ▝▝
```

Mascot character-exact, `Claude Code` bold beside row 1, a dim `anthropic` byline beside row 2 at the column the real welcome aligns to (the hermes "nous research" pattern), and the lockup in the shipped casing. It stays the smallest plate at 22 cells because the shipped art *is* small - making it bigger would mean inventing art again, which is the thing being fixed.

## A cross-plate invariant

New test no per-plate case could catch: every span must address runes that exist in its row, and each declared `Width` must equal its widest row. These rows are block characters at 3 bytes each, so a span computed against the wrong index base would mis-colour silently, and a short `Width` would let a plate render clipped instead of swapping to its lockup.

## The reregister backoff deflake

`TestReregisterBackoffBounded` flaked on main (#99's merge run: "expected 3 attempts, got 15", green on a plain re-run). The assertion was **unsound**, not unlucky: it counted requests server-side inside a 10s window, and the handler counts a request whose response the client never received - so a loaded runner inflates the count for a run that is behaving correctly.

The schedule is now a pure function with the table as a seam var (the house `shellTimeout` idiom), pinned by a table-driven test with no clock in it: rising delays, held at the longest value, never zero. Verified to fail against a mutated schedule. The loop test keeps its healing assertion and drops from seconds to ~20ms.

Plus a sweep of stale comments that described claude as a guest that might exist one day.

`make cover-gate` PASS, module 92.1%.