### PR TITLE
web: reel/market fixes + homepage copy refresh

### DIFF
--- a/features/web/homepage_company_research_branding.feature
+++ b/features/web/homepage_company_research_branding.feature
@@ -10,7 +10,7 @@ Feature: The homepage presents RogerAI as a research and infrastructure company
       Given a visitor opens the RogerAI homepage
       Then the eyebrow identifies RogerAI as American AI research and infrastructure
       And the headline still promises one local OpenAI-compatible endpoint
-      And the supporting copy names open model research and inference infrastructure
+      And the supporting copy names open models and private inference infrastructure
       And routing, failover, metering, signed receipts, and operator control remain visible
       And the install command remains in the first viewport on a typical desktop
 

--- a/features/web/homepage_company_research_branding.feature
+++ b/features/web/homepage_company_research_branding.feature
@@ -10,7 +10,7 @@ Feature: The homepage presents RogerAI as a research and infrastructure company
       Given a visitor opens the RogerAI homepage
       Then the eyebrow identifies RogerAI as American AI research and infrastructure
       And the headline still promises one local OpenAI-compatible endpoint
-      And the supporting copy names open models and private inference infrastructure
+      And the supporting copy names private inference networks and open models
       And routing, failover, metering, signed receipts, and operator control remain visible
       And the install command remains in the first viewport on a typical desktop
 

--- a/features/web/network_story.feature
+++ b/features/web/network_story.feature
@@ -18,8 +18,9 @@ Feature: Every landing surface tells the network's real story
 
   Scenario: The homepage tells the unlinking, the two earn paths, and the tower
     When the homepage renders
-    # moved 2026-09-11 from a hero subhead clause to its own section headline
-    # (PRIVACY-FIRST AIRWAVES) - same claim, "hears" replacing "sees"
+    # a hero subhead clause making this same claim ("sees" not "hears") was
+    # dropped 2026-09-11 - nothing moved, the pre-existing PRIVACY-FIRST
+    # AIRWAVES section headline already stated it, so one placement remains
     Then it says the provider hears a station, never you
     And the monetize section names both transmitters: your GPU and your contracts
     And the tower section offers the 5 percent relay and the free standalone exit

--- a/features/web/network_story.feature
+++ b/features/web/network_story.feature
@@ -18,7 +18,9 @@ Feature: Every landing surface tells the network's real story
 
   Scenario: The homepage tells the unlinking, the two earn paths, and the tower
     When the homepage renders
-    Then it says the upstream sees a station, never you
+    # moved 2026-09-11 from a hero subhead clause to its own section headline
+    # (PRIVACY-FIRST AIRWAVES) - same claim, "hears" replacing "sees"
+    Then it says the provider hears a station, never you
     And the monetize section names both transmitters: your GPU and your contracts
     And the tower section offers the 5 percent relay and the free standalone exit
     And the comparison tease concedes when going direct is cheaper

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -45,7 +45,7 @@
 
       <p class="hero__sub">
         RogerAI provides private inference networks for the edge, that means you and your
-        homelab, that means factories and their fleet. Our labs focuses on enabling open models
+        homelab, that means factories and their fleet. Our labs focus on enabling open models
         to run on a spectrum of <a href="/research-hardware.html">hardware</a>. Our
         network runs one OpenAI-compatible local endpoint only you have access to, in a
         privatized relay on top of community and private hardware. It handles discovery,

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -44,12 +44,12 @@
       </h1>
 
       <p class="hero__sub">
-        RogerAI is an inference network for the edge, that means you and your homelab, that
-        means factories and their fleet, and more. Our open model research targets the
-        whole spectrum of <a href="/pricing.html#why">hardware</a>. Our network runs one
-        OpenAI-compatible local endpoint only you have access to, in a privatized relay
-        on top of community and private hardware. It handles discovery, routing,
-        failover, metering, and signed receipts, and every upstream sees a station - never you.
+        RogerAI provides private inference networks for the edge, that means you and your
+        homelab, that means factories and their fleet. Our labs focuses on enabling open models
+        to run on a spectrum of <a href="/research-hardware.html">hardware</a>. Our
+        network runs one OpenAI-compatible local endpoint only you have access to, in a
+        privatized relay on top of community and private hardware. It handles discovery,
+        routing, failover, metering, and signed receipts.
         Get Control, <a href="/pricing.html#why">Read the receipts &rarr;</a>
       </p>
 
@@ -210,8 +210,15 @@
         <video class="reel__video" id="edgeVideo" muted playsinline preload="none"
                poster="assets/edge/poster-a.webp"
                aria-label="Roger Edge brand film, Story A and Story B, looping">
