### PR TITLE
Sharpen Research and homepage positioning

### DIFF
--- a/web/src/company.html
+++ b/web/src/company.html
@@ -24,7 +24,7 @@
         <p class="research-hero__lead">
           RogerAI builds local-first inference infrastructure and open models for the
           hardware people and plants already own. We are based in Orange County,
-          California, independently owned, and not venture funded — which is why our
+          California, independently owned, and not venture funded. Our
           roadmap answers to the machines it runs on rather than to a growth curve.
         </p>
         <div class="research-actions">
@@ -149,14 +149,14 @@
         </div>
         <div class="research-prose">
           <p><b>Pilots, engagements, and press.</b> Model optimization, edge deployment,
-             benchmarking and model selection, and scoped on-premises pilots — plus press
+             benchmarking and model selection, and scoped on-premises pilots, plus press
              and partnership enquiries. <a href="mailto:labs@rogerai.fm">labs@rogerai.fm</a></p>
           <p><b>Security disclosure.</b> Report privately; please do not open a public issue.
              <a href="mailto:security@rogerai.fm">security@rogerai.fm</a> · <a href="/security.html">Policy</a></p>
           <p><b>Billing and accounts.</b> <a href="mailto:billing@rogerai.fm">billing@rogerai.fm</a> ·
              <b>Privacy.</b> <a href="mailto:privacy@rogerai.fm">privacy@rogerai.fm</a> ·
              <b>Legal.</b> <a href="mailto:legal@rogerai.fm">legal@rogerai.fm</a></p>
-          <p><b>The work itself.</b> The source is public and the notebook is open — reading
+          <p><b>The work itself.</b> The source is public and the notebook is open. Reading
              either tells you more than a sales call would.
              <a href="https://github.com/rogerai-fyi/roger">Source</a> ·
              <a href="/broadcasts.html">Open Air Waves</a></p>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- include: head.html title="RogerAI - a two-way radio for GPUs" desc="RogerAI is a two-way radio for GPUs. Local-AI enthusiasts put their self-hosted models on air; you tune in and pay per token on the CLI. curl -fsSL https://rogerai.fm/install.sh | sh" theme=inline css=site og=1 -->
+  <!-- include: head.html title="RogerAI - run models across local GPUs" desc="One OpenAI-compatible local endpoint for models running across community and private hardware, with routing, failover, metering, and signed receipts." theme=inline css=site og=1 -->
 </head>
 <body data-onair="idle">
 
@@ -25,19 +25,19 @@
 
       <span class="hero__eyebrow" data-reveal>
         <span class="onair" aria-hidden="true">((<span class="onair__dot">•</span>))</span>
-        <span class="hero__callsign">ON AIR</span>
+        <span class="hero__callsign">ROGERAI</span>
         <span class="hero__sep" aria-hidden="true">·</span>
-        a two-way radio for GPUs
+        local inference infrastructure
       </span>
 
       <h1 class="hero__title" data-reveal data-reveal-delay="60">
-        Tune in to the world's<br /><span class="hero__op">home GPUs</span>.<br /><span class="hero__fast">In under 30 seconds.</span>
+        Run models through<br /><span class="hero__op">one local endpoint</span>.<br /><span class="hero__fast">On hardware you choose.</span>
       </h1>
 
       <p class="hero__sub" data-reveal data-reveal-delay="120">
-        Operators put their self-hosted models <b>on air</b> - ham radio,
-        for LLMs. You <b>tune in</b> and pay per token on the CLI. No inbound
-        ports, no account to browse.
+        RogerAI connects OpenAI-compatible models across community and private
+        hardware. It handles discovery, routing, failover, metering, and signed
+        receipts. Operators keep control of their machines and open no inbound ports.
       </p>
 
       <!-- NEW hero order: headline -> subhead -> Ping (always-on concierge) ->
@@ -212,13 +212,12 @@
     <div class="wrap">
       <div class="demo__head" data-reveal>
         <span class="sectionno">§1 / OPERATING PROCEDURE</span>
-        <h2>Tune in. Use it. Go on air.</h2>
-        <p>One CLI does both sides of the radio: <b>borrow</b> a model from someone's
-          home GPU, or <b>lend</b> your own and get paid per token. Pick a tape below
-          and watch it run.</p>
-        <p class="demo__fine">Under the hood, tuning in hands your bots a local
-          <b>OpenAI-compatible endpoint + key</b> on <code class="inline">127.0.0.1</code> -
-          a drop-in for any tool that already speaks OpenAI.</p>
+        <h2>Use capacity. Provide capacity.</h2>
+        <p>One CLI lets you use a model on another machine or make your own
+          OpenAI-compatible model available at a rate you control.</p>
+        <p class="demo__fine">Your applications receive a local endpoint and scoped key at
+          <code class="inline">127.0.0.1</code>, compatible with tools that already use
+          the OpenAI API format.</p>
       </div>
 
       <span class="fig" aria-hidden="true">FIG. 3 - THE CONSOLE · DEMO REPLAY</span>
@@ -302,11 +301,9 @@
     <div class="wrap">
       <div class="market__head" data-reveal>
         <span class="sectionno">§2 / THE BAND</span>
-        <h2>Read the band.</h2>
-        <p>Every model is a band; every station is a home GPU serving it.
-          <b>More stations&nbsp;=&nbsp;stronger signal</b>, faster tokens, more choice.
-          Operators set their own rates. As a band fills or empties, prices
-          drift. An open market - real data only, no station no signal.</p>
+        <h2>Live capacity, price, and performance.</h2>
+        <p>Compare available models by station count, throughput, quality, and price.
+          Operators set their own rates, and the directory reports live data only.</p>
       </div>
 
       <div class="market__panel" data-reveal data-reveal-delay="80">
@@ -365,10 +362,9 @@
     <div class="wrap">
       <div class="section__head" data-reveal>
         <span class="sectionno">§3 / THE TUNE</span>
-        <h2>Home GPUs, on the air.</h2>
-        <p>An operator puts a model on the air at a price they set; you tune in and
-          pay per token; every token is lineage-tracked. Fair, private, and
-          dead-simple from either side.</p>
+        <h2>Two sides of the same network.</h2>
+        <p>Use remote model capacity through a local endpoint, or make an
+          OpenAI-compatible model available at a price and schedule you control.</p>
       </div>
 
       <div class="twoway" data-reveal data-reveal-delay="80">
@@ -483,7 +479,7 @@
     <div class="wrap monetize">
       <div class="monetize__copy" data-reveal>
         <span class="sectionno">§6 / MONETIZE</span>
-        <h2>Your GPU pays rent while you sleep.</h2>
+        <h2>Put idle GPU capacity to work.</h2>
         <p>Set a rate. Keep 70% of every token you serve. Or run open for free, plenty of
           stations broadcast for the love of the band.</p>
         <ul class="checks">
@@ -541,11 +537,11 @@
 
         <article class="company__card company__card--labs">
           <span class="company__label">ROGERAI LABS</span>
-          <h3>Open research that reaches the edge</h3>
-          <p>RogerAI Labs makes frontier-model optimization more accessible and
-            develops open model and inference work for edge, manufacturing,
-            industrial, and personal use. Open Air Waves publishes the evidence;
-            Wave models are the measured, device-first research program.</p>
+          <h3>Models for local constraints</h3>
+          <p>RogerAI Labs works across a clear size ladder: frontier-scale
+            optimization for workstations, Wave Nano for local text and tools,
+            Wave Micro for routing and extraction, and Roger Edge for sensing
+            and fixed commands. Each program exists for a specific hardware envelope.</p>
           <p class="company__links">
             <a href="/research.html">Explore Research</a>
             <a href="/broadcasts.html">Open Air Waves</a>
