### PR TITLE
license: dual-license the node-agent protocol + receipt SDK under Apache-2.0

### DIFF
--- a/LICENSE-APACHE-2.0
+++ b/LICENSE-APACHE-2.0
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,52 @@
+# Licensing
+
+RogerAI carries **two licenses side by side**. Which one applies depends on the file.
+
+| Part | License | Text |
+|---|---|---|
+| The **node-agent protocol** and the **usage-receipt SDK** | Apache License 2.0 | [`LICENSE-APACHE-2.0`](LICENSE-APACHE-2.0) |
+| Everything else (the broker, the marketplace, the CLI/TUI, the web surfaces) | PolyForm Perimeter 1.0.0 | [`LICENSE`](LICENSE) |
+
+## Why a carve-out
+
+Two different jobs. The protocol and the receipt format are **interoperability surfaces**:
+somebody writing their own node agent, or auditing what they were charged, has to be able to
+read, implement and re-implement them without asking anyone's permission. A non-OSI license
+there would make an open protocol a closed one in practice.
+
+The platform is the product, and it stays under PolyForm Perimeter, which permits use and
+modification but not building a competing service out of it.
+
+The two licenses **sit alongside each other** - the Apache grant does not extend to the rest
+of the repository, and the PolyForm terms do not restrict the Apache-licensed files.
+
+## Exactly which files
+
+Apache-2.0 applies to the files carrying an `SPDX-License-Identifier: Apache-2.0` header,
+and no others. Today that is:
+
+- `internal/protocol/protocol.go` - the wire types a node registers and serves with
+  (`ModelOffer`, `NodeRegistration` and its Ed25519 signing/verification), plus the
+  `UsageReceipt`: its canonical signing bytes, hash, and cost arithmetic.
+- `internal/protocol/auth.go` - the request-signing scheme a node or consumer uses to prove
+  who is spending. Without it the protocol above is not implementable against a real broker,
+  so it belongs to the same surface.
+
+Deliberately **not** carved out, though they live in the same package: `band.go` (private
+frequency codes) and `rc.go` (the remote-control wire) are platform features, not things a
+third-party node has to speak.
+
+`internal/protocol/license_carveout_test.go` pins this list, so a new file cannot drift into
+or out of the carve-out unnoticed.
+
+## Known limitation, being fixed
+
+The Apache files currently live under `internal/`, which Go forbids other modules from
+importing. The license is real, but to *use* it today you would have to copy the files rather
+than import them. Moving this surface to an importable path is a mechanical change that
+rewrites the import in ~230 files, so it is being done as its own focused change rather than
+folded in here. Until then, treat these files as the reference implementation of the format.
+
+## Third parties
+
+Vendored or referenced third-party code keeps its own license; nothing here changes it.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ go test ./...
 
 ## License
 
-[PolyForm Perimeter 1.0.0](LICENSE) - source-available, free for any non-competing use. You can
-self-host your own broker for your own community; you can't run it as a competing commercial
-marketplace service. See the LICENSE for the exact grant.
+Two licenses, side by side ([LICENSING.md](LICENSING.md) has the exact file list):
+
+- **The node-agent protocol and the usage-receipt SDK are [Apache-2.0](LICENSE-APACHE-2.0).**
+  Anyone can implement a compatible node, or verify what they were charged, without asking.
+  An interoperability surface only counts as open if it is actually open.
+- **Everything else is [PolyForm Perimeter 1.0.0](LICENSE)** - source-available, free for any
+  non-competing use. You can self-host your own broker for your own community; you can't run
+  it as a competing commercial marketplace service. See the LICENSE for the exact grant.

--- a/features/answers/web_search.feature
+++ b/features/answers/web_search.feature
@@ -76,6 +76,21 @@ Feature: web_search - the retrieval tool that finds sources
       Then the result is clipped to maxToolOutput and marked truncated
       # Same clip() contract as every other builtin.
 
+  Rule: provider text is cleaned before the model sees it
+
+    Scenario: markup in a snippet is stripped
+      Given the provider returns a snippet marked up with "<strong>" around the match
+      When the model calls web_search
+      Then the snippet reaches the model as plain text
+      And no markup tags survive
+      # Brave wraps query-term matches in <strong>. Passing that through spends the model's
+      # context on markup and hands an agent tag-shaped text it has no reason to trust.
+
+    Scenario: escaped entities are decoded
+      Given the provider returns a title containing "&amp;" and "&#39;"
+      When the model calls web_search
+      Then the title reaches the model with those characters decoded
+
   Rule: provider failures surface to the model as recoverable results, never crash the loop
 
     Scenario Outline: provider errors become tool results the model can react to