-          <source type="video/webm">
+          <!-- mp4/H.264 FIRST: a <video> picks the first <source> whose type it
+               can play, in DOM order - not "best" by any quality/size metric.
+               H.264 hardware-decodes almost everywhere; VP9 hardware decode is
+               inconsistent across GPUs/drivers, and falls back to a notably
+               heavier software decode when it's missing or the GPU is already
+               busy (edge-story.js:tick-free by design, so a decode-side stutter
+               here is coming from the codec choice, not from this file). -->
           <source type="video/mp4">
+          <source type="video/webm">
         </video>
         <span class="reel__tag mono" id="edgeTag" aria-hidden="true">STORY A</span>
       </div>
@@ -422,7 +429,9 @@
           <span class="company__label">PRODUCT</span>
           <h3>The radio for Local Models</h3>
           <p>One OpenAI-compatible endpoint for developers and teams, over community
-            and private hardware; operators keep control of their machines.</p>
+            and private hardware; operators keep control of their machines - sharing
+            a model never shares your files or your machine
+            (<a href="/faq.html#share">what a requester can reach &rarr;</a>).</p>
           <p>Open model and runtime work ships under its stated model license.
             The network and broker remain source-visible under PolyForm Perimeter.</p>
           <p class="company__links">
@@ -436,7 +445,7 @@
         <article class="company__card company__card--labs">
           <!-- include: tube-ping.html -->
           <span class="company__label">ROGERAI LABS · THE WAVE SPECTRUM</span>
-          <h3>A model program with its gates in the open.</h3>
+          <h3>American open-source model programme</h3>
           <p><span class="status">TRAINED</span>
             Wave Pico, the edge child of the Spectrum, has a certified waypoint build -
             trained from scratch on our data, sized for a Raspberry Pi.

--- a/web/src/js/edge-story.js
+++ b/web/src/js/edge-story.js
@@ -215,15 +215,33 @@
     var ioEnter = new IntersectionObserver(function (entries) {
       entries.forEach(function (e) { if (e.isIntersecting) powerOn(); });
     }, { threshold: 0, rootMargin: "0px 0px 20% 0px" });
-    // ioExit: powerOff() only, against a top edge shrunk by a LOT (-40%).
+    // ioExit: BOTH powerOff() and powerOn(), against a top edge shrunk by a
+    // LOT (-40%). Power-off-only was a real bug (caught in review): on a
+    // viewport shorter than 40% of the reel's shrunk zone (portrait/mobile),
+    // the reel can re-enter from below without ever re-crossing ioEnter's
+    // TRUE (unshrunk) boundary - ioEnter had already fired once and stays
+    // intersecting throughout, so nothing calls powerOn() again, and the set
+    // is stuck dark until scrolled fully past. Being bidirectional here
+    // restores that recovery path; ioEnter still owns the one read that has
+    // to be trustworthy (the very first), since ioExit ignores its own first
+    // callback (see ioExitPrimed below).
+    //
     // This one only ever runs after the set is already on, so the risky
-    // first-read case above does not apply to it - it can be as eager as
-    // the close animation needs. It fires while a solid chunk of the reel
-    // is still on screen, leaving room to actually see the collapse play
-    // out before the reel scrolls past the top, instead of catching only
-    // its last sliver (or none of it).
+    // first-read case above does not apply to its OWN activation - it can be
+    // as eager as the close animation needs, firing while a solid chunk of
+    // the reel is still on screen instead of catching only its last sliver.
+    var ioExitPrimed = false;
     var ioExit = new IntersectionObserver(function (entries) {
-      entries.forEach(function (e) { if (!e.isIntersecting) powerOff(); });
+      // IntersectionObserver.observe() delivers one synchronous-ish read of
+      // CURRENT geometry the instant it starts - and it starts right as the
+      // power-on animation finishes (below). On a tall viewport where the
+      // fully-open reel already sits above the -40% line, that first read
+      // says "not intersecting" and would power off the instant power-on
+      // completes: an on-then-off flash. Skipping exactly that one read (not
+      // deferring observe() itself, which only delays the same problem) is
+      // what actually avoids it; every read after is a real scroll change.
+      if (!ioExitPrimed) { ioExitPrimed = true; return; }
+      entries.forEach(function (e) { e.isIntersecting ? powerOn() : powerOff(); });
     }, { threshold: 0, rootMargin: "-40% 0px 0px 0px" });
     // Stay collapsed on load, even if the reel is already geometrically in
     // view (a tall viewport, a mid-page anchor link) - observing only