@@ -559,8 +555,8 @@
   <section class="cta">
     <div class="wrap cta__inner" data-reveal>
       <span class="sectionno">§8 / GO</span>
-      <h2>Pick up the mic.</h2>
-      <p>Install the CLI. One command to go on air, or to tune in.</p>
+      <h2>Start with the CLI.</h2>
+      <p>Install RogerAI to browse models, use capacity, or share your own.</p>
       <button class="install__box install__box--lg" id="installCmd2" type="button"
               aria-label="Copy install command to clipboard">
         <span class="install__prompt" aria-hidden="true">$</span>

--- a/web/src/research.html
+++ b/web/src/research.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- include: head.html title="RogerAI Research - open edge models and inference systems" desc="RogerAI Labs conducts open edge-model and inference research: reproducible model work for local hardware, ARM devices, and optional community routing." theme=external og=post ogtype=website ogtitle="RogerAI Research - open models for the devices people own" ogdesc="Open edge-model and inference research, with lineage, limitations, and raw evidence." ogurl="https://rogerai.fm/research.html" ogimage="https://rogerai.fm/og.png" -->
+  <!-- include: head.html title="RogerAI Research - models for local hardware" desc="RogerAI Labs builds and optimizes models for practical inference on local hardware, from workstations to embedded devices." theme=external og=post ogtype=website ogtitle="RogerAI Research - models for local hardware" ogdesc="Small models, local inference, and measured optimization work." ogurl="https://rogerai.fm/research.html" ogimage="https://rogerai.fm/og.png" -->
 </head>
 <body data-onair="idle">
   <div class="rail" aria-hidden="true">
-    <span class="rail__head">RogerAI · Research Notebook</span>
+    <span class="rail__head">RogerAI · Research</span>
     <span class="rail__rev">Rev. 2026.07 · LABS</span>
   </div>
 
@@ -17,285 +17,138 @@
         <span class="hero__eyebrow">
           <span class="onair" aria-hidden="true">((<span class="onair__dot">•</span>))</span>
           <span class="hero__callsign">ROGERAI LABS</span>
-          <span class="hero__sep" aria-hidden="true">·</span>
-          public research notebook
         </span>
-        <h1>Open models for the devices people already own.</h1>
+        <h1>Models built for local constraints.</h1>
         <p class="research-hero__lead">
-          RogerAI Labs conducts independent model and inference research. We build
-          reproducible, local-first systems for CPUs, GPUs, phones, ARM boards, and
-          small embedded devices. The network is an option—not a condition of local use.
+          We make useful models smaller, faster, and easier to run on local hardware.
+          Every project has a specific job, a visible status, and evidence you can inspect.
         </p>
         <div class="research-actions">
-          <a class="research-button research-button--primary" href="#projects">Explore projects</a>
+          <a class="research-button research-button--primary" href="#models">Explore models</a>
           <a class="research-button" href="/broadcasts.html">Read the evidence</a>
-          <a class="research-button" href="https://github.com/rogerai-fyi/roger">View source</a>
+          <a class="research-button" href="https://huggingface.co/rogerai-fyi">View weights</a>
         </div>
       </div>
     </section>
 
     <aside class="research-distinction">
       <div class="wrap research-distinction__grid">
-        <div><span class="research-kicker">RESEARCH</span><b>This page</b> lists RogerAI research artifacts and active projects.</div>
-        <div><span class="research-kicker">THE LIVE BAND</span><b><a href="/models.html">/models.html</a></b> lists live broker stations.</div>
-        <p>Not every research artifact or project is currently served, and not every broker station is a RogerAI model.</p>
+        <div><span class="research-kicker">RESEARCH PROGRAMS</span><b>This page</b> shows model and optimization work.</div>
+        <div><span class="research-kicker">LIVE NETWORK MODELS</span><b><a href="/models.html">Models on air</a></b> are available through the network now.</div>
+        <p>A research program is not automatically a released model or a live network station.</p>
       </div>
     </aside>
 
-    <section class="section" id="projects">
+    <section class="section" id="models">
       <div class="wrap">
         <div class="section__head section__head--left">
-          <span class="sectionno">§1 / OPEN BUILDS · ACTIVE</span>
-          <h2>Work with the labels left on.</h2>
-          <p>Upstream lineage and unresolved gates stay visible. Optimization is not pretraining.</p>
+          <span class="sectionno">§1 / MODELS</span>
+          <h2>One model for each operating envelope.</h2>
+          <p>No Wave checkpoint has been released. Programs remain labeled as research or
+             design work until they pass their release gates.</p>
         </div>
-        <div class="research-grid">
-          <article class="research-card">
-            <header><span class="lineage lineage--optimized">Optimized by RogerAI</span><span class="status">ACTIVE</span></header>
-            <h3>DeepSeek-V4-Flash MTP</h3>
-            <p class="research-parent">Upstream parent: <a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash">DeepSeek-V4-Flash</a> · <a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/LICENSE">MIT License</a></p>
-            <p>Converter, runtime, MTP, benchmark, and artifact work for locally friendlier inference.</p>
-            <p>This is a project summary, not a stable model card: the published GGUF research builds have not passed the new RogerAI Labs release contract.</p>
-            <dl><div><dt>Evidence</dt><dd><a href="/broadcasts-deepseek-mtp-gguf.html">Engineering field note</a> · <a href="https://huggingface.co/rogerai-fyi/DeepSeek-V4-Flash-MTP-GGUF">research weights</a></dd></div><div><dt>Status</dt><dd>Research build</dd></div></dl>
+
+        <div class="model-list">
+          <article class="model-row">
+            <div class="model-row__identity">
+              <span class="status">RESEARCH BUILD</span>
+              <h3>DeepSeek-V4-Flash MTP</h3>
+              <p class="research-parent">Optimized by RogerAI · Upstream: DeepSeek-V4-Flash</p>
+            </div>
+            <div>
+              <span class="research-kicker">WHY IT EXISTS</span>
+              <p>Converter, runtime, MTP, and GGUF work for more practical local inference
+                 with a large upstream model.</p>
+              <div class="model-row__actions">
+                <a class="model-download" href="https://huggingface.co/rogerai-fyi/DeepSeek-V4-Flash-MTP-GGUF">Hugging Face</a>
+                <a class="model-note" href="/broadcasts-deepseek-mtp-gguf.html">Field note</a>
+              </div>
+            </div>
           </article>