--- a/features/answers/web_search.feature
+++ b/features/answers/web_search.feature
@@ -86,6 +86,13 @@ Feature: web_search - the retrieval tool that finds sources
       # Brave wraps query-term matches in <strong>. Passing that through spends the model's
       # context on markup and hands an agent tag-shaped text it has no reason to trust.
 
+    Scenario: escaped markup cannot re-form into tags after decoding
+      Given the provider returns a snippet containing "&lt;strong&gt;"
+      When the model calls web_search
+      Then no markup tags survive
+      # Stripping runs before decoding, so a snippet that ESCAPES its markup would
+      # otherwise decode into tag-shaped text after the stripper had already gone past.
+
     Scenario: escaped entities are decoded
       Given the provider returns a title containing "&amp;" and "&#39;"
       When the model calls web_search

--- a/internal/harness/answers_live_e2e_test.go
+++ b/internal/harness/answers_live_e2e_test.go
@@ -21,13 +21,14 @@ package harness
 //	                    lack of a key: proves the degradation path (the turn still answers,
 //	                    with no sources) against the actual provider.
 //	search_fetch_cite   the full chain a real answer takes: the model searches, picks a
-//	                    result, fetches it, and cites it. The SEARCH RESULTS ARE REAL (live
-//	                    Wikipedia search over a real corpus) and the fetched page is real;
-//	                    only the response SHAPE is translated to Brave's by a local shim,
-//	                    because no Brave key exists on this machine. So this does NOT prove
-//	                    Brave's success-response parsing - that is covered by the unit and
-//	                    BDD suites against Brave's documented shape, and needs one live run
-//	                    with a real key to be closed out.
+//	                    result, fetches it, and cites it. When a Brave key is configured in
+//	                    search.json it runs against the REAL Brave API - which also proves
+//	                    the adapter's success-response parsing against the live shape. With
+//	                    no key it falls back to a local shim that performs a REAL search
+//	                    (live Wikipedia over a real corpus) and re-shapes the answer to
+//	                    Brave's format, so the chain is still exercised end to end; only the
+//	                    shape translation is stood in for, and the subtest says which mode
+//	                    it ran in.
 //
 // Env knobs: ROGER_E2E_BROKER (default https://broker.rogerai.fyi), ROGER_E2E_MODEL (the
 // band to tune), ROGER_E2E_URL (the page fetch_and_cite reads).
@@ -108,12 +109,19 @@ func TestAnswersLiveE2E(t *testing.T) {
 		}
 	})
 
-	// The full chain, with REAL search results over a real corpus and a REAL fetched page.
+	// The full chain, with REAL search results and a REAL fetched page.
 	t.Run("search_fetch_cite", func(t *testing.T) {
-		shim := realSearchShim(t)
-		defer shim.Close()
-		restore := liveSearchConfig(t, shim.URL, "shim")
-		defer restore()
+		if key := configuredBraveKey(); key != "" {
+			t.Log("mode: REAL Brave API (a key is configured) - this also proves the adapter's success-response parsing")
+			restore := liveSearchConfig(t, braveDefaultEndpoint, key)
+			defer restore()
+		} else {
+			t.Log("mode: shim (no Brave key configured) - real search results, Brave's shape stood in for")
+			shim := realSearchShim(t)
+			defer shim.Close()
+			restore := liveSearchConfig(t, shim.URL, "shim")
+			defer restore()
+		}
 
 		res := liveTurn(t, broker, model, liveResearchPersona,
 			"Search the web for the Valkey project, then read the most relevant result and "+
@@ -226,6 +234,27 @@ func liveTurn(t *testing.T, broker, model, persona, ask string) liveResult {
 	return res
 }
 
+// configuredBraveKey returns the key from the operator's REAL search.json, or "" when
+// answers mode is not configured on this machine. It is what lets the chain subtest run
+// against the live provider here and still be runnable on a box with no key.
+func configuredBraveKey() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".config", "rogerai", "search.json"))
+	if err != nil {
+		return ""
+	}
+	var cfg struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Key)
+}
+
 // liveSearchConfig points the search adapter at endpoint for the duration of a subtest. It
 // copies the REAL config dir (so the broker still sees the real signing identity) into a
 // temp XDG_CONFIG_HOME and adds search.json there, rather than writing into the user's live
