### PR TITLE
web: fix Roger Edge reel's first-scroll trigger missing zero-delta gestures

### DIFF
--- a/web/src/js/edge-story.js
+++ b/web/src/js/edge-story.js
@@ -209,6 +209,11 @@
     // on (so it isn't dead weight for someone reading without scrolling),
     // but a visitor who scrolls first gets the scroll-triggered version and
     // the fallback is cancelled outright, never firing on top of it later.
+    // `scroll` alone MISSES a real gesture that doesn't move scrollY - scrolling
+    // up while already at the top, a rubber-band swipe that snaps back, a wheel
+    // tick too small to register. Those still fire `wheel`/`keydown`/`touchstart`
+    // even though the page never actually moved, so listen for all of them; the
+    // `settled` guard means only the first of any type does anything.
     var settled = false;
     function beginObserving() {
       if (settled) return;
@@ -217,7 +222,9 @@
       io.observe(reel);
     }
     var autoStartTimer = setTimeout(beginObserving, 5000);
-    window.addEventListener("scroll", beginObserving, { once: true, passive: true });
+    ["scroll", "wheel", "touchstart", "keydown"].forEach(function (type) {
+      window.addEventListener(type, beginObserving, { once: true, passive: true });
+    });
   } else {
     ensureLoaded();
     playCurrent();


### PR DESCRIPTION
## Summary
- The reel's IntersectionObserver only started watching on the first `scroll` event, but `scroll` doesn't fire for a gesture that doesn't actually move `scrollY` (scrolling up while already at the top, a rubber-band swipe that snaps back, a sub-threshold wheel tick). A visitor whose first interaction was one of those saw nothing happen until the 5s fallback timer.
- Now `scroll`, `wheel`, `touchstart`, and `keydown` all funnel into the same one-shot guarded starter, so any real interaction (or the 5s fallback, whichever comes first) reliably wakes it.

## Test plan
- [x] `npm test` - 809/809 passing
- [x] `node build.mjs` - clean build