-          <article class="research-card">
-            <header><span class="lineage lineage--optimized">Optimized by RogerAI</span><span class="status">IN PROGRESS</span></header>
-            <h3>Kimi-K3 on a 256 GB system</h3>
-            <p class="research-parent">Upstream parent: <a href="https://huggingface.co/moonshotai/Kimi-K3">Kimi-K3</a> · <a href="https://huggingface.co/moonshotai/Kimi-K3/blob/main/LICENSE">Kimi K3 License</a></p>
-            <p>Streaming REAP analysis, expert pruning, MXFP4 execution, conversion, and hardware-fit validation.</p>
-            <div class="research-caution"><b>Measured:</b> a paired 16,376-token held-out evaluation selected the per-head-truncated <code>A_log</code> interpretation; its NLL advantage had a bootstrap interval wholly above zero. Pruning quality and serialized fit gates remain unresolved.</div>
-            <dl><div><dt>Target</dt><dd>One 256 GB-class workstation</dd></div><div><dt>Status</dt><dd>Arithmetic resolved · no released checkpoint</dd></div></dl>
+
+          <article class="model-row">
+            <div class="model-row__identity">
+              <span class="status">IN PROGRESS</span>
+              <h3>Kimi-K3</h3>
+              <p class="research-parent">Optimized by RogerAI · Upstream: Kimi-K3</p>
+            </div>
+            <div>
+              <span class="research-kicker">WHY IT EXISTS</span>
+              <p>Test whether pruning, low-precision execution, and conversion can fit a
+                 frontier-scale upstream model on one high-memory workstation.</p>
+              <div class="model-row__actions">
+                <span class="model-download is-disabled" aria-disabled="true">Hugging Face · coming soon</span>
+              </div>
+            </div>
           </article>
-          <article class="research-card">
-            <header><span class="lineage lineage--research">Research</span><span class="status">IN PROGRESS</span></header>
-            <h3>Roger Wave Nano</h3>
-            <p class="research-parent"><b>Prototype parents:</b> Granite-4.0-350M for Tool · SmolLM2-360M-Instruct for Text/control · Apache-2.0</p>
-            <p>The unmodified bake-off is complete. A matched, fail-closed LoRA grid now tests whether Wave Nano becomes one combined Tool/Text model, two specialists, or no release.</p>
-            <dl><div><dt>Measured</dt><dd>Held-out BPB · F16/Q4 edge tasks · artifact bytes</dd></div><div><dt>Next gate</dt><dd>Expanded unseen suite, reviewed data, resume smoke, explicit training approval</dd></div></dl>
+
+          <article class="model-row">
+            <div class="model-row__identity">
+              <span class="status">IN PROGRESS</span>
+              <h3>Wave Nano</h3>
+              <p class="research-parent">About 350M parameters · Pi, phone, and edge computer</p>
+            </div>
+            <div>
+              <span class="research-kicker">WHY IT EXISTS</span>
+              <p>Bounded local text and tool use where a general cloud model adds unnecessary
+                 latency, cost, or exposure.</p>
+              <div class="model-row__actions">
+                <span class="model-download is-disabled" aria-disabled="true">Hugging Face · coming soon</span>
+              </div>
+            </div>
+          </article>
+
+          <article class="model-row">
+            <div class="model-row__identity">
+              <span class="status">IN DESIGN</span>
+              <h3>Wave Micro</h3>
+              <p class="research-parent">Under 100M parameters · ARM and NPU systems</p>
+            </div>
+            <div>
+              <span class="research-kicker">WHY IT EXISTS</span>
+              <p>Fast routing, extraction, and triage without carrying the memory and compute
+                 cost of a chat model.</p>
+              <div class="model-row__actions">
+                <span class="model-download is-disabled" aria-disabled="true">Hugging Face · coming soon</span>
+              </div>
+            </div>
+          </article>
+
+          <article class="model-row">
+            <div class="model-row__identity">
+              <span class="status">IN DESIGN</span>
+              <h3>Roger Edge</h3>
+              <p class="research-parent">KB to MB scale · Microcontrollers</p>
+            </div>
+            <div>
+              <span class="research-kicker">WHY IT EXISTS</span>
+              <p>Wake, voice activity, sensing, and fixed commands need reliable task models,
+                 not miniature chatbots.</p>
+              <div class="model-row__actions">
+                <span class="model-download is-disabled" aria-disabled="true">Hugging Face · coming soon</span>
+              </div>
+            </div>
           </article>
         </div>
       </div>
     </section>
 
-    <section class="section" id="wave">
-      <div class="wrap">
-        <div class="section__head section__head--left">
-          <span class="sectionno">§2 / THE WAVE FAMILY · IN DESIGN</span>
-          <h2>Small models, sized to the machine they live on.</h2>
-          <p>Wave is the RogerAI Labs model family for edge hardware. Every tier below is a
-             program with gates, not a product: no Wave checkpoint has been released, and no
-             tier ships until it passes the release contract on real devices.</p>
-        </div>
-        <figure class="wave-map" aria-labelledby="wave-map-title wave-map-caption">
-          <svg viewBox="0 0 1040 390" role="img">
-            <title id="wave-map-title">The Wave family from sensor endpoint to local multimodal system</title>
-            <desc>Roger Edge produces typed events. Wave Micro filters and routes them. Wave Nano reasons and calls approved tools. Wave Embed grounds Nano in local documents. Future Wave Vision and Audio models add local perception.</desc>
-            <defs>
-              <marker id="wave-arrow" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
-                <path d="M0 0L9 4.5L0 9Z" class="wave-map__arrowhead"/>
-              </marker>
-            </defs>
-            <path class="wave-map__flow" marker-end="url(#wave-arrow)" d="M200 142H280"/>
-            <path class="wave-map__flow" marker-end="url(#wave-arrow)" d="M466 142H546"/>
-            <path class="wave-map__support" marker-end="url(#wave-arrow)" d="M655 302V226"/>
-            <path class="wave-map__future" marker-end="url(#wave-arrow)" d="M736 142H816"/>
-
-            <g class="wave-map__node wave-map__node--edge">
-              <rect x="24" y="72" width="176" height="140" rx="4"/>
-              <text x="42" y="101" class="wave-map__eyebrow">SENSE · FIXED ACTIONS</text>
-              <text x="42" y="132" class="wave-map__name">Roger Edge</text>
-              <text x="42" y="158" class="wave-map__size">KB–MB · ESP32</text>
-              <text x="42" y="188" class="wave-map__job">wake · VAD · events</text>
-            </g>
-            <g class="wave-map__node">
-              <rect x="280" y="72" width="186" height="140" rx="4"/>
-              <text x="298" y="101" class="wave-map__eyebrow">FILTER · ROUTE</text>
-              <text x="298" y="132" class="wave-map__name">Wave Micro</text>
-              <text x="298" y="158" class="wave-map__size">&lt;100M · ARM/NPU</text>
-              <text x="298" y="188" class="wave-map__job">intent · extract · triage</text>
-            </g>
-            <g class="wave-map__node wave-map__node--active">
-              <rect x="546" y="60" width="190" height="164" rx="4"/>
-              <text x="564" y="92" class="wave-map__eyebrow">REASON · USE TOOLS</text>
-              <text x="564" y="126" class="wave-map__name">Wave Nano</text>
-              <text x="564" y="154" class="wave-map__size">~350M · Pi/phone/IPC</text>
-              <text x="564" y="184" class="wave-map__job">Tool + Text prototypes</text>
-              <text x="564" y="205" class="wave-map__state">first measured program</text>
-            </g>
-            <g class="wave-map__node wave-map__node--future">
-              <rect x="816" y="72" width="200" height="140" rx="4"/>
-              <text x="834" y="101" class="wave-map__eyebrow">SEE · HEAR</text>
-              <text x="834" y="132" class="wave-map__name">Wave VL + Audio</text>
-              <text x="834" y="158" class="wave-map__size">~0.3–2B · NPU/GPU</text>
-              <text x="834" y="188" class="wave-map__job">inspection · floor voice</text>
-            </g>
-            <g class="wave-map__node wave-map__node--support">
-              <rect x="546" y="278" width="190" height="94" rx="4"/>
-              <text x="564" y="307" class="wave-map__eyebrow">GROUND LOCALLY</text>
-              <text x="564" y="336" class="wave-map__name">Wave Embed</text>
-              <text x="564" y="358" class="wave-map__size">100–300M · local retrieval</text>
-            </g>
-          </svg>
-          <figcaption id="wave-map-caption">
-            <b>One local stack, separate contracts.</b> Sensors become typed events; Micro
-            filters; Nano reasons over approved context and tools. Retrieval, vision, and
-            audio earn their own models only when their own evaluations exist.
-          </figcaption>
-        </figure>
-        <div class="research-grid">
-          <article class="research-card">
-            <header><span class="lineage lineage--research">Program</span><span class="status">PROTOTYPE GRID DESIGNED</span></header>
-            <h3>Wave Nano</h3>
-            <p>Two ~350M-class prototypes now enter a matched adaptation grid:
-               Granite for typed tools and SmolLM2 for the text control. Both consume the same
-               example bytes and evaluation policy; neither may train until the data ledger,
-               expanded unseen suite, token budget, and approval are complete.</p>
-            <dl><div><dt>First jobs</dt><dd>Typed tools · bounded text transformation</dd></div><div><dt>Decision</dt><dd>One combined model, two specialists, or no v0 release</dd></div></dl>
-          </article>
-          <article class="research-card">
-            <header><span class="lineage lineage--research">Program</span><span class="status">IN DESIGN</span></header>
-            <h3>Wave Micro</h3>
-            <p>Sub-100M task specialists: classification, extraction, routing, intent, and
-               sensor-adjacent inference for NPUs and constrained ARM boards. Micro models do
-               one job each and publish their exact operating envelope — they are not chat
-               models shrunk until they fib.</p>
-            <dl><div><dt>First jobs</dt><dd>Intent, extraction, anomaly triage</dd></div><div><dt>Delivery</dt><dd>Quantized, per-device measured</dd></div></dl>
-          </article>
-          <article class="research-card">
-            <header><span class="lineage lineage--research">Roadmap</span><span class="status">AFTER NANO</span></header>
-            <h3>Wave Embed · Wave VL · Wave Audio</h3>
-            <p>Technical retrieval is the next high-leverage local component. Compact vision
-               and speech/audio variants open only after Nano and Micro prove the workflow.
-               Inspection and floor-voice claims require their own domain-shift and noise
-               evaluations.</p>
-            <dl><div><dt>Order</dt><dd>Nano · Micro/Embed · VL · Audio</dd></div></dl>
-          </article>
-        </div>
-        <p class="research-parent">Below the Wave line, <b>Roger Edge</b> covers
-           microcontroller-class artifacts — wake, VAD, fixed commands, sensing — described in
-           §4. An ESP32 gets a task model, not a language model.</p>
-      </div>
-    </section>
-
-    <section class="section research-tone">
+    <section class="section research-tone" id="principles">
       <div class="wrap research-split">
         <div>