@@ -335,30 +364,16 @@ func realSearchShim(t *testing.T) *httptest.Server {
 			out.Web.Results = append(out.Web.Results, braveResult{
 				Title: s.Title,
 				URL:   "https://en.wikipedia.org/wiki/" + strings.ReplaceAll(s.Title, " ", "_"),
-				// Wikipedia snippets carry markup; strip it the crude way (the adapter
-				// flattens whitespace itself, which is the behavior under test).
-				Description: stripTags(s.Snippet),
+				// Wikipedia snippets carry <span> highlights, exactly as Brave carries
+				// <strong> ones - so the shim hands them over raw and lets the ADAPTER's
+				// own cleaning (flatten) be what is under test.
+				Description: s.Snippet,
 			})
 		}
 		t.Logf("shim: real search for %q returned %d results", q, len(out.Web.Results))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(out)
 	}))
-}
-
-// stripTags removes the <span> markup Wikipedia wraps match highlights in.
-func stripTags(s string) string {
-	for {
-		i := strings.IndexByte(s, '<')
-		if i < 0 {
-			return s
-		}
-		j := strings.IndexByte(s[i:], '>')
-		if j < 0 {
-			return s[:i]
-		}
-		s = s[:i] + s[i+j+1:]
-	}
 }
 
 // envOr returns the env var or a default.