--- a/web/src/js/edge-story.js
+++ b/web/src/js/edge-story.js
@@ -51,8 +51,10 @@
   function setStory(key) {
     current = key;
     var s = STORIES[key];
-    sources[0].src = s.webm;
-    sources[1].src = s.mp4;
+    // index 0 is the mp4 <source> (listed first in the markup - see its
+    // comment for why: H.264 hardware-decodes far more reliably than VP9).
+    sources[0].src = s.mp4;
+    sources[1].src = s.webm;
     video.setAttribute("poster", s.poster);
     if (tagEl) tagEl.textContent = s.tag;
     video.load();
@@ -137,11 +139,18 @@
     state = "poweringOff";
   }
 
+  // set once the FIRST power-on animation completes (below) - ioExit only
+  // starts watching once the set is confirmed fully on, never at the same
+  // instant as ioEnter, so a position already close to ioExit's shrunk top
+  // line can't fire a conflicting powerOff() a tick after powerOn() starts.
+  var exitObserving = false;
+
   reel.addEventListener("animationend", function (e) {
     if (e.animationName === "reelPowerOn" && state === "poweringOn") {
       reel.classList.remove("is-powering-on");
       reel.classList.add("is-on");
       state = "on";
+      if (!exitObserving && CAN_FX) { exitObserving = true; ioExit.observe(reel); }
     } else if (e.animationName === "reelPowerOff" && state === "poweringOff") {
       reel.classList.remove("is-powering-off", "is-on");
       video.pause(); // freeze on the collapsed line, not mid-picture
@@ -190,21 +199,35 @@
       setScreenA11y(true);
     }
   } else if (CAN_FX) {
-    // Fire as the reel is APPROACHING each edge, not once it's already well
-    // past it. rootMargin is not direction-aware, so the two edges need
-    // OPPOSITE signs to both mean "sooner": a positive bottom margin grows
-    // the box downward, so entering from below counts as intersecting while
-    // still under the fold - powerOn() starts before it's actually visible.
-    // A negative top margin shrinks the box upward from the real top edge,
-    // so leaving through the top (the common case: scrolling on down the
-    // page) counts as NOT intersecting while the reel still has real
-    // clearance left - powerOff() starts well before it's actually gone.
-    var io = new IntersectionObserver(function (entries) {
-      entries.forEach(function (e) { e.isIntersecting ? powerOn() : powerOff(); });
-    }, { threshold: 0, rootMargin: "-45% 0px 20% 0px" });
+    // TWO observers, not one, each with exactly one job - a single shared
+    // rootMargin can't satisfy both "turn on reliably" and "turn off with
+    // room to see the animation finish" at once (tried that; see the
+    // history below), because they need opposite-sized top margins.
+    //
+    // ioEnter: powerOn() only, on the TRUE top edge (no shrink). This is
+    // what has to be trustworthy the instant observation starts (right
+    // after the visitor's first scroll/wheel/key gesture) - a shrunk top
+    // here previously meant a single ordinary scroll (even a Page Down)
+    // could carry the reel's position past the shrunk boundary before that
+    // first read ever happened, and it stayed stuck "off" from then on
+    // (only scrolling back up would have fixed it). The +20% bottom margin
+    // still makes entering from below fire before it's actually visible.
+    var ioEnter = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) { if (e.isIntersecting) powerOn(); });
+    }, { threshold: 0, rootMargin: "0px 0px 20% 0px" });
+    // ioExit: powerOff() only, against a top edge shrunk by a LOT (-40%).
+    // This one only ever runs after the set is already on, so the risky
+    // first-read case above does not apply to it - it can be as eager as
+    // the close animation needs. It fires while a solid chunk of the reel
+    // is still on screen, leaving room to actually see the collapse play
+    // out before the reel scrolls past the top, instead of catching only
+    // its last sliver (or none of it).
+    var ioExit = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) { if (!e.isIntersecting) powerOff(); });
+    }, { threshold: 0, rootMargin: "-40% 0px 0px 0px" });
     // Stay collapsed on load, even if the reel is already geometrically in
     // view (a tall viewport, a mid-page anchor link) - observing only
-    // starts on the first real scroll OR a 5s fallback timer, WHICHEVER
+    // starts on the first real scroll OR a 2.5s fallback timer, WHICHEVER
     // FIRST: a visitor who never touches the page still sees the set come
     // on (so it isn't dead weight for someone reading without scrolling),
     // but a visitor who scrolls first gets the scroll-triggered version and
@@ -219,9 +242,9 @@
       if (settled) return;
       settled = true;
       clearTimeout(autoStartTimer);
-      io.observe(reel);
+      ioEnter.observe(reel); // ioExit starts once the first power-on completes, above
     }
-    var autoStartTimer = setTimeout(beginObserving, 5000);
+    var autoStartTimer = setTimeout(beginObserving, 2500);
     ["scroll", "wheel", "touchstart", "keydown"].forEach(function (type) {
       window.addEventListener(type, beginObserving, { once: true, passive: true });
     });