-          <span class="sectionno">§3 / LINEAGE</span>
-          <h2>Four verbs, four claims.</h2>
-          <p>The badge describes the work RogerAI actually performed.</p>
-        </div>
-        <dl class="lineage-list">
-          <div><dt><span class="lineage">Trained by RogerAI</span></dt><dd>Pretrained by RogerAI from an initialized architecture.</dd></div>
-          <div><dt><span class="lineage">Adapted by RogerAI</span></dt><dd>Continually pretrained or post-trained by RogerAI.</dd></div>
-          <div><dt><span class="lineage">Optimized by RogerAI</span></dt><dd>Pruned, quantized, converted, or runtime-modified.</dd></div>
-          <div><dt><span class="lineage">Verified by RogerAI</span></dt><dd>Tested unchanged in the RogerAI harness.</dd></div>
-        </dl>
-      </div>
-    </section>
-
-    <section class="section" id="devices">
-      <div class="wrap">
-        <div class="section__head section__head--left">
-          <span class="sectionno">§4 / RUN ANYWHERE · PROVE EACHWHERE</span>
-          <h2>“Edge” is not one machine.</h2>
-          <p>Compatibility follows measurements, not memory-size guesses.</p>
-        </div>
-        <div class="device-grid">
-          <article class="device-card">
-            <span class="device-tier">WAVE · ARM LINUX</span>
-            <h3>Raspberry Pi</h3>
-            <p>Raspberry Pi evidence names the exact board and RAM, OS, runtime, format, quantization, and context.</p>
-            <p class="device-proof">Required record: cold load · peak memory · prompt speed · decode speed · temperature and throttling.</p>
-            <p>One Pi result is not generalized to every ARM device.</p>
-          </article>
-          <article class="device-card">
-            <span class="device-tier">WAVE · ACCELERATORS</span>
-            <h3>GPU and NPU</h3>
-            <p>Generic NPU support is not claimed from CPU or GPU evidence. Every NPU claim names the exact SoC and accelerator, compiled backend, full delegation, partial delegation, and CPU fallback.</p>
-          </article>
-          <article class="device-card device-card--wide">
-            <span class="device-tier">EDGE · MICROCONTROLLERS</span>
-            <h3>ESP32 and LILYGO T-Embed</h3>
-            <p>An ESP32 does not run a 350M Roger Wave model. Roger Edge artifacts are task-specific: wake, VAD, fixed commands, sensing, or vision—not open-ended generation or general speech recognition.</p>
-            <p>Wi-Fi-equipped boards such as a LILYGO T-Embed can keep allowlisted controls offline and, under configured consent, ask a nearby trusted Pi or phone before optional internet routing.</p>
-            <p>Remote results are structured data. Local firmware validates the action, typed arguments, nonce, expiry, and issuer. ESP32-P4 has no native Wi-Fi or Bluetooth; a wireless P4 artifact must name its companion C6 or other connectivity board.</p>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section" id="industry">
-      <div class="wrap">
-        <div class="section__head section__head--left">
-          <span class="sectionno">§5 / INDUSTRY · WHERE LOCAL MODELS GO TO WORK</span>
-          <h2>The data never wanted to leave the building.</h2>
-          <p>The industrial-IoT platform era proved it: cloud-first analytics died at the OT
-             firewall. Plants, warehouses, and field sites run separated, often air-gapped
-             networks — and that constraint is exactly where local models fit. These are the
-             deployment patterns RogerAI Labs builds and consults on.</p>
-        </div>
-        <div class="research-grid">
-          <article class="research-card">
-            <header><span class="research-kicker">MANUFACTURING</span></header>
-            <h3>Plant floor, without the cloud</h3>
-            <p>Operator copilots that troubleshoot from OEM manuals and site history on the
-               plant network. Alarm-flood triage in plain language — what changed before the
-               alarm, not another threshold. Maintenance-log and shift-note fusion that
-               classical time-series systems always ignored. Vision-model inspection at the
-               station, prompt-defined instead of a bespoke CV project.</p>
-          </article>
-          <article class="research-card">
-            <header><span class="research-kicker">WAREHOUSES &amp; LOGISTICS</span></header>
-            <h3>Docks, picks, and paperwork</h3>
-            <p>Natural-language queries over inventory and movement data. Vision checks at
-               dock doors and pick stations. Label, manifest, and delivery-document extraction
-               on a box that lives in the building. Shift-handover summaries a supervisor can
-               actually read.</p>
-          </article>
-          <article class="research-card">
-            <header><span class="research-kicker">ENERGY &amp; HEAVY ASSETS</span></header>
-            <h3>Ask the historian a question</h3>
-            <p>Conversational access to asset hierarchies and telemetry summaries — the
-               digital-twin front end without the platform tax. Anomaly explanation and
-               work-order drafting for rotating equipment, utilities, and fleets, on-premises.</p>
-          </article>
-          <article class="research-card">
-            <header><span class="research-kicker">DEFENSE &amp; PUBLIC SECTOR</span></header>
-            <h3>Air-gapped by design</h3>
-            <p>Document intelligence and assistant workloads on fully disconnected networks.
-               Local weights, signed artifacts, verifiable lineage, and no telemetry — the
-               deployment model is the security model. Suitable for regulated and classified
-               environments where cloud inference is not an option.</p>
-          </article>
-        </div>
-        <div class="research-caution">
-          <b>Patterns, not case studies.</b> RogerAI Labs does not name customers it does not
-          have, and keeps advisory models out of real-time control loops — closed-loop control
-          stays with deterministic systems. When a deployment produces publishable evidence,
-          it will appear in the notebook with numbers.
-        </div>
-      </div>
-    </section>
-
-    <section class="section research-tone" id="services">
-      <div class="wrap research-split">
-        <div>
-          <span class="sectionno">§6 / SERVICES</span>
-          <h2>The lab takes engagements.</h2>
-          <p>Consulting is how the research pays its power bill — and how the patterns above
-             meet real constraints. Small, self-contained, one problem at a time.</p>
+          <span class="sectionno">§2 / PROOF</span>
+          <h2>Claims follow measurements.</h2>
+          <p>Compact pages do not mean hidden evidence.</p>
         </div>
         <div class="research-prose">