--- a/internal/harness/answers_live_e2e_test.go
+++ b/internal/harness/answers_live_e2e_test.go
@@ -238,11 +238,13 @@ func liveTurn(t *testing.T, broker, model, persona, ask string) liveResult {
 // answers mode is not configured on this machine. It is what lets the chain subtest run
 // against the live provider here and still be runnable on a box with no key.
 func configuredBraveKey() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
+	// Mirror searchConfigPath: os.UserConfigDir, not a hardcoded ~/.config, or the real-Brave
+	// mode would silently never trigger on macOS despite a configured key.
+	dir, err := os.UserConfigDir()
+	if err != nil || dir == "" {
 		return ""
 	}
-	b, err := os.ReadFile(filepath.Join(home, ".config", "rogerai", "search.json"))
+	b, err := os.ReadFile(filepath.Join(dir, "rogerai", "search.json"))
 	if err != nil {
 		return ""
 	}

--- a/internal/harness/search.go
+++ b/internal/harness/search.go
@@ -212,8 +212,15 @@ func renderResults(rs []searchResult) string {
 // title or snippet would forge an extra "[n] Title / URL" pair that the citation reader
 // would then bind to somebody else's URL.
 func flatten(s string) string {
-	return strings.Join(strings.Fields(html.UnescapeString(stripTags(s))), " ")
+	// Strip, then decode, then NEUTRALIZE what decoding may have re-formed: a snippet
+	// carrying &lt;strong&gt; would otherwise decode into literal tag-shaped text after the
+	// stripper had already run. Decoding first instead would eat legitimate prose ("a < b"),
+	// so the angle brackets are blanked rather than the order reversed.
+	return strings.Join(strings.Fields(angleBrackets.Replace(html.UnescapeString(stripTags(s)))), " ")
 }
+
+// angleBrackets blanks any angle bracket surviving the strip+decode pass.
+var angleBrackets = strings.NewReplacer("<", " ", ">", " ")
 
 // stripTags removes anything between angle brackets. Provider snippets are HTML fragments,
 // not documents, so this is deliberately blunt: no parser, no partial-tag ambiguity, and an

--- a/internal/harness/search.go
+++ b/internal/harness/search.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
@@ -202,8 +203,38 @@ func renderResults(rs []searchResult) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// flatten collapses all whitespace (including newlines) into single spaces.
-func flatten(s string) string { return strings.Join(strings.Fields(s), " ") }
+// flatten cleans one field of provider text: markup out, entities decoded, all whitespace
+// (including newlines) collapsed to single spaces.
+//
+// Brave wraps query-term matches in <strong>; a live run showed that reaching the model
+// verbatim. Markup spends context on nothing, and tag-shaped text handed to an agent is
+// worse than noise. The newline collapse is load-bearing separately: a newline inside a
+// title or snippet would forge an extra "[n] Title / URL" pair that the citation reader
+// would then bind to somebody else's URL.
+func flatten(s string) string {
+	return strings.Join(strings.Fields(html.UnescapeString(stripTags(s))), " ")
+}
+
+// stripTags removes anything between angle brackets. Provider snippets are HTML fragments,
+// not documents, so this is deliberately blunt: no parser, no partial-tag ambiguity, and an
+// unclosed "<" simply truncates there rather than leaking the rest as markup.
+func stripTags(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for {
+		i := strings.IndexByte(s, '<')
+		if i < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		b.WriteString(s[:i])
+		j := strings.IndexByte(s[i:], '>')
+		if j < 0 {
+			return b.String()
+		}
+		s = s[i+j+1:]
+	}
+}
 
 // braveSearch calls the Brave Search API once. NO retry: a 429 must not be answered by
 // hammering a rate-limited provider (the /discover incident's lesson).

--- a/internal/harness/websearch_bdd_test.go
+++ b/internal/harness/websearch_bdd_test.go
@@ -397,6 +397,14 @@ func (s *searchState) noMarkupSurvives() error {
 	return nil
 }
 
+func (s *searchState) providerReturnsEscapedMarkup(esc string) error {
+	s.results = []map[string]any{{
+		"title": "Valkey", "url": "https://valkey.io/",
+		"description": "Valkey is " + esc + "fast" + strings.Replace(esc, "&lt;", "&lt;/", 1),
+	}}
+	return s.callSearchQuery("escaped")
+}
+
 func (s *searchState) providerReturnsEntities(a, b string) error {
 	s.results = []map[string]any{{
 		"title": "Ben " + a + " Jerry" + b + "s", "url": "https://x.example/", "description": "snip",
@@ -704,6 +712,7 @@ func TestWebSearchBDD(t *testing.T) {
 			sc.Step(`^the provider returns a snippet marked up with "([^"]*)" around the match$`, st.providerReturnsMarkedUpSnippet)
 			sc.Step(`^the snippet reaches the model as plain text$`, st.snippetIsPlainText)
 			sc.Step(`^no markup tags survive$`, st.noMarkupSurvives)
+			sc.Step(`^the provider returns a snippet containing "([^"]*)"$`, st.providerReturnsEscapedMarkup)
 			sc.Step(`^the provider returns a title containing "([^"]*)" and "([^"]*)"$`, st.providerReturnsEntities)
 			sc.Step(`^the title reaches the model with those characters decoded$`, st.entitiesDecoded)
 			sc.Step(`^the provider returns a result with url "([^"]*)"$`, st.providerReturnsURL)

--- a/internal/harness/websearch_bdd_test.go
+++ b/internal/harness/websearch_bdd_test.go
@@ -370,6 +370,47 @@ func (s *searchState) atMostNResults(n int) error {
 	return nil
 }
 
+func (s *searchState) providerReturnsMarkedUpSnippet(tag string) error {
+	s.results = []map[string]any{{
+		"title": "Valkey", "url": "https://valkey.io/",
+		"description": "Valkey is " + tag + "an open source" + strings.Replace(tag, "<", "</", 1) + " datastore",
+	}}
+	return s.callSearchQuery("valkey")
+}
+
+func (s *searchState) snippetIsPlainText() error {
+	if s.err != nil {
+		return fmt.Errorf("web_search errored: %v", s.err)
+	}
+	if !strings.Contains(s.result, "Valkey is an open source datastore") {
+		return fmt.Errorf("the snippet text did not survive stripping: %q", s.result)
+	}
+	return nil
+}
+
+func (s *searchState) noMarkupSurvives() error {
+	for _, bad := range []string{"<strong>", "</strong>", "<", ">"} {
+		if strings.Contains(s.result, bad) {
+			return fmt.Errorf("markup %q reached the model: %q", bad, s.result)
+		}
+	}
+	return nil
+}
+
+func (s *searchState) providerReturnsEntities(a, b string) error {
+	s.results = []map[string]any{{
+		"title": "Ben " + a + " Jerry" + b + "s", "url": "https://x.example/", "description": "snip",
+	}}
+	return s.callSearchQuery("entities")
+}
+
+func (s *searchState) entitiesDecoded() error {
+	if !strings.Contains(s.result, "Ben & Jerry's") {
+		return fmt.Errorf("entities were not decoded: %q", s.result)
+	}
+	return nil
+}
+
 func (s *searchState) providerReturnsURL(u string) error {
 	s.results = append([]map[string]any{{"title": "bad scheme", "url": u, "description": "should be dropped"}}, s.results...)
 	return nil
@@ -660,6 +701,11 @@ func TestWebSearchBDD(t *testing.T) {
 			sc.Step(`^the model calls web_search with count ?(\d*)$`, st.callSearchCount)
 			sc.Step(`^at most (\d+) results are returned$`, st.atMostNResults)
 
+			sc.Step(`^the provider returns a snippet marked up with "([^"]*)" around the match$`, st.providerReturnsMarkedUpSnippet)
+			sc.Step(`^the snippet reaches the model as plain text$`, st.snippetIsPlainText)
+			sc.Step(`^no markup tags survive$`, st.noMarkupSurvives)
+			sc.Step(`^the provider returns a title containing "([^"]*)" and "([^"]*)"$`, st.providerReturnsEntities)
+			sc.Step(`^the title reaches the model with those characters decoded$`, st.entitiesDecoded)
 			sc.Step(`^the provider returns a result with url "([^"]*)"$`, st.providerReturnsURL)
 			sc.Step(`^the results are shaped$`, st.resultsAreShaped)
 			sc.Step(`^that result is dropped$`, st.badResultDropped)

--- a/internal/protocol/auth.go
+++ b/internal/protocol/auth.go
@@ -1,3 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 RogerAI
+//
+// This file is part of the RogerAI node-agent protocol + usage-receipt SDK, released
+// under the Apache License 2.0 so anyone can implement a compatible node or verify a
+// receipt independently. The rest of the RogerAI platform is licensed separately (see
+// LICENSING.md). Do not add platform logic to this file.
+
 package protocol
 
 import (

--- a/internal/protocol/license_carveout_test.go
+++ b/internal/protocol/license_carveout_test.go
@@ -23,7 +23,10 @@ var apacheFiles = map[string]bool{
 	"auth.go":     true,
 }
 
-const spdxApache = "// SPDX-License-Identifier: Apache-2.0"
+// spdxApache is SPLIT so this file does not contain the marker it searches for. Whole, it
+// would sit inside the scan window of its own source and make the guard flag itself the
+// moment the comment above shrank.
+const spdxApache = "// SPDX-License-Identifier: " + "Apache-2.0"
 
 func TestLicenseCarveout(t *testing.T) {
 	entries, err := os.ReadDir(".")

--- a/internal/protocol/license_carveout_test.go
+++ b/internal/protocol/license_carveout_test.go
@@ -33,7 +33,7 @@ func TestLicenseCarveout(t *testing.T) {
 	seen := map[string]bool{}
 	for _, e := range entries {
 		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+		if e.IsDir() || !strings.HasSuffix(name, ".go") {
 			continue
 		}
 		b, err := os.ReadFile(filepath.Clean(name))
@@ -45,6 +45,16 @@ func TestLicenseCarveout(t *testing.T) {
 			head = head[:600]
 		}
 		carved := strings.Contains(head, spdxApache)
+		if strings.HasSuffix(name, "_test.go") {
+			// Tests are never part of the published surface. A header here would claim a
+			// grant over code nobody receives, so it is always wrong - and skipping test
+			// files outright would have let one sit unnoticed.
+			if carved {
+				t.Errorf("%s is a test file carrying an Apache-2.0 header - tests are not part "+
+					"of the carve-out", name)
+			}
+			continue
+		}
 		seen[name] = true
 
 		switch {

--- a/internal/protocol/license_carveout_test.go
+++ b/internal/protocol/license_carveout_test.go
@@ -1,0 +1,78 @@
+package protocol
+
+// license_carveout_test.go pins the Apache-2.0 carve-out (see LICENSING.md). This package
+// deliberately holds files under TWO licenses: the node-agent protocol and the usage-receipt
+// SDK are Apache-2.0 so a third party can implement them; the private-band and
+// remote-control wires are platform features that stay under PolyForm.
+//
+// A per-file boundary is easy to drift across by accident - a new file, or new code appended
+// to the wrong one - and the drift is silent and legal, not a compile error. So the list is
+// pinned here: adding a file to this package fails until it is placed on one side or the
+// other DELIBERATELY, and the doc updated to match.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// apacheFiles are the files released under Apache-2.0. Keep in sync with LICENSING.md.
+var apacheFiles = map[string]bool{
+	"protocol.go": true,
+	"auth.go":     true,
+}
+
+const spdxApache = "// SPDX-License-Identifier: Apache-2.0"
+
+func TestLicenseCarveout(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		head := string(b)
+		if i := len(head); i > 600 {
+			head = head[:600]
+		}
+		carved := strings.Contains(head, spdxApache)
+		seen[name] = true
+
+		switch {
+		case apacheFiles[name] && !carved:
+			t.Errorf("%s is listed as Apache-2.0 in LICENSING.md but carries no SPDX header - "+
+				"the file is effectively platform-licensed", name)
+		case !apacheFiles[name] && carved:
+			t.Errorf("%s carries an Apache-2.0 SPDX header but is NOT in the carve-out list - "+
+				"either add it to LICENSING.md deliberately, or remove the header", name)
+		}
+	}
+	for name := range apacheFiles {
+		if !seen[name] {
+			t.Errorf("LICENSING.md claims %s is Apache-2.0, but the file is gone - "+
+				"the published carve-out now names something that does not exist", name)
+		}
+	}
+}
+
+// TestApacheLicenseTextPresent: the carve-out is only real if the license text ships with it.
+func TestApacheLicenseTextPresent(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("..", "..", "LICENSE-APACHE-2.0"))
+	if err != nil {
+		t.Fatalf("LICENSE-APACHE-2.0 is missing from the repo root: %v", err)
+	}
+	for _, want := range []string{"Apache License", "Version 2.0, January 2004", "TERMS AND CONDITIONS"} {
+		if !strings.Contains(string(b), want) {
+			t.Errorf("LICENSE-APACHE-2.0 does not look like the Apache 2.0 text (missing %q)", want)
+		}
+	}
+}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -1,3 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 RogerAI
+//
+// This file is part of the RogerAI node-agent protocol + usage-receipt SDK, released
+// under the Apache License 2.0 so anyone can implement a compatible node or verify a
+// receipt independently. The rest of the RogerAI platform is licensed separately (see
+// LICENSING.md). Do not add platform logic to this file.
+
 // Package protocol holds the shared types for RogerAI P0: model offers, node
 // registration, and the hash-chained, co-signed UsageReceipt that is the basis
 // of the "model-lineage guarantee" - every served request produces a receipt


### PR DESCRIPTION
Makes the licensing intent visible at the repo root, and closes the last gap in answers mode.

## Licensing

Executes the carve-out decided 2026-07-27: the **node-agent protocol and the usage-receipt SDK go Apache-2.0**, the platform stays **PolyForm Perimeter**, and the two **sit alongside each other** - the Apache grant does not reach the rest of the repo, and PolyForm does not restrict the carved files.

At the root, so the intent is visible without reading code:

- `LICENSE-APACHE-2.0` - the canonical text from apache.org
- `LICENSING.md` - the arrangement, the reasoning, and the exact file list
- `README.md` - now leads its License section with both

The boundary is drawn on **what a third party must be able to re-implement**:

| File | Why |
|---|---|
| `internal/protocol/protocol.go` | `ModelOffer`, `NodeRegistration` + Ed25519 signing/verification, and `UsageReceipt` with its canonical signing bytes, hash and cost arithmetic - the format you audit a charge against |
| `internal/protocol/auth.go` | the request-signing scheme that proves who is spending; without it the protocol above cannot be implemented against a real broker |

`band.go` (private frequency codes) and `rc.go` (the remote-control wire) stay PolyForm - platform features, not things a node has to speak.

A per-file boundary drifts **silently**: a new file, or platform logic appended to a carved one, is legal and invisible rather than a compile error. `license_carveout_test.go` fails if a file is claimed without the header, carries the header without being claimed, disappears from under the published list, or is a test file carrying one. Each arm was verified to actually fail.

**Stated plainly in LICENSING.md rather than glossed:** these files live under `internal/`, which Go forbids other modules from importing, so today you would have to copy them rather than import them. Moving the surface to an importable path rewrites the import in ~230 files and is its own focused change.

## Answers mode

The first live run against the real Brave API showed Brave wrapping query matches in `<strong>` and handing that straight to the model. Titles and snippets now have tags stripped and entities decoded - and a follow-up fix closes the case where escaped markup (`&lt;strong&gt;`) re-formed into tags *after* the stripper ran. The live chain test now runs against the real Brave endpoint whenever a key is configured, which also proves the adapter's success-response parsing against the live shape.

`make cover-gate` PASS. Every commit here passed the pre-push audit.