--- a/web/src/js/edge-story.js
+++ b/web/src/js/edge-story.js
@@ -128,6 +128,14 @@
     if (state === "poweringOff") forceReflow();
     reel.classList.add("is-powering-on");
     state = "poweringOn";
+    // belt-and-suspenders: animationend normally arms ioExit (below) right
+    // on schedule (~0.85s), but if the animation is ever suppressed after
+    // this point (reduced-motion toggled live mid-session, the element
+    // display:none'd elsewhere) that event may never arrive - without it,
+    // state sticks at "poweringOn" forever with no path left to power off a
+    // video that has since scrolled off-screen. armExitObserving's own guard
+    // makes this a no-op on the normal path, where animationend always wins.
+    setTimeout(armExitObserving, 1000);
   }
 
   function powerOff() {
@@ -144,13 +152,16 @@
   // instant as ioEnter, so a position already close to ioExit's shrunk top
   // line can't fire a conflicting powerOff() a tick after powerOn() starts.
   var exitObserving = false;
+  function armExitObserving() {
+    if (!exitObserving && CAN_FX) { exitObserving = true; ioExit.observe(reel); }
+  }
 
   reel.addEventListener("animationend", function (e) {
     if (e.animationName === "reelPowerOn" && state === "poweringOn") {
       reel.classList.remove("is-powering-on");
       reel.classList.add("is-on");
       state = "on";
-      if (!exitObserving && CAN_FX) { exitObserving = true; ioExit.observe(reel); }
+      armExitObserving();
     } else if (e.animationName === "reelPowerOff" && state === "poweringOff") {
       reel.classList.remove("is-powering-off", "is-on");
       video.pause(); // freeze on the collapsed line, not mid-picture

--- a/web/src/js/edge-story.js
+++ b/web/src/js/edge-story.js
@@ -223,24 +223,23 @@
     // intersecting throughout, so nothing calls powerOn() again, and the set
     // is stuck dark until scrolled fully past. Being bidirectional here
     // restores that recovery path; ioEnter still owns the one read that has
-    // to be trustworthy (the very first), since ioExit ignores its own first
-    // callback (see ioExitPrimed below).
+    // to be trustworthy on the very first activation.
     //
-    // This one only ever runs after the set is already on, so the risky
-    // first-read case above does not apply to its OWN activation - it can be
-    // as eager as the close animation needs, firing while a solid chunk of
-    // the reel is still on screen instead of catching only its last sliver.
-    var ioExitPrimed = false;
+    // This one only ever runs after the set is already on, so it can be as
+    // eager as the close animation needs, firing while a solid chunk of the
+    // reel is still on screen instead of catching only its last sliver. It
+    // also acts on its OWN first read (unlike ioEnter) - an earlier version
+    // skipped that read to dodge an "on-then-immediately-off" case where a
+    // fast scroll during the open animation leaves the reel already past the
+    // -40% line by the time this starts watching. That skip was itself a
+    // worse bug (caught in review): if THAT swallowed read was the only
+    // moment the reel was ever out of range, nothing calls powerOff() again,
+    // and the video keeps playing off-screen indefinitely. Reacting to the
+    // first read is correct either way: if the reel is still in range it's a
+    // harmless powerOn() no-op, and if fast scrolling already carried it out
+    // of range, immediately closing again is the right response, not a flash
+    // to guard against.
     var ioExit = new IntersectionObserver(function (entries) {
-      // IntersectionObserver.observe() delivers one synchronous-ish read of
-      // CURRENT geometry the instant it starts - and it starts right as the
-      // power-on animation finishes (below). On a tall viewport where the
-      // fully-open reel already sits above the -40% line, that first read
-      // says "not intersecting" and would power off the instant power-on
-      // completes: an on-then-off flash. Skipping exactly that one read (not
-      // deferring observe() itself, which only delays the same problem) is
-      // what actually avoids it; every read after is a real scroll change.
-      if (!ioExitPrimed) { ioExitPrimed = true; return; }
       entries.forEach(function (e) { e.isIntersecting ? powerOn() : powerOff(); });
     }, { threshold: 0, rootMargin: "-40% 0px 0px 0px" });
     // Stay collapsed on load, even if the reel is already geometrically in

--- a/web/src/js/market.js
+++ b/web/src/js/market.js
@@ -504,6 +504,7 @@
       li.style.setProperty("--i", i);
       listEl.appendChild(li);
     });
+    heads = null; // the old nodes are gone - tick() re-queries once, lazily
   }
 
   /* ---------- live signal "VU" (rAF, only the head bars) ----------
@@ -512,10 +513,27 @@
      a sine and, at the peak of the breath, the glyph ticks up one notch
      on the ▁▂▃▄▅▆▇█ ramp so the level reads as ALIVE, not as decoration.
      The swap is RELATIVE to each cell's own base glyph, so a weak band
-     never jumps to a full bar. Cheap: one sine + an optional glyph swap. */
-  function tick() {
-    shimmer += 0.035;
-    var heads = listEl.querySelectorAll(".sigbar--head");
+     never jumps to a full bar. Cheap: one sine + an optional glyph swap -
+     but the glyph swap is a textContent write, and that reflows, so this
+     runs throttled (~20fps, same technique as radiomap's canvas loop) and
+     caches the node list instead of querying it every single frame; both
+     were previously reflowing on every full 60fps tick with a fresh
+     querySelectorAll, which read as a faint but steady stutter site-wide
+     once anything else on the page (a background video, say) was also
+     asking for main-thread time. */
+  var heads = null;
+  var lastWorkAt = 0;
+  var TICK_INTERVAL = 1000 / 20;
+  function tick(now) {
+    rafId = requestAnimationFrame(tick);
+    if (!lastWorkAt) lastWorkAt = now; // first call: nothing to measure elapsed against yet
+    var elapsed = now - lastWorkAt;
+    if (elapsed < TICK_INTERVAL) return;
+    lastWorkAt = now;
+    // 0.035 was calibrated per ~60fps frame (~16.7ms) - scale by the REAL
+    // elapsed time so throttling the call rate changes smoothness, not speed.
+    shimmer += 0.035 * (elapsed / (1000 / 60));
+    if (!heads) heads = listEl.querySelectorAll(".sigbar--head");
     for (var i = 0; i < heads.length; i++) {
       var h = heads[i];
       // remember each head's base glyph + its one-notch-up neighbour once
@@ -530,7 +548,6 @@
       var want = s > 0.82 ? h.__hi : h.__lo;   // peak of the breath = +1 notch
       if (h.textContent !== want) h.textContent = want;
     }
-    rafId = requestAnimationFrame(tick);
   }
   function startShimmer() {
     if (REDUCED || rafId || !visible) return;

--- a/web/src/js/market.js
+++ b/web/src/js/market.js
@@ -533,7 +533,12 @@
     lastWorkAt = now;
     // 0.035 was calibrated per ~60fps frame (~16.7ms) - scale by the REAL
     // elapsed time so throttling the call rate changes smoothness, not speed.
-    shimmer += 0.035 * (elapsed / (1000 / 60));
+    // Clamped: an occluded tab or a heavy main-thread stall can make a
+    // single `elapsed` huge, which would otherwise scale into an equally
+    // huge one-off phase jump - every bar snapping instead of resuming its
+    // breath, the same symptom stopShimmer's lastWorkAt reset guards against
+    // for the stop/start case.
+    shimmer += 0.035 * (Math.min(elapsed, 100) / (1000 / 60));
     if (!heads) heads = listEl.querySelectorAll(".sigbar--head");
     for (var i = 0; i < heads.length; i++) {
       var h = heads[i];

--- a/web/src/js/market.js
+++ b/web/src/js/market.js
@@ -379,6 +379,7 @@
     stopShimmer();
     rendered = [];
     listEl.classList.remove("is-stale");
+    heads = null; // the old nodes are gone, same as paint() - see tick()
     listEl.innerHTML =
       '<li class="mkt-quiet">' +
         '<span class="mkt-quiet__txt">The band is quiet right now - no stations on air yet. ' +
@@ -555,6 +556,12 @@
   }
   function stopShimmer() {
     if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    // without this, the next tick() after any stop/start (tab hidden, panel
+    // scrolled out, a held-market poll) computes elapsed against a stale
+    // timestamp - a huge one-off `elapsed`, so shimmer jumps by a
+    // correspondingly huge phase step and every bar snaps instead of
+    // resuming its breath smoothly.
+    lastWorkAt = 0;
   }
 
   /* ---------- status helpers ------------------------------------ */

--- a/web/src/styles/home.css
+++ b/web/src/styles/home.css
@@ -1134,14 +1134,28 @@ html.js .mkt-quiet--nojs { display: none; }
 }
 
 /* overlaid on the screen's opposite corner, not a block below it - the
-   screen now runs edge to edge, so anything "under" it would too. */
+   screen now runs edge to edge, so anything "under" it would too. It is
+   positioned against .reel-band (bottom:12px), not .reel__screen, and
+   .reel-band's own height is just whatever .reel__screen currently is - when
+   reel--fx has that collapsed to 6px (off, or mid power-on/off), 12px from
+   THAT bottom edge floats the ~28px-tall control up over whatever precedes
+   the band in the document, still fully clickable there. (Confirmed live,
+   2026-09-11: floating over hero copy at rest and after every scroll-out.)
+   Fix is to only show it once the set is actually confirmed on - reel--fx
+   without is-on covers every collapsed/transitional state at once, so
+   there's no state left where the band is too short to hold it. Plain
+   fallback paths (reduced motion / no IntersectionObserver / JS-off) never
+   gain reel--fx at all and keep the control visible always, matching how
+   they never collapse the screen either. */
 .reel__mute {
   position: absolute; right: var(--gutter); bottom: 12px; z-index: 1;
   display: inline-flex; align-items: center; gap: 6px;
   padding: 5px 10px; border: 1px solid rgba(255,255,255,.35); background: rgba(5,5,5,.66);
   color: rgba(255,255,255,.8); font-family: var(--font-mono); font-size: var(--t-xs);
-  cursor: pointer; transition: color var(--d-2), border-color var(--d-2);
+  cursor: pointer; opacity: 1; pointer-events: auto;
+  transition: color var(--d-2), border-color var(--d-2), opacity var(--d-2);
 }
+.reel--fx:not(.is-on) .reel__mute { opacity: 0; pointer-events: none; }
 .reel__mute:hover, .reel__mute:focus-visible { color: #fff; border-color: #fff; }
 .reel__mute .reel__icon--sound { display: none; }
 .reel__mute.is-unmuted .reel__icon--muted { display: none; }

--- a/web/src/styles/home.css
+++ b/web/src/styles/home.css
@@ -850,8 +850,11 @@
   .radar__blip { animation: none; opacity: .8; transform: none; }
 }
 
+/* left-bound like everything else on this page (.term above it uses the
+   same margin:0 convention) - centering this with margin:0 auto is what
+   left it visibly inset from the heading and the terminal box above it. */
 .market__panel {
-  max-width: 880px; margin: 0 auto; background: var(--paper);
+  max-width: 880px; margin: 0; background: var(--paper);
   border: 1px solid var(--hairline); border-top: 2px solid var(--ink-900);
   box-shadow: none; overflow: hidden;
 }

--- a/web/src/styles/home.css
+++ b/web/src/styles/home.css
@@ -1155,7 +1155,10 @@ html.js .mkt-quiet--nojs { display: none; }
   display: inline-flex; align-items: center; gap: 6px;
   padding: 5px 10px; border: 1px solid rgba(255,255,255,.35); background: rgba(5,5,5,.66);
   color: rgba(255,255,255,.8); font-family: var(--font-mono); font-size: var(--t-xs);
-  cursor: pointer; opacity: 1; visibility: visible; pointer-events: auto;
+  cursor: pointer;
+  /* only the transition list has any effect here - opacity/visibility/
+     pointer-events are already the element's default values; they exist as
+     the reverse-direction endpoints the transition below animates toward. */
   transition: color var(--d-2), border-color var(--d-2), opacity var(--d-2),
     visibility 0s linear 0s;
 }
@@ -1163,8 +1166,18 @@ html.js .mkt-quiet--nojs { display: none; }
    focusable and in the tab order - a keyboard user could land on a
    perfectly invisible control. visibility:hidden removes it from the tab
    order too, delayed so it only takes effect once the fade-out (above) has
-   actually finished, not the instant this class lands. */
-.reel--fx:not(.is-on) .reel__mute {
+   actually finished, not the instant this class lands.
+
+   :not(.is-on) alone MISSED the close animation: powerOff() adds
+   is-powering-off immediately, but is-on is not removed until animationend
+   fires 0.78s later, so for that whole window neither selector matched and
+   the control stayed fully visible, floating over whatever the collapsing
+   screen was revealing beneath it - the exact reported bug, just during the
+   closing half instead of the resting state. is-powering-off is listed
+   explicitly rather than dropping is-on earlier in powerOff() itself, to
+   avoid touching what is-on's presence means for anything else. */
+.reel--fx:not(.is-on) .reel__mute,
+.reel--fx.is-powering-off .reel__mute {
   opacity: 0; visibility: hidden; pointer-events: none;
   transition: color var(--d-2), border-color var(--d-2), opacity var(--d-2),
     visibility 0s linear var(--d-2);

--- a/web/src/styles/home.css
+++ b/web/src/styles/home.css
@@ -1155,10 +1155,20 @@ html.js .mkt-quiet--nojs { display: none; }
   display: inline-flex; align-items: center; gap: 6px;
   padding: 5px 10px; border: 1px solid rgba(255,255,255,.35); background: rgba(5,5,5,.66);
   color: rgba(255,255,255,.8); font-family: var(--font-mono); font-size: var(--t-xs);
-  cursor: pointer; opacity: 1; pointer-events: auto;
-  transition: color var(--d-2), border-color var(--d-2), opacity var(--d-2);
+  cursor: pointer; opacity: 1; visibility: visible; pointer-events: auto;
+  transition: color var(--d-2), border-color var(--d-2), opacity var(--d-2),
+    visibility 0s linear 0s;
 }
-.reel--fx:not(.is-on) .reel__mute { opacity: 0; pointer-events: none; }
+/* opacity:0 + pointer-events:none hides it from the mouse but leaves it
+   focusable and in the tab order - a keyboard user could land on a
+   perfectly invisible control. visibility:hidden removes it from the tab
+   order too, delayed so it only takes effect once the fade-out (above) has
+   actually finished, not the instant this class lands. */
+.reel--fx:not(.is-on) .reel__mute {
+  opacity: 0; visibility: hidden; pointer-events: none;
+  transition: color var(--d-2), border-color var(--d-2), opacity var(--d-2),
+    visibility 0s linear var(--d-2);
+}
 .reel__mute:hover, .reel__mute:focus-visible { color: #fff; border-color: #fff; }
 .reel__mute .reel__icon--sound { display: none; }
 .reel__mute.is-unmuted .reel__icon--muted { display: none; }

--- a/web/src/styles/home.css
+++ b/web/src/styles/home.css
@@ -1172,15 +1172,24 @@ html.js .mkt-quiet--nojs { display: none; }
    is-powering-off immediately, but is-on is not removed until animationend
    fires 0.78s later, so for that whole window neither selector matched and
    the control stayed fully visible, floating over whatever the collapsing
-   screen was revealing beneath it - the exact reported bug, just during the
-   closing half instead of the resting state. is-powering-off is listed
-   explicitly rather than dropping is-on earlier in powerOff() itself, to
-   avoid touching what is-on's presence means for anything else. */
-.reel--fx:not(.is-on) .reel__mute,
-.reel--fx.is-powering-off .reel__mute {
+   screen was revealing beneath it. Enumerating is-powering-off as a second
+   hide case fixed that, but missed the SAME gap for an interrupted re-open
+   (scroll past, then reverse within the 0.78s close): powerOn() also never
+   removes is-on, so the element can carry is-on and is-powering-on at once
+   and neither hide case matches, floating the control during the first 45%
+   of the open keyframe too. Inverted instead of enumerating a third
+   transitional combination: hidden is the default for any reel--fx state,
+   and only a CLEANLY settled is-on (neither transition class present) shows
+   it - correct for every current and future transitional state at once. */
+.reel--fx .reel__mute {
   opacity: 0; visibility: hidden; pointer-events: none;
   transition: color var(--d-2), border-color var(--d-2), opacity var(--d-2),
     visibility 0s linear var(--d-2);
+}
+.reel--fx.is-on:not(.is-powering-on):not(.is-powering-off) .reel__mute {
+  opacity: 1; visibility: visible; pointer-events: auto;
+  transition: color var(--d-2), border-color var(--d-2), opacity var(--d-2),
+    visibility 0s linear 0s;
 }
 .reel__mute:hover, .reel__mute:focus-visible { color: #fff; border-color: #fff; }
 .reel__mute .reel__icon--sound { display: none; }

--- a/web/test/company-positioning.test.mjs
+++ b/web/test/company-positioning.test.mjs
@@ -31,10 +31,12 @@ test("homepage masthead joins the company identity to the product promise", () =
   const hero = home.match(/<section class="hero">[\s\S]*?<\/section>/)?.[0] || "";
   assert.match(hero, /American AI research \+ infrastructure/i);
   assert.match(compact(hero), /one OpenAI-compatible local endpoint/i);
-  // rewritten 2026-09-11: "our labs focuses on enabling open models..." - the
-  // same claim (RogerAI's research side is about OPEN models), reworded away
-  // from the literal "open model research" string this used to require.
-  assert.match(hero, /open models?/i);
+  // rewritten 2026-09-11 (features/web/homepage_company_research_branding.feature
+  // updated to match): "our labs focus on enabling open models..." - the same
+  // claim (RogerAI's research side is about OPEN models), reworded away from
+  // the literal "open model research" string this used to require. Pinned to
+  // the actual claim, not just the near-universal word "open" or "models".
+  assert.match(hero, /enabling open models/i);
   assert.match(hero, /routing/i);
   assert.match(hero, /failover/i);
   assert.match(hero, /metering/i);

--- a/web/test/company-positioning.test.mjs
+++ b/web/test/company-positioning.test.mjs
@@ -31,7 +31,10 @@ test("homepage masthead joins the company identity to the product promise", () =
   const hero = home.match(/<section class="hero">[\s\S]*?<\/section>/)?.[0] || "";
   assert.match(hero, /American AI research \+ infrastructure/i);
   assert.match(compact(hero), /one OpenAI-compatible local endpoint/i);
-  assert.match(hero, /open model research/i);
+  // rewritten 2026-09-11: "our labs focuses on enabling open models..." - the
+  // same claim (RogerAI's research side is about OPEN models), reworded away
+  // from the literal "open model research" string this used to require.
+  assert.match(hero, /open models?/i);
   assert.match(hero, /routing/i);
   assert.match(hero, /failover/i);
   assert.match(hero, /metering/i);

--- a/web/test/why-rogerai.test.mjs
+++ b/web/test/why-rogerai.test.mjs
@@ -88,7 +88,10 @@ test("the why argument is one click from the homepage, and the old page is unlin
 
 test("the homepage tells the story (network_story.feature)", () => {
   const home = read("index.html");
-  assert.match(home, /sees a station -?\s*(never|not) you/i, "the unlinking line");
+  // the unlinking line moved from the hero subhead to the PRIVACY-FIRST
+  // AIRWAVES section's own headline (2026-09-11) - still the same claim,
+  // now the section's own h2 instead of a subhead clause.
+  assert.match(home, /hears a station\.?\s*(never|not) you/i, "the unlinking line");
   assert.match(home, /Two kinds of transmitter/i, "both earn paths framed as one verb");
   assert.match(home, /curated station/i, "the resale path is named");
   assert.match(home, /keeps <b>5%<\/b> of everything it\s+carries/i, "the tower relay earn");

--- a/web/test/why-rogerai.test.mjs
+++ b/web/test/why-rogerai.test.mjs
@@ -88,9 +88,9 @@ test("the why argument is one click from the homepage, and the old page is unlin
 
 test("the homepage tells the story (network_story.feature)", () => {
   const home = read("index.html");
-  // the unlinking line moved from the hero subhead to the PRIVACY-FIRST
-  // AIRWAVES section's own headline (2026-09-11) - still the same claim,
-  // now the section's own h2 instead of a subhead clause.
+  // the hero subhead clause making this claim was dropped 2026-09-11 -
+  // nothing moved, the claim just has one placement now instead of two: the
+  // pre-existing PRIVACY-FIRST AIRWAVES section headline already stated it.
   assert.match(home, /hears a station\.?\s*(never|not) you/i, "the unlinking line");
   assert.match(home, /Two kinds of transmitter/i, "both earn paths framed as one verb");
   assert.match(home, /curated station/i, "the resale path is named");


### PR DESCRIPTION
## Summary
Three rounds of review-fix cycles on top of the confirmed-live mute-button bug fix (already merged separately):

- **Homepage copy**: subhead rewrite (private inference networks, open models, hardware link to research-hardware.html), trust clarification linking to the FAQ's existing detailed answer, Labs headline update, market panel left-alignment (was inconsistently centered).
- **Video codec order**: mp4/H.264 now listed before webm/VP9 in `<source>` - a likely contributor to a reported site-wide stutter, since VP9 hardware decode is inconsistent across GPUs and falls back to a much heavier software decode.
- **Reel scroll-timing rework**: split one IntersectionObserver into two (`ioEnter`/`ioExit`) since a single shared rootMargin can't satisfy both "turn on reliably on the first read" and "turn off with room to see the close animation" - they need opposite-sized top margins. Went through two further audit-fix rounds: `ioExit` is now bidirectional (fixes a portrait/mobile stuck-off state), reacts to its own first read (an earlier "skip the first read" guard was itself a worse bug - it could swallow the only power-off signal), and has a timeout fallback in case `animationend` never fires.
- **Mute-button visibility during the reel's collapse/expand**: the hide rule was rewritten twice more after review found it missed the 0.78s close-animation window and an interrupted-reopen window; the third pass inverts the logic to "hidden by default, shown only when cleanly settled on" rather than enumerating transitional states one at a time.
- **Market ticker performance**: cached node list + throttled to ~20fps (was re-querying the DOM and forcing layout via textContent writes up to 60x/sec), plus two follow-up fixes (cache invalidation in the quiet-state path, elapsed-time clamping).
- **Spec hygiene**: two `.feature` files were left stale describing copy this changed removed, while the enforcing tests were quietly loosened instead - both specs now describe the actual shipped wording, and the loosened test regex is tightened back to something that pins the real claim.

## Test plan
- [x] `npm test` - 809/809 passing at every commit in this stack
- [x] `node build.mjs` - clean build
- [x] `node scripts/verify-artifacts.mjs` - all advertised artifacts public
- [x] Four full pre-push audit rounds - first three found real, fixed issues (a stuck-off state, an on/off flash, a mute-button visibility gap in two different transitional windows, stale specs); final round: clean PASS
- [ ] Founder: eyeball the reel timing + hero copy in a real browser before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)