-          <p><b>Model optimization engineering.</b> Quantization, pruning, and runtime fit for
-             your hardware — with measured quality deltas and error bars, never a lucky draw.</p>
-          <p><b>Edge deployment.</b> From a GPU workstation on the OT network to ARM boards and
-             microcontroller endpoints: sizing, runtimes, and honest device envelopes.</p>
-          <p><b>Benchmarking and model selection.</b> Same-harness comparisons across candidate
-             models on your workload, with raw results you keep.</p>
-          <p><b>Industrial pilots.</b> A scoped on-premises problem — inspection, triage,
-             document intelligence — delivered against the evaluation contract in §9.</p>
-          <p>Using RogerAI models never requires buying services, and services never require
-             the broker. Write to <a href="mailto:labs@rogerai.fm">labs@rogerai.fm</a>.</p>
+          <p><b>Reproducible.</b> Published measurements name the hardware, artifact,
+             runtime, settings, and raw results.</p>
+          <p><b>Honest lineage.</b> We distinguish training from adaptation, optimization,
+             and verification. Upstream work keeps its original name and license.</p>
+          <p><b>Durable.</b> Negative results remain available. Qualifying artifacts use
+             standard formats and runtimes.</p>
+          <p><b>Local first.</b> You may download and run qualifying artifacts locally.
+             Publishing through the RogerAI network is optional.</p>
         </div>
       </div>
     </section>
@@ -303,77 +156,46 @@
     <section class="section" id="developers">
       <div class="wrap">
         <div class="section__head section__head--left">
-          <span class="sectionno">§7 / DEVELOPERS</span>
-          <h2>Standard formats, standard runtimes.</h2>
-          <p>No proprietary runtime and no SDK moat: RogerAI artifacts ship in open formats and
-             run on the tools you already use.</p>
+          <span class="sectionno">§3 / DEVELOPERS</span>
+          <h2>From artifact to local endpoint.</h2>
+          <p>Released model cards will carry exact commands. The flow stays the same across
+             the family.</p>
         </div>
-        <div class="research-grid">
-          <article class="research-card">
-            <header><span class="research-kicker">RUN IT</span></header>
-            <h3>GGUF on llama.cpp</h3>
-            <p>Research builds publish as GGUF and serve with stock or lightly patched
-               llama.cpp; every card names the exact runtime, format, quantization, and
-               context it was measured with. Conversion and runtime patches are developed in
-               the open and offered upstream.</p>
-            <dl><div><dt>Weights</dt><dd><a href="https://huggingface.co/rogerai-fyi">huggingface.co/rogerai-fyi</a></dd></div><div><dt>Source</dt><dd><a href="https://github.com/rogerai-fyi">github.com/rogerai-fyi</a></dd></div></dl>
+        <div class="developer-steps">
+          <article class="developer-step">
+            <span class="developer-step__no">01</span>
+            <h3>Download</h3>
+            <p>Pull a released artifact and its model card from Hugging Face.</p>
+            <code>huggingface-cli download rogerai-fyi/&lt;model&gt;</code>
           </article>
-          <article class="research-card">
-            <header><span class="research-kicker">CHECK IT</span></header>
-            <h3>Reproduce the numbers</h3>
-            <p>Published results carry the serve command, settings, harness, and raw outputs.
-               If you cannot reproduce a number on the named hardware, that is a bug in the
-               release — report it and it gets fixed or retracted.</p>
+          <article class="developer-step">
+            <span class="developer-step__no">02</span>
+            <h3>Run locally</h3>
+            <p>Serve GGUF with llama.cpp as an OpenAI-compatible endpoint.</p>
+            <code>llama-server -m model.gguf --port 8080</code>
           </article>
-          <article class="research-card">
-            <header><span class="research-kicker">SHARE IT</span></header>
-            <h3>Put it on air — if you want</h3>
-            <p>Anything you run locally can optionally join the RogerAI network for discovery,
-               routing, payments, failover, and signed receipts. Local use never requires it.</p>
-            <dl><div><dt>Live stations</dt><dd><a href="/models.html">/models.html</a></dd></div></dl>
+          <article class="developer-step">
+            <span class="developer-step__no">03</span>
+            <h3>Reproduce</h3>
+            <p>Match the artifact version, hardware, runtime, and settings from the
+               published evaluation record.</p>
+            <code>git clone https://github.com/rogerai-fyi/roger</code>
           </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section research-tone" id="open">
-      <div class="wrap research-split">
-        <div>
-          <span class="sectionno">§8 / OPEN · REPRODUCIBLE</span>
-          <h2>Freedom needs receipts.</h2>
-          <p>Users may download and run qualifying open models locally. Publishing to RogerAI is optional.</p>
-        </div>
-        <div class="research-prose">
-          <p><b>Open weights</b> means weights are available under their stated terms. Open Source AI requires the published RogerAI reproducibility checklist: weights, source, recipe, provenance, evaluations, and limitations.</p>
-          <p>PolyForm broker: source-available, not an open-source component. Its value is discovery, routing, payments, failover, and signed receipts—not a license restriction forcing remote inference through RogerAI.</p>
-        </div>
-      </div>
-    </section>
-
-    <section class="section" id="evidence">
-      <div class="wrap research-split">
-        <div>
-          <span class="sectionno">§9 / EVALUATION CONTRACT</span>
-          <h2>Same harness or no victory claim.</h2>
-          <p>RogerAI measurements remain distinct from upstream vendor measurements.</p>
-        </div>
-        <div class="evidence-plate">
-          <p>Every published number identifies the artifact version, evaluation harness, hardware, settings, and raw results. Superiority claims require the same harness and controls.</p>
-          <p><b>Negative and superseded results remain discoverable.</b> Failed hypotheses keep their reason and evidence even when an artifact becomes deprecated.</p>
-          <a href="/broadcasts.html">Read the public notebook →</a>
         </div>
       </div>
     </section>
 
     <section class="section research-closing">
       <div class="wrap">
-        <span class="sectionno">§10 / THE LAB</span>
-        <h2>Built by computer scientists and systems engineers.</h2>
-        <p>RogerAI brings computer-science and systems-engineering experience to model arithmetic, runtimes, compression, distributed inference, and reproducible evaluation. Named biographies will follow only after individual approval.</p>
+        <span class="sectionno">§4 / FOLLOW THE WORK</span>
+        <h2>Weights, source, and field notes.</h2>
+        <p>Release detail lives with the artifact. Engineering decisions and measurements
+           live in Open Air Waves.</p>
         <div class="research-actions">
-          <a class="research-button research-button--primary" href="https://github.com/rogerai-fyi/roger">Inspect the source</a>
-          <a class="research-button" href="/broadcasts.html">Follow the notebook</a>
-          <a class="research-button" href="/models.html">Tune to live stations</a>
+          <a class="research-button research-button--primary" href="https://huggingface.co/rogerai-fyi">Weights</a>
+          <a class="research-button" href="https://github.com/rogerai-fyi/roger">Source</a>
+          <a class="research-button" href="/broadcasts.html">Open Air Waves</a>
+          <a class="research-button" href="mailto:labs@rogerai.fm">Contact Labs</a>
         </div>
       </div>
     </section>

--- a/web/src/styles/research.css
+++ b/web/src/styles/research.css
@@ -49,6 +49,56 @@
 .research-card dt { color: var(--ink-400); font-family: var(--font-mono); font-size: var(--t-micro); text-transform: uppercase; }
 .research-card dd { margin: 0; color: var(--ink-700); font-size: var(--t-sm); }
 
+.model-list { border-top: 2px solid var(--ink-900); }
+.model-row {
+  display: grid;
+  grid-template-columns: minmax(240px, .8fr) minmax(0, 1.2fr);
+  gap: var(--s-10);
+  padding-block: var(--s-7);
+  border-bottom: 1px solid var(--hairline);
+}
+.model-row h3 { margin: var(--s-3) 0 0; color: var(--ink-900); font-size: var(--t-h3); }
+.model-row p { margin-bottom: 0; color: var(--ink-500); line-height: var(--lh-body); }
+.model-row__identity .research-parent { margin-top: var(--s-3); }
+.model-row__actions { display: flex; flex-wrap: wrap; align-items: center; gap: var(--s-3); margin-top: var(--s-5); }
+.model-download, .model-note {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 8px 12px;
+  border: 1px solid var(--ink-900);
+  color: var(--ink-900);
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  letter-spacing: .04em;
+}
+.model-download::before { content: "↧"; margin-right: 8px; color: var(--live); }
+.model-download:hover, .model-download:focus-visible { border-color: var(--live); color: var(--live); }
+.model-download.is-disabled {
+  border-color: var(--hairline-2);
+  color: var(--ink-400);
+  cursor: not-allowed;
+}
+.model-download.is-disabled::before { color: var(--ink-400); }
+.model-note { border-color: transparent; padding-inline: 4px; }
+.model-note:hover, .model-note:focus-visible { color: var(--live); }
+
+.developer-steps { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-block: 2px solid var(--ink-900); }
+.developer-step { min-width: 0; padding: var(--s-6); border-right: 1px solid var(--hairline); }
+.developer-step:last-child { border-right: 0; }
+.developer-step__no { color: var(--live); font-family: var(--font-mono); font-size: var(--t-xs); }
+.developer-step h3 { margin: var(--s-4) 0 0; color: var(--ink-900); font-size: var(--t-h3); }
+.developer-step p { color: var(--ink-500); line-height: var(--lh-body); }
+.developer-step code {
+  display: block;
+  overflow-x: auto;
+  padding: var(--s-4);
+  background: var(--ink-900);
+  color: var(--paper);
+  font-size: var(--t-xs);
+  white-space: nowrap;
+}
+
 .research-tone { background: var(--paper-2); border-block: 1px solid var(--hairline); }
 .research-split { display: grid; grid-template-columns: minmax(240px, .75fr) minmax(0, 1.25fr); gap: var(--s-12); align-items: start; }
 .research-split h2, .research-closing h2 { margin: var(--s-3) 0 0; color: var(--ink-900); font-size: var(--t-h2); }
@@ -69,6 +119,10 @@
 
 @media (max-width: 820px) {
   .research-grid { grid-template-columns: 1fr; }
+  .model-row { grid-template-columns: 1fr; gap: var(--s-4); }
+  .developer-steps { grid-template-columns: 1fr; }
+  .developer-step { border-right: 0; border-bottom: 1px solid var(--hairline); }
+  .developer-step:last-child { border-bottom: 0; }
   .research-distinction__grid, .research-split { grid-template-columns: 1fr; }
   .research-distinction__grid p { padding: var(--s-4) 0 0; border-left: 0; border-top: 1px solid var(--hairline-2); }
 }

--- a/web/test/company-positioning.test.mjs
+++ b/web/test/company-positioning.test.mjs
@@ -11,8 +11,20 @@ import path from "node:path";
 
 const WEB = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DIST = path.join(WEB, "dist");
+const compact = (value) => value.replace(/\s+/g, " ");
 
 before(() => execFileSync("node", ["build.mjs"], { cwd: WEB }));
+
+test("homepage leads with a concrete product promise", () => {
+  const home = readFileSync(path.join(DIST, "index.html"), "utf8");
+  const hero = home.match(/<section class="hero">[\s\S]*?<\/section>/)?.[0];
+  assert.ok(hero, "homepage has a hero");
+  assert.match(hero, /OpenAI-compatible/i);
+  assert.match(hero, /local endpoint/i);
+  assert.match(compact(hero), /community and private hardware/i);
+  assert.doesNotMatch(hero, /ham radio/i);
+  assert.doesNotMatch(home, /pays rent while you sleep|Pick up the mic/i);
+});
 
 test("homepage connects company, product, audience, evaluation, and research", () => {
   const home = readFileSync(path.join(DIST, "index.html"), "utf8");
@@ -30,7 +42,7 @@ test("homepage connects company, product, audience, evaluation, and research", (
   assert.match(section, /href="\/company\.html"/);
   assert.match(section, /RogerAI Labs/);
   assert.match(section, /Open Air Waves/);
-  assert.match(section, /Wave models/i);
+  assert.match(section, /Wave Nano/i);
   assert.match(section, /edge|manufacturing|industrial|personal/i);
 });
 

--- a/web/test/research-page.test.mjs
+++ b/web/test/research-page.test.mjs
@@ -1,206 +1,105 @@
-// Behavior lock for features/web/research_labs.feature.
-// Assertions run against built HTML so shared-nav includes, metadata, CSS
-// integration, and the no-JavaScript static content are tested together.
 import { test, before } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const WEB = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DIST = path.join(WEB, "dist");
 const read = (name) => readFileSync(path.join(DIST, name), "utf8");
-const articleFor = (page, heading) => {
-  const articles = [...page.matchAll(/<article\b[\s\S]*?<\/article>/g)].map((m) => m[0]);
-  const article = articles.find((candidate) => candidate.includes(heading));
-  assert.ok(article, `article exists for ${heading}`);
-  return article;
-};
+const text = (name) => read(name).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ");
 
 before(() => execFileSync("node", ["build.mjs"], { cwd: WEB }));
 
-test("Research is a first-class, buildable navigation destination", () => {
-  assert.ok(existsSync(path.join(DIST, "research.html")), "research.html builds");
-  const home = read("index.html");
-  assert.match(home, /href="\/research\.html"[^>]*>Research<\/a>/);
-  const page = read("research.html");
-  assert.match(page, /RogerAI Labs/);
-  assert.match(page, /aria-current="page"/);
-});
-
-test("metadata describes research without claiming an unreleased model", () => {
+test("Research is a concise first-class destination", () => {
   const page = read("research.html");
   assert.match(page, /<title>RogerAI Research/);
-  assert.match(page, /name="description" content="[^"]*open edge-model and inference research/i);
+  assert.match(page, /RogerAI Labs/);
+  assert.match(page, /aria-current="page"/);
   assert.match(page, /rel="canonical" href="https:\/\/rogerai\.fm\/research\.html"/);
-  assert.match(page, /property="og:url" content="https:\/\/rogerai\.fm\/research\.html"/);
-  assert.doesNotMatch(page, /Wave Nano[^<]*(available now|download now)/i);
+  const main = page.match(/<main[\s\S]*?<\/main>/)?.[0] || "";
+  assert.ok(main.length < 15000, `research content is concise (${main.length} bytes)`);
 });
 
-test("research and the live broker directory are explicitly distinct", () => {
+test("the page leads with the work, not a biography of the company", () => {
+  const page = read("research.html");
+  assert.match(page, /Models built for local constraints/i);
+  assert.match(page, /smaller|less memory|local hardware/i);
+  assert.doesNotMatch(page, /team|founders?|venture|employees|our origins/i);
+});
+
+test("the model list gives every program a reason and honest status", () => {
+  const page = text("research.html");
+  for (const model of [
+    "DeepSeek-V4-Flash MTP",
+    "Kimi-K3",
+    "Wave Nano",
+    "Wave Micro",
+    "Roger Edge",
+  ]) assert.match(page, new RegExp(model));
+  for (const reason of [
+    /practical local inference/i,
+    /high-memory workstation/i,
+    /local text and tool use/i,
+    /routing, extraction, and triage/i,
+    /wake, voice activity, sensing, and fixed commands/i,
+  ]) assert.match(page, reason);
+  assert.match(page, /Research build/i);
+  assert.match(page, /In progress/i);
+  assert.match(page, /In design/i);
+  assert.match(page, /No Wave checkpoint has been released/i);
+});
+
+test("upstream work is never presented as RogerAI pretraining", () => {
+  const page = read("research.html");
+  assert.match(page, /Optimized by RogerAI/);
+  assert.match(page, /Upstream: DeepSeek-V4-Flash/);
+  assert.match(page, /Upstream: Kimi-K3/);
+  assert.doesNotMatch(page, /RogerAI (?:pre)?trained (?:DeepSeek|Kimi)/i);
+});
+
+test("evidence and local-use promises stay explicit", () => {
+  const page = text("research.html");
+  assert.match(page, /hardware, artifact, runtime, settings, and raw results/i);
+  assert.match(page, /Negative results remain available/i);
+  assert.match(page, /download and run qualifying artifacts locally/i);
+  assert.match(page, /network is optional/i);
+  const html = read("research.html");
+  assert.match(html, /href="\/broadcasts\.html"/);
+  assert.match(html, /href="https:\/\/huggingface\.co\/rogerai-fyi"/);
+  assert.match(html, /href="https:\/\/github\.com\/rogerai-fyi\/roger"/);
+});
+
+test("downloads are real or clearly marked as coming soon", () => {
+  const page = read("research.html");
+  assert.match(page, /href="https:\/\/huggingface\.co\/rogerai-fyi\/DeepSeek-V4-Flash-MTP-GGUF"/);
+  assert.equal((page.match(/Hugging Face · coming soon/g) || []).length, 4);
+  assert.equal((page.match(/aria-disabled="true"/g) || []).length, 4);
+  assert.doesNotMatch(page, /href="[^"]*(?:placeholder|coming-soon)[^"]*"/i);
+});
+
+test("developers have a compact path from artifact to local inference", () => {
+  const page = read("research.html");
+  assert.match(page, /id="developers"/);
+  assert.match(page, /Download/);
+  assert.match(page, /Run locally/);
+  assert.match(page, /Reproduce/);
+  assert.match(page, /huggingface-cli download/);
+  assert.match(page, /llama-server/);
+  assert.match(page, /OpenAI-compatible endpoint/i);
+  assert.match(page, /artifact version[^<]*hardware[^<]*runtime[^<]*settings/i);
+});
+
+test("research and the live network directory remain distinct", () => {
   const page = read("research.html");
   assert.match(page, /href="\/models\.html"/);
-  assert.match(page, /live broker stations/i);
-  assert.match(page, /not every research (?:artifact|project)[^<]*currently served/i);
-  assert.match(page, /not every broker station[^<]*RogerAI model/i);
+  assert.match(page, /live network models/i);
+  assert.match(page, /research programs/i);
 });
 
-test("current projects have honest status, lineage, parent, and unresolved gates", () => {
-  const page = read("research.html");
-  const deepseek = articleFor(page, "DeepSeek-V4-Flash MTP");
-  assert.match(deepseek, /Optimized by RogerAI/);
-  assert.match(deepseek, /Upstream parent:[\s\S]*DeepSeek-V4-Flash/i);
-  assert.match(deepseek, /MIT License/);
-  assert.match(deepseek, /converter[^<]*runtime[^<]*MTP[^<]*benchmark[^<]*artifact/i);
-  assert.match(deepseek, /project summary, not a stable model card/i);
-  assert.doesNotMatch(deepseek, /pretrained/i);
-
-  const kimi = articleFor(page, "Kimi-K3 on a 256 GB system");
-  assert.match(kimi, /Optimized by RogerAI/);
-  assert.match(kimi, /Upstream parent:[\s\S]*Kimi-K3/i);
-  assert.match(kimi, /Kimi K3 License/);
-  assert.match(kimi, /A_log/);
-  assert.match(kimi, /16,376-token/i);
-  assert.match(kimi, /per-head-truncated/i);
-  assert.match(kimi, /Pruning quality[^<]*fit gates remain unresolved/i);
-  assert.doesNotMatch(kimi, /pretrained/i);
-
-  const wave = articleFor(page, "Roger Wave Nano");
-  assert.match(wave, /(?:Research|In progress)/i);
-  assert.match(wave, /Granite-4\.0-350M[^<]*Tool/i);
-  assert.match(wave, /SmolLM2-360M-Instruct[^<]*Text\/control/i);
-  assert.match(wave, /no release/i);
-  assert.match(wave, /reviewed data[^<]*resume smoke[^<]*training approval/i);
-  assert.doesNotMatch(wave, /(?:beats|downloads?|tok\/s)/i);
-});
-
-test("lineage taxonomy and component-specific openness are visible", () => {
-  const page = read("research.html");
-  for (const badge of [
-    "Trained by RogerAI", "Adapted by RogerAI",
-    "Optimized by RogerAI", "Verified by RogerAI",
-  ]) assert.match(page, new RegExp(badge));
-  assert.match(page, /open weights/i);
-  assert.match(page, /Open Source AI[^<]*reproducibility checklist/i);
-  assert.match(page, /PolyForm[^<]*source-available/i);
-  assert.doesNotMatch(page, /PolyForm[^<]*open source/i);
-});
-
-test("local use is independent and RogerAI publishing is optional", () => {
-  const page = read("research.html");
-  assert.match(page, /download and run[^<]*locally/i);
-  assert.match(page, /publishing[^<]*RogerAI[^<]*optional/i);
-  for (const value of ["discovery", "routing", "payments", "failover", "signed receipts"]) {
-    assert.match(page, new RegExp(value, "i"));
+test("new institutional pages contain no em dash character", () => {
+  for (const name of ["research.html", "company.html", "index.html"]) {
+    assert.doesNotMatch(read(name), /—/, `${name} contains an em dash`);
   }
-  assert.doesNotMatch(page, /remote inference[^<]*(must|required)[^<]*RogerAI/i);
-});
-
-test("device program separates Wave, Raspberry Pi evidence, and Roger Edge", () => {
-  const page = read("research.html");
-  assert.match(page, /Raspberry Pi[^<]*exact board/i);
-  for (const field of [
-    "OS", "runtime", "format", "quantization", "context",
-    "cold load", "peak memory", "prompt speed", "decode speed",
-  ]) assert.match(page, new RegExp(field, "i"));
-  assert.match(page, /generic NPU support[^<]*not/i);
-  assert.match(page, /full delegation[^<]*partial delegation[^<]*CPU fallback/i);
-
-  assert.match(page, /ESP32[^<]*does not run[^<]*350M/i);
-  assert.match(page, /Roger Edge/);
-  for (const task of ["wake", "VAD", "fixed commands", "sensing", "vision"]) {
-    assert.match(page, new RegExp(task, "i"));
-  }
-  assert.match(page, /LILYGO T-Embed/i);
-  assert.match(page, /nearby[^<]*(?:Pi|phone)/i);
-  assert.match(page, /consent/i);
-  assert.match(page, /nonce[^<]*expiry[^<]*issuer/i);
-  assert.match(page, /ESP32-P4[^<]*no native Wi-Fi or Bluetooth/i);
-});
-
-test("benchmark and publication policy preserves evidence and negative results", () => {
-  const page = read("research.html");
-  for (const field of [
-    "artifact version", "evaluation harness", "raw results",
-    "RogerAI measurements", "upstream vendor measurements",
-  ]) assert.match(page, new RegExp(field, "i"));
-  assert.match(page, /same harness/i);
-  assert.match(page, /negative and superseded results/i);
-  assert.match(page, /computer-science and systems-engineering experience/i);
-});
-
-test("Wave family tiers are programs with gates, never products", () => {
-  const page = read("research.html");
-  const nano = articleFor(page, "<h3>Wave Nano</h3>");
-  assert.match(nano, /PROTOTYPE GRID DESIGNED/i);
-  assert.match(nano, /Granite[^<]*typed tools[^<]*SmolLM2[^<]*text control/i);
-  assert.match(nano, /same[^<]*example bytes/i);
-  assert.match(nano, /One combined model[^<]*two specialists[^<]*no v0 release/i);
-  assert.doesNotMatch(nano, /(?:available now|download|tok\/s|beats)/i);
-  const micro = articleFor(page, "Wave Micro");
-  assert.match(micro, /IN DESIGN/i);
-  assert.match(micro, /task specialists/i);
-  assert.doesNotMatch(micro, /(?:available now|download|tok\/s|beats)/i);
-  const roadmap = articleFor(page, "Wave Embed");
-  assert.match(roadmap, /Wave VL/);
-  assert.match(roadmap, /Wave Audio/);
-  assert.match(roadmap, /roadmap/i);
-  assert.match(page, /Roger Edge<\/b> covers[\s\S]*microcontroller/i);
-});
-
-test("Wave family infographic exposes size, role, order, and release honesty", () => {
-  const page = read("research.html");
-  assert.match(page, /<figure class="wave-map"[^>]*aria-labelledby=/);
-  assert.match(page, /<svg[^>]*role="img"/);
-  for (const tier of ["Roger Edge", "Wave Micro", "Wave Nano", "Wave Embed", "Wave VL \\+ Audio"]) {
-    assert.match(page, new RegExp(tier));
-  }
-  for (const size of ["KB–MB", "&lt;100M", "~350M", "100–300M", "~0\\.3–2B"]) {
-    assert.match(page, new RegExp(size));
-  }
-  assert.match(page, /Sensors become typed events[^<]*Micro[^<]*Nano/i);
-  assert.match(page, /first measured program/i);
-});
-
-test("industry section sells patterns and air-gapped locality, not invented customers", () => {
-  const page = read("research.html");
-  for (const vertical of [
-    "MANUFACTURING", "WAREHOUSES &amp; LOGISTICS",
-    "ENERGY &amp; HEAVY ASSETS", "DEFENSE &amp; PUBLIC SECTOR",
-  ]) assert.match(page, new RegExp(vertical));
-  assert.match(page, /air-gapped/i);
-  assert.match(page, /OT\s+firewall/i);
-  assert.match(page, /Patterns, not case studies/i);
-  assert.match(page, /does not name customers it does not[\s\S]*have/i);
-  assert.match(page, /closed-loop control[\s\S]*deterministic/i);
-});
-
-test("services are offered without conditioning model use on them", () => {
-  const page = read("research.html");
-  assert.match(page, /Model optimization engineering/i);
-  assert.match(page, /Edge deployment/i);
-  assert.match(page, /Benchmarking and model selection/i);
-  assert.match(page, /Industrial pilots/i);
-  assert.match(page, /never requires buying services/i);
-  assert.match(page, /services never require\s+the broker/i);
-  assert.match(page, /mailto:labs@rogerai\.fm/);
-});
-
-test("developers section names standard formats and reproduction paths", () => {
-  const page = read("research.html");
-  assert.match(page, /GGUF/);
-  assert.match(page, /llama\.cpp/);
-  assert.match(page, /href="https:\/\/huggingface\.co\/rogerai-fyi"/);
-  assert.match(page, /href="https:\/\/github\.com\/rogerai-fyi"/);
-  assert.match(page, /serve command/i);
-  assert.match(page, /optionally join the RogerAI network/i);
-});
-
-test("essential research content and links are static and require no client JavaScript", () => {
-  const page = read("research.html");
-  assert.match(page, /<main[\s\S]*RogerAI Labs[\s\S]*DeepSeek-V4-Flash MTP[\s\S]*Kimi-K3[\s\S]*Roger Wave Nano/);
-  assert.match(page, /href="https:\/\/github\.com\/rogerai-fyi\/roger"/);
-  assert.match(page, /href="\/broadcasts\.html"/);
-  assert.doesNotMatch(page, /Loading research|placeholder metric/i);
 });


### PR DESCRIPTION
## Summary
- condense Research into a purpose-led model catalog
- add honest Hugging Face download and coming-soon states
- add a compact developer path for download, local serving, and reproduction
- make homepage positioning more concrete and professional
- remove em dashes from the revised institutional copy

## Verification
- 123/123 web tests
- 30/30 smoke checks
- Go build, vet, formatting, and package tests
- all 33 pages return 200 and all 63 internal links